### PR TITLE
[v1alpha2] Add Create/GetRecord.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,7 @@ github.com/google/licenseclassifier v0.0.0-20190926221455-842c0d70d702/go.mod h1
 github.com/google/licenseclassifier v0.0.0-20200708223521-3d09a0ea2f39/go.mod h1:qsqn2hxC+vURpyBRygGUuinTO42MFRLcsmQ/P8v94+M=
 github.com/google/mako v0.0.0-20190821191249-122f8dcef9e3/go.mod h1:YzLcVlL+NqWnmUEPuhS1LxDDwGO9WNbVlEXaF4IH35g=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible h1:xmapqc1AyLoB+ddYT6r04bD9lIjlOqGaREovi0SzFaE=
 github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/pkg/api/server/db/errors.go
+++ b/pkg/api/server/db/errors.go
@@ -53,6 +53,8 @@ func sqlite(err sqlite3.Error) codes.Code {
 		switch err.ExtendedCode {
 		case sqlite3.ErrConstraintUnique:
 			return codes.AlreadyExists
+		case sqlite3.ErrConstraintForeignKey:
+			return codes.FailedPrecondition
 		}
 		return codes.InvalidArgument
 	case sqlite3.ErrNotFound:

--- a/pkg/api/server/db/model.go
+++ b/pkg/api/server/db/model.go
@@ -21,10 +21,15 @@ func (r Result) String() string {
 
 // Record is the database model of a Record
 type Record struct {
+	// Result is used to create the relationship between the Result and Records
+	// table. Data will not be returned here during reads. Use the foreign key
+	// fields instead.
+	Result     Result `gorm:"foreignKey:Parent,ResultID;references:Parent,ID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Parent     string `gorm:"primaryKey;index:records_by_name,priority:1"`
 	ResultID   string `gorm:"primaryKey"`
-	ID         string `gorm:"primaryKey"`
 	ResultName string `gorm:"index:records_by_name,priority:2"`
-	Name       string `gorm:"index:records_by_name,priority:3"`
-	Data       []byte
+
+	ID   string `gorm:"primaryKey"`
+	Name string `gorm:"index:records_by_name,priority:3"`
+	Data []byte
 }

--- a/pkg/api/server/test/db.go
+++ b/pkg/api/server/test/db.go
@@ -60,6 +60,10 @@ func NewDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to open the results.db: %v", err)
 	}
 
+	// Enable foreign key support. Only needed for sqlite instance we use for
+	// tests.
+	gdb.Exec("PRAGMA foreign_keys = ON;")
+
 	return gdb
 }
 

--- a/pkg/api/server/v1alpha1/server.go
+++ b/pkg/api/server/v1alpha1/server.go
@@ -51,12 +51,18 @@ func (s *Server) CreateResult(ctx context.Context, req *pb.CreateResultRequest) 
 	// Slightly confusing since this is CreateResult, but this maps better to
 	// Records in the v1alpha2 API, so store this as a Record for
 	// compatibility.
-	record := &dbmodel.Record{
+	result := &dbmodel.Result{
 		Parent: req.GetParent(),
-		// TODO: Require Records to be nested in Results. Since v1alpha1
-		// results ~= records, allow parent-less records for now to allow
-		// clients to continue working.
-		ResultID: "",
+		ID:     name,
+		// This should be the parent-less name, but allow for now for compatibility.
+		Name: r.Name,
+	}
+	if err := s.gdb.WithContext(ctx).Create(result).Error; err != nil {
+		return nil, err
+	}
+	record := &dbmodel.Record{
+		Parent:   req.GetParent(),
+		ResultID: name,
 		ID:       name,
 		// This should be the parent-less name, but allow for now for compatibility.
 		Name: r.Name,

--- a/pkg/api/server/v1alpha2/record/record.go
+++ b/pkg/api/server/v1alpha2/record/record.go
@@ -1,0 +1,56 @@
+// Package record provides utilities for manipulating and validating Records.
+package record
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/tektoncd/results/pkg/api/server/db"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// NameRegex matches valid name specs for a Result.
+	NameRegex = regexp.MustCompile("(^[a-z0-9_-]{1,63})/results/([a-z0-9_-]{1,63})/records/([a-z0-9_-]{1,63}$)")
+)
+
+// ParseName splits a full Result name into its individual (parent, result, name)
+// components.
+func ParseName(raw string) (parent, result, name string, err error) {
+	s := NameRegex.FindStringSubmatch(raw)
+	if len(s) != 4 {
+		return "", "", "", status.Errorf(codes.InvalidArgument, "name must match %s", NameRegex.String())
+	}
+	return s[1], s[2], s[3], nil
+}
+
+// FormatName takes in a parent ("a/results/b") and record name ("c") and
+// returns the full resource name ("a/results/b/records/c").
+func FormatName(parent, name string) string {
+	return fmt.Sprintf("%s/records/%s", parent, name)
+}
+
+// ToStorage converts an API Record into its corresponding database storage
+// equivalent.
+// parent,result,name should be the name parts (e.g. not containing "/results/" or "/records/").
+func ToStorage(parent, resultName, resultID, name string, r *pb.Record) (*db.Record, error) {
+	return &db.Record{
+		Parent:     parent,
+		ResultName: resultName,
+		ResultID:   resultID,
+
+		ID:   r.GetId(),
+		Name: name,
+	}, nil
+}
+
+// ToAPI converts a database storage Record into its corresponding API
+// equivalent.
+func ToAPI(r *db.Record) *pb.Record {
+	return &pb.Record{
+		Name: fmt.Sprintf("%s/results/%s/records/%s", r.Parent, r.ResultName, r.Name),
+		Id:   r.ID,
+	}
+}

--- a/pkg/api/server/v1alpha2/record/record_test.go
+++ b/pkg/api/server/v1alpha2/record/record_test.go
@@ -1,0 +1,129 @@
+package record
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/results/pkg/api/server/db"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestParseName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		// if want is nil, assume error
+		want []string
+	}{
+		{
+			name: "simple",
+			in:   "a/results/b/records/c",
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "resource name reuse",
+			in:   "results/results/records/records/records",
+			want: []string{"results", "records", "records"},
+		},
+		{
+			name: "missing name",
+			in:   "a/results/b/records/",
+		},
+		{
+			name: "missing name, no slash",
+			in:   "a/results/b/records/",
+		},
+		{
+			name: "missing parent",
+			in:   "/records/b",
+		},
+		{
+			name: "missing parent, no slash",
+			in:   "records/b",
+		},
+		{
+			name: "wrong resource",
+			in:   "a/tacocat/b/records/c",
+		},
+		{
+			name: "result resource",
+			in:   "a/results/b",
+		},
+		{
+			name: "invalid parent",
+			in:   "a/b/results/c",
+		},
+		{
+			name: "invalid name",
+			in:   "a/results/b/records/c/d",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parent, result, name, err := ParseName(tc.in)
+			if err != nil {
+				if tc.want == nil {
+					// error was expected, continue
+					return
+				}
+				t.Fatal(err)
+			}
+			if tc.want == nil {
+				t.Fatalf("expected error, got: [%s, %s]", parent, name)
+			}
+
+			if parent != tc.want[0] || result != tc.want[1] || name != tc.want[2] {
+				t.Errorf("want: %v, got: [%s, %s, %s]", tc.want, parent, result, name)
+			}
+		})
+	}
+}
+
+func TestToStorage(t *testing.T) {
+	got, err := ToStorage("foo", "bar", "1", "baz", &pb.Record{
+		Name: "foo/results/bar",
+		Id:   "a",
+
+		// These fields are ignored for now.
+		Etag: "tacocat",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &db.Record{
+		Parent:     "foo",
+		ResultID:   "1",
+		ResultName: "bar",
+		Name:       "baz",
+		ID:         "a",
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want,+got: %s", diff)
+	}
+}
+
+func TestToAPI(t *testing.T) {
+	got := ToAPI(&db.Record{
+		Parent:     "foo",
+		ResultID:   "1",
+		ResultName: "bar",
+		Name:       "baz",
+		ID:         "a",
+	})
+	want := &pb.Record{
+		Name: "foo/results/bar/records/baz",
+		Id:   "a",
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("-want,+got: %s", diff)
+	}
+}
+
+func TestFormatName(t *testing.T) {
+	got := FormatName("a", "b")
+	want := "a/records/b"
+	if want != got {
+		t.Errorf("want %s, got %s", want, got)
+	}
+}

--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"context"
+
+	"github.com/tektoncd/results/pkg/api/server/db"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *Server) CreateRecord(ctx context.Context, req *pb.CreateRecordRequest) (*pb.Record, error) {
+	r := req.GetRecord()
+
+	// Validate the incoming request
+	parent, resultName, name, err := record.ParseName(r.GetName())
+	if err != nil {
+		return nil, err
+	}
+	if req.GetParent() != result.FormatName(parent, resultName) {
+		return nil, status.Error(codes.InvalidArgument, "requested parent does not match resource name")
+	}
+
+	// Look up the result ID from the name. This does not have to happen
+	// transactionally with the insert since name<->ID mappings are immutable,
+	// and if the the parent result is deleted mid-request, the insert should
+	// fail due to foreign key constraints.
+	resultID, err := s.getResultID(ctx, parent, resultName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate Result with server provided fields.
+	r.Id = uid()
+
+	store, err := record.ToStorage(parent, resultName, resultID, name, req.GetRecord())
+	if err != nil {
+		return nil, err
+	}
+	q := s.db.WithContext(ctx).
+		Model(store).
+		Create(store).Error
+	if err := db.WrapError(q); err != nil {
+		return nil, err
+	}
+
+	return record.ToAPI(store), nil
+}
+
+// resultID is a utility struct to extract partial Result data representing
+// Result name <-> ID mappings.
+type resultID struct {
+	Name string
+	ID   string
+}
+
+func (s *Server) getResultIDImpl(ctx context.Context, parent, result string) (string, error) {
+	id := new(resultID)
+	q := s.db.WithContext(ctx).
+		Model(&db.Result{}).
+		Where(&db.Result{Parent: parent, Name: result}).
+		First(id)
+	if err := db.WrapError(q.Error); err != nil {
+		return "", err
+	}
+	return id.ID, nil
+}
+
+// GetRecord returns a single Record.
+func (s *Server) GetRecord(ctx context.Context, req *pb.GetRecordRequest) (*pb.Record, error) {
+	parent, result, name, err := record.ParseName(req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	store := &db.Record{}
+	q := s.db.WithContext(ctx).
+		Where(&db.Record{Result: db.Result{Parent: parent, Name: result}, Name: name}).
+		First(store)
+	if err := db.WrapError(q.Error); err != nil {
+		return nil, err
+	}
+	return record.ToAPI(store), nil
+}

--- a/pkg/api/server/v1alpha2/records_test.go
+++ b/pkg/api/server/v1alpha2/records_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/results/pkg/api/server/test"
+	recordutil "github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
+	resultutil "github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
+
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestCreateRecord(t *testing.T) {
+	srv, err := New(test.NewDB(t))
+	if err != nil {
+		t.Fatalf("failed to create temp file for db: %v", err)
+	}
+
+	ctx := context.Background()
+	result, err := srv.CreateResult(ctx, &pb.CreateResultRequest{
+		Parent: "foo",
+		Result: &pb.Result{
+			Name: "foo/results/bar",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateResult: %v", err)
+	}
+
+	req := &pb.CreateRecordRequest{
+		Parent: result.GetName(),
+		Record: &pb.Record{
+			Name: recordutil.FormatName(result.GetName(), "baz"),
+		},
+	}
+	t.Run("success", func(t *testing.T) {
+		got, err := srv.CreateRecord(ctx, req)
+		if err != nil {
+			t.Fatalf("CreateRecord: %v", err)
+		}
+		want := proto.Clone(req.GetRecord()).(*pb.Record)
+		want.Id = fmt.Sprint(lastID)
+		if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
+			t.Errorf("-want, +got: %s", diff)
+		}
+	})
+
+	// Errors
+	for _, tc := range []struct {
+		name string
+		req  *pb.CreateRecordRequest
+		want codes.Code
+	}{
+		{
+			name: "mismatched parent",
+			req: &pb.CreateRecordRequest{
+				Parent: req.GetParent(),
+				Record: &pb.Record{
+					Name: resultutil.FormatName("foo", "baz"),
+				},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "parent does not exist",
+			req: &pb.CreateRecordRequest{
+				Parent: resultutil.FormatName("foo", "doesnotexist"),
+				Record: &pb.Record{
+					Name: recordutil.FormatName(resultutil.FormatName("foo", "doesnotexist"), "baz"),
+				},
+			},
+			want: codes.NotFound,
+		},
+		{
+			name: "missing name",
+			req: &pb.CreateRecordRequest{
+				Parent: req.GetParent(),
+				Record: &pb.Record{
+					Name: fmt.Sprintf("%s/results/", result.GetName()),
+				},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "result used as name",
+			req: &pb.CreateRecordRequest{
+				Parent: req.GetParent(),
+				Record: &pb.Record{
+					Name: result.GetName(),
+				},
+			},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "already exists",
+			req:  req,
+			want: codes.AlreadyExists,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := srv.CreateRecord(ctx, tc.req); status.Code(err) != tc.want {
+				t.Fatalf("want: %v, got: %v - %+v", tc.want, status.Code(err), err)
+			}
+		})
+	}
+}
+
+// TestCreateRecord_ConcurrentDelete simulates a concurrent deletion of a
+// Result parent mocking the result name -> id conversion. This tricks the
+// API Server into thinking the parent is valid during initial validation,
+// but fails when writing the Record due to foreign key constraints.
+func TestCreateRecord_ConcurrentDelete(t *testing.T) {
+	result := "deleted"
+	srv := &Server{
+		db: test.NewDB(t),
+		getResultID: func(context.Context, string, string) (string, error) {
+			return result, nil
+		},
+	}
+
+	ctx := context.Background()
+	parent := resultutil.FormatName("foo", result)
+	record, err := srv.CreateRecord(ctx, &pb.CreateRecordRequest{
+		Parent: parent,
+		Record: &pb.Record{
+			Name: recordutil.FormatName(parent, "baz"),
+		},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("CreateRecord: %+v, %v", record, err)
+	}
+}
+
+func TestGetRecord(t *testing.T) {
+	srv, err := New(test.NewDB(t))
+	if err != nil {
+		t.Fatalf("failed to create temp file for db: %v", err)
+	}
+
+	ctx := context.Background()
+	result, err := srv.CreateResult(ctx, &pb.CreateResultRequest{
+		Parent: "foo",
+		Result: &pb.Result{
+			Name: "foo/results/bar",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateResult: %v", err)
+	}
+
+	record, err := srv.CreateRecord(ctx, &pb.CreateRecordRequest{
+		Parent: result.GetName(),
+		Record: &pb.Record{
+			Name: recordutil.FormatName(result.GetName(), "baz"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateRecord: %v", err)
+	}
+
+	t.Run("success", func(t *testing.T) {
+		got, err := srv.GetRecord(ctx, &pb.GetRecordRequest{Name: record.GetName()})
+		if err != nil {
+			t.Fatalf("GetRecord: %v", err)
+		}
+		if diff := cmp.Diff(got, record, protocmp.Transform()); diff != "" {
+			t.Errorf("-want, +got: %s", diff)
+		}
+	})
+
+	// Errors
+	for _, tc := range []struct {
+		name string
+		req  *pb.GetRecordRequest
+		want codes.Code
+	}{
+		{
+			name: "no name",
+			req:  &pb.GetRecordRequest{},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "invalid name",
+			req:  &pb.GetRecordRequest{Name: "a/results/doesnotexist"},
+			want: codes.InvalidArgument,
+		},
+		{
+			name: "not found",
+			req:  &pb.GetRecordRequest{Name: recordutil.FormatName(result.GetName(), "doesnotexist")},
+			want: codes.NotFound,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := srv.GetRecord(ctx, tc.req); status.Code(err) != tc.want {
+				t.Fatalf("want: %v, got: %v - %+v", tc.want, status.Code(err), err)
+			}
+		})
+	}
+}

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -29,6 +29,12 @@ func ParseName(raw string) (parent, name string, err error) {
 	return s[1], s[2], nil
 }
 
+// FormatName takes in a parent ("a") and result name ("b") and
+// returns the full resource name ("a/results/b").
+func FormatName(parent, name string) string {
+	return fmt.Sprintf("%s/results/%s", parent, name)
+}
+
 // ToStorage converts an API Result into its corresponding database storage
 // equivalent.
 // parent,name should be the name parts (e.g. not containing "/results/").
@@ -51,7 +57,7 @@ func ToStorage(r *pb.Result) (*db.Result, error) {
 // equivalent.
 func ToAPI(r *db.Result) *pb.Result {
 	return &pb.Result{
-		Name:        fmt.Sprintf("%s/results/%s", r.Parent, r.Name),
+		Name:        FormatName(r.Parent, r.Name),
 		Id:          r.ID,
 		CreatedTime: timestamppb.New(r.CreatedTime),
 		UpdatedTime: timestamppb.New(r.UpdatedTime),

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -76,7 +76,7 @@ func TestParseName(t *testing.T) {
 				t.Fatalf("expected error, got: [%s, %s]", parent, name)
 			}
 
-			if parent != tc.want[0] && name != tc.want[1] {
+			if parent != tc.want[0] || name != tc.want[1] {
 				t.Errorf("want: %v, got: [%s, %s]", tc.want, parent, name)
 			}
 		})
@@ -198,5 +198,13 @@ func TestMatch(t *testing.T) {
 				t.Errorf("want: %t, got: %t", tc.match, got)
 			}
 		})
+	}
+}
+
+func TestFormatName(t *testing.T) {
+	got := FormatName("a", "b")
+	want := "a/results/b"
+	if want != got {
+		t.Errorf("want %s, got %s", want, got)
 	}
 }

--- a/pkg/api/server/v1alpha2/server.go
+++ b/pkg/api/server/v1alpha2/server.go
@@ -1,11 +1,12 @@
 package server
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/cel-go/cel"
-	"github.com/google/uuid"
 
+	"github.com/google/uuid"
 	cw "github.com/jonboulle/clockwork"
 	resultscel "github.com/tektoncd/results/pkg/api/server/cel"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
@@ -24,6 +25,10 @@ type Server struct {
 	pb.UnimplementedResultsServer
 	env *cel.Env
 	db  *gorm.DB
+
+	// Converts result names -> IDs configurable to allow overrides for
+	// testing.
+	getResultID func(ctx context.Context, parent, result string) (string, error)
 }
 
 // New set up environment for the api server
@@ -36,5 +41,9 @@ func New(db *gorm.DB) (*Server, error) {
 		db:  db,
 		env: env,
 	}
+
+	// Set default impls of overridable behavior
+	srv.getResultID = srv.getResultIDImpl
+
 	return srv, nil
 }

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -1,4 +1,3 @@
-
 CREATE TABLE results (
 	parent varchar(64),
 	id varchar(64),
@@ -20,6 +19,7 @@ CREATE TABLE records (
 	name varchar(64),
 	data BLOB,
 
-	PRIMARY KEY(parent, result_id, id)
+	PRIMARY KEY(parent, result_id, id),
+	FOREIGN KEY(parent, result_id) REFERENCES results(parent, id) ON DELETE CASCADE
 );
 CREATE UNIQUE INDEX records_by_name ON records(parent, result_name, name);


### PR DESCRIPTION
- Implements CreateRecord and GetRecord v1alpha2 RPC methods
- Enforces foreign key constraints for local sqlite3 testing.
- Updates v1alpha1 to also write Results due to foreign key constraints
(since we are getting rid of this soon, this was not done in a
transactionally safe way).

Fixes #6, #7 