### PR TITLE
Implement v1alpha2 UpdateResult

### DIFF
--- a/pkg/api/server/db/model.go
+++ b/pkg/api/server/db/model.go
@@ -2,6 +2,9 @@
 package db
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -13,6 +16,7 @@ type Result struct {
 	Name        string `gorm:"index:results_by_name,priority:2"`
 	CreatedTime time.Time
 	UpdatedTime time.Time
+	Annotations dbjson
 }
 
 func (r Result) String() string {
@@ -27,4 +31,27 @@ type Record struct {
 	ResultName string `gorm:"index:records_by_name,priority:2"`
 	Name       string `gorm:"index:records_by_name,priority:3"`
 	Data       []byte
+}
+
+type dbjson json.RawMessage
+
+// Scan scan value into Jsonb, implements sql.Scanner interface
+func (j *dbjson) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	}
+
+	result := json.RawMessage{}
+	err := json.Unmarshal(bytes, &result)
+	*j = dbjson(result)
+	return err
+}
+
+// Value return json value, implement driver.Valuer interface
+func (j dbjson) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return nil, nil
+	}
+	return json.RawMessage(j).MarshalJSON()
 }

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -2,6 +2,7 @@
 package result
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 var (
@@ -31,9 +33,12 @@ func ParseName(raw string) (parent, name string, err error) {
 
 // ToStorage converts an API Result into its corresponding database storage
 // equivalent.
-// parent,name should be the name parts (e.g. not containing "/results/").
 func ToStorage(r *pb.Result) (*db.Result, error) {
 	parent, name, err := ParseName(r.GetName())
+	if err != nil {
+		return nil, err
+	}
+	ann, err := json.Marshal(r.GetAnnotations())
 	if err != nil {
 		return nil, err
 	}
@@ -43,6 +48,7 @@ func ToStorage(r *pb.Result) (*db.Result, error) {
 		Name:        name,
 		UpdatedTime: r.UpdatedTime.AsTime(),
 		CreatedTime: r.CreatedTime.AsTime(),
+		Annotations: ann,
 	}
 	return result, nil
 }
@@ -50,9 +56,14 @@ func ToStorage(r *pb.Result) (*db.Result, error) {
 // ToAPI converts a database storage Result into its corresponding API
 // equivalent.
 func ToAPI(r *db.Result) *pb.Result {
+	ann := map[string]string{}
+	if err := json.Unmarshal(r.Annotations, &ann); err != nil {
+		ann = nil
+	}
 	return &pb.Result{
 		Name:        fmt.Sprintf("%s/results/%s", r.Parent, r.Name),
 		Id:          r.ID,
+		Annotations: ann,
 		CreatedTime: timestamppb.New(r.CreatedTime),
 		UpdatedTime: timestamppb.New(r.UpdatedTime),
 	}
@@ -79,4 +90,24 @@ func Match(r *pb.Result, prg cel.Program) (bool, error) {
 		return false, status.Errorf(codes.InvalidArgument, "expected boolean result, got %s", out.Type().TypeName())
 	}
 	return b, nil
+}
+
+// GetResultByName is the helper function to get a Result by its parent and name
+func GetResultByName(gdb *gorm.DB, name string) (*pb.Result, error) {
+	parent, name, err := ParseName(name)
+	if err != nil {
+		return nil, err
+	}
+	var results []*db.Result = []*db.Result{}
+	if err := gdb.Where("parent = ?", parent).Where("name = ?", name).Find(&results).Error; err != nil {
+		log.Printf("failed to query on database: %v", err)
+		return nil, fmt.Errorf("failed to query on a result: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, status.Error(codes.NotFound, "result not found")
+	}
+	if len(results) > 1 {
+		log.Println("Warning: multiple rows found")
+	}
+	return ToAPI(results[0]), nil
 }

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -89,18 +90,23 @@ func TestToStorage(t *testing.T) {
 		Id:          "a",
 		CreatedTime: timestamppb.New(clock.Now()),
 		UpdatedTime: timestamppb.New(clock.Now()),
+		Annotations: map[string]string{"a": "b"},
 
 		// These fields are ignored for now.
-		Annotations: map[string]string{"a": "b"},
-		Etag:        "tacocat",
+		Etag: "tacocat",
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	ann, err := json.Marshal(map[string]string{"a": "b"})
+	if err != nil {
+		t.Fatalf("fail to marshal annotation")
 	}
 	want := &db.Result{
 		Parent:      "foo",
 		Name:        "bar",
 		ID:          "a",
+		Annotations: ann,
 		CreatedTime: clock.Now(),
 		UpdatedTime: clock.Now(),
 	}

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -7,6 +7,7 @@ CREATE TABLE results (
 	created_time timestamp default current_timestamp not null,
 	updated_time timestamp default current_timestamp not null,
 
+	annotations text,
 	PRIMARY KEY(parent, id)
 );
 CREATE UNIQUE INDEX results_by_name ON results(parent, name);


### PR DESCRIPTION
The logic is basically the same as the v1alpha1 version. The only one
difference is there isn't `executions` field in the Result definition,
so the UpdateResult function won't tackle that field anymore, instead,
UpdateRecord will take charge.