### PR TITLE
Add a new column "annotations" to the table result

### DIFF
--- a/pkg/api/server/db/model_test.go
+++ b/pkg/api/server/db/model_test.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAnnotationsScan(t *testing.T) {
+	v := make(Annotations)
+	v["foo"] = "bar"
+
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+
+	var ann *Annotations
+	if err := ann.Scan(bytes); err == nil {
+		t.Error("annotation pointer must not be nil, expected error")
+	}
+
+	ann = &Annotations{}
+	if err := ann.Scan(bytes); err != nil {
+		t.Fatalf("failed to scan data from database: %v", err)
+	}
+
+	if diff := cmp.Diff(*ann, v); diff != "" {
+		t.Errorf("-want, +got: %s", diff)
+	}
+}
+
+func TestAnnotationsValue(t *testing.T) {
+	v := make(Annotations)
+	v["foo"] = "bar"
+
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal(): %v", err)
+	}
+
+	annv, err := v.Value()
+	if err != nil {
+		t.Fatalf("Value(): %v", err)
+	}
+
+	if diff := cmp.Diff(annv, bytes); diff != "" {
+		t.Errorf("-want, +got: %s", diff)
+	}
+}

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -49,6 +49,7 @@ func ToStorage(r *pb.Result) (*db.Result, error) {
 		Name:        name,
 		UpdatedTime: r.UpdatedTime.AsTime(),
 		CreatedTime: r.CreatedTime.AsTime(),
+		Annotations: r.Annotations,
 	}
 	return result, nil
 }
@@ -61,6 +62,7 @@ func ToAPI(r *db.Result) *pb.Result {
 		Id:          r.ID,
 		CreatedTime: timestamppb.New(r.CreatedTime),
 		UpdatedTime: timestamppb.New(r.UpdatedTime),
+		Annotations: r.Annotations,
 	}
 }
 

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -89,10 +89,10 @@ func TestToStorage(t *testing.T) {
 		Id:          "a",
 		CreatedTime: timestamppb.New(clock.Now()),
 		UpdatedTime: timestamppb.New(clock.Now()),
+		Annotations: map[string]string{"a": "b"},
 
 		// These fields are ignored for now.
-		Annotations: map[string]string{"a": "b"},
-		Etag:        "tacocat",
+		Etag: "tacocat",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -101,6 +101,7 @@ func TestToStorage(t *testing.T) {
 		Parent:      "foo",
 		Name:        "bar",
 		ID:          "a",
+		Annotations: map[string]string{"a": "b"},
 		CreatedTime: clock.Now(),
 		UpdatedTime: clock.Now(),
 	}
@@ -110,18 +111,21 @@ func TestToStorage(t *testing.T) {
 }
 
 func TestToAPI(t *testing.T) {
+	ann := map[string]string{"a": "b"}
 	got := ToAPI(&db.Result{
 		Parent:      "foo",
 		Name:        "bar",
 		ID:          "a",
 		CreatedTime: clock.Now(),
 		UpdatedTime: clock.Now(),
+		Annotations: ann,
 	})
 	want := &pb.Result{
 		Name:        "foo/results/bar",
 		Id:          "a",
 		CreatedTime: timestamppb.New(clock.Now()),
 		UpdatedTime: timestamppb.New(clock.Now()),
+		Annotations: ann,
 	}
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("-want,+got: %s", diff)

--- a/pkg/api/server/v1alpha2/results.go
+++ b/pkg/api/server/v1alpha2/results.go
@@ -48,7 +48,6 @@ func (s *Server) CreateResult(ctx context.Context, req *pb.CreateResultRequest) 
 	if err := errors.Wrap(s.db.WithContext(ctx).Create(store).Error); err != nil {
 		return nil, err
 	}
-
 	return result.ToAPI(store), nil
 }
 

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -5,6 +5,8 @@ CREATE TABLE results (
 	name varchar(64),
 	created_time timestamp default current_timestamp not null,
 	updated_time timestamp default current_timestamp not null,
+	
+	annotations BLOB,
 
 	PRIMARY KEY(parent, id)
 );


### PR DESCRIPTION
Adds a new column "Annotations" to the result table schema.

Defines a new type "Annotations" and implements sql.Scanner and driver.Valuer interface to let gorm know how to receive and save that field from/to database.

Get this new field set in the "result" model when testing CreateResult, ToStorage, and ToAPI.