### PR TITLE
CreateRecord: store Record data.

### DIFF
--- a/pkg/api/server/internal/protoutil/protoutil.go
+++ b/pkg/api/server/internal/protoutil/protoutil.go
@@ -1,0 +1,27 @@
+// Package protoutil provides utilities for manipulating protos in tests.
+package protoutil
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// Any wraps a proto message in an Any proto. If there is any problem,
+// this panics.
+func Any(m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+// AnyBytes returns the marshalled bytes of an Any proto wrapping the given
+// message. If there is any problem, this panics.
+func AnyBytes(m proto.Message) []byte {
+	b, err := proto.Marshal(Any(m))
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -46,7 +46,7 @@ func (s *Server) CreateRecord(ctx context.Context, req *pb.CreateRecordRequest) 
 		return nil, err
 	}
 
-	return record.ToAPI(store), nil
+	return record.ToAPI(store)
 }
 
 // resultID is a utility struct to extract partial Result data representing
@@ -81,5 +81,5 @@ func (s *Server) GetRecord(ctx context.Context, req *pb.GetRecordRequest) (*pb.R
 	if err := db.WrapError(q.Error); err != nil {
 		return nil, err
 	}
-	return record.ToAPI(store), nil
+	return record.ToAPI(store)
 }

--- a/pkg/api/server/v1alpha2/records_test.go
+++ b/pkg/api/server/v1alpha2/records_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/results/pkg/api/server/internal/protoutil"
 	"github.com/tektoncd/results/pkg/api/server/test"
 	recordutil "github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
 	resultutil "github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
-
+	ppb "github.com/tektoncd/results/proto/pipeline/v1beta1/pipeline_go_proto"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -38,6 +39,7 @@ func TestCreateRecord(t *testing.T) {
 		Parent: result.GetName(),
 		Record: &pb.Record{
 			Name: recordutil.FormatName(result.GetName(), "baz"),
+			Data: protoutil.Any(&ppb.TaskRun{Metadata: &ppb.ObjectMeta{Name: "tacocat"}}),
 		},
 	}
 	t.Run("success", func(t *testing.T) {


### PR DESCRIPTION
This change stores the Record data in the database, which was previously
ignored.

Also introduces an internal protoutil library to help streamline common
marshalling operations in tests. Since these are intended to be test
only, we're liberal with the use of panic to allow for callers to embed
these inline to struct definitions.

Missing part of #6 