### PR TITLE
Automatically clear any proto fields marked OUTPUT_ONLY.

### DIFF
--- a/pkg/api/server/internal/protoutil/protoutil_test.go
+++ b/pkg/api/server/internal/protoutil/protoutil_test.go
@@ -1,0 +1,31 @@
+package protoutil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestClearOutputOnly(t *testing.T) {
+	m := &pb.Result{
+		Name:        "a",
+		Id:          "b",
+		CreatedTime: timestamppb.Now(),
+		UpdatedTime: timestamppb.Now(),
+		Annotations: map[string]string{"c": "d"},
+		Etag:        "f",
+	}
+	want := &pb.Result{
+		Name:        m.Name,
+		Annotations: m.Annotations,
+	}
+
+	ClearOutputOnly(m)
+
+	if diff := cmp.Diff(want, m, protocmp.Transform()); diff != "" {
+		t.Errorf("-want, +got: %s", diff)
+	}
+}

--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tektoncd/results/pkg/api/server/db"
 	"github.com/tektoncd/results/pkg/api/server/db/errors"
 	"github.com/tektoncd/results/pkg/api/server/db/pagination"
+	"github.com/tektoncd/results/pkg/api/server/internal/protoutil"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
@@ -37,6 +38,7 @@ func (s *Server) CreateRecord(ctx context.Context, req *pb.CreateRecordRequest) 
 	}
 
 	// Populate Result with server provided fields.
+	protoutil.ClearOutputOnly(r)
 	r.Id = uid()
 
 	store, err := record.ToStorage(parent, resultName, resultID, name, req.GetRecord())

--- a/pkg/api/server/v1alpha2/results.go
+++ b/pkg/api/server/v1alpha2/results.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tektoncd/results/pkg/api/server/db"
 	"github.com/tektoncd/results/pkg/api/server/db/errors"
 	"github.com/tektoncd/results/pkg/api/server/db/pagination"
+	"github.com/tektoncd/results/pkg/api/server/internal/protoutil"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/grpc/codes"
@@ -31,6 +32,7 @@ func (s *Server) CreateResult(ctx context.Context, req *pb.CreateResultRequest) 
 	}
 
 	// Populate Result with server provided fields.
+	protoutil.ClearOutputOnly(r)
 	r.Id = uid()
 	r.CreatedTime = timestamppb.New(clock.Now())
 	r.UpdatedTime = timestamppb.New(clock.Now())


### PR DESCRIPTION
This is heavily based off the example in
https://blog.golang.org/protobuf-apiv2 to iterate over all proto fields
and clear out any fields annotated as OUTPUT_ONLY. This ensures that
unwanted user input is automatically cleared away in any mutations.