### PR TITLE
watcher/reconciler: Use controller.StartAll for integration test.

### DIFF
--- a/pkg/watcher/reconciler/reconciler_test.go
+++ b/pkg/watcher/reconciler/reconciler_test.go
@@ -3,169 +3,106 @@ package reconciler
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	pipelinetest "github.com/tektoncd/pipeline/test"
-	"github.com/tektoncd/results/pkg/watcher/convert"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
+	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun"
+	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
+	rtesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/internal/test"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/pipelinerun"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/taskrun"
-	pb "github.com/tektoncd/results/proto/v1alpha1/results_go_proto"
-	"google.golang.org/protobuf/testing/protocmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
 )
 
-func TestReconciler(t *testing.T) {
-	testFuncs := map[string]func(*testing.T){
-		"Update PipelineRun to the existed Result": testUpdatePipelineRunToTheExistedResult,
-		"Update TaskRun to the existed Result":     testUpdateTaskRunToTheExistedResult,
-	}
+// TestController starts a full TaskRun + PipelineRun controller and waits for
+// objects to be reconciled. Unlike the individual controller tests that call
+// Reconcile directly, this test is asynchronous and is slower as a result.
+// If possible, prefer adding synchronous tests to the individual reconcilers.
+func TestController(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
-	for name, testFunc := range testFuncs {
-		t.Run(name, testFunc)
-	}
+	// Create reconcilers, start controller.
+	results := test.NewResultsClient(t)
+	trctrl := taskrun.NewController(ctx, nil, results)
+	prctrl := pipelinerun.NewController(ctx, nil, results)
+	go controller.StartAll(ctx, trctrl, prctrl)
+
+	// Start informers - this notifies the controller of new events.
+	go taskruninformer.Get(ctx).Informer().Run(ctx.Done())
+	go pipelineruninformer.Get(ctx).Informer().Run(ctx.Done())
+
+	pipeline := fakepipelineclient.Get(ctx)
+	t.Run("taskrun", func(t *testing.T) {
+		reconcileTaskRun(ctx, t, pipeline)
+	})
+	t.Run("pipelinerun", func(t *testing.T) {
+		reconcilePipelineRun(ctx, t, pipeline)
+	})
 }
 
-type ReconcilerTest struct {
-	taskRun *v1beta1.TaskRun
-	trAsset pipelinetest.Assets
-
-	pipelineRun *v1beta1.PipelineRun
-	prAsset     pipelinetest.Assets
-	ctx         context.Context
-	client      pb.ResultsClient
-}
-
-func newReconcilerTest(t *testing.T) *ReconcilerTest {
-	client := test.NewResultsClient(t)
-	tr := &v1beta1.TaskRun{
+func reconcileTaskRun(ctx context.Context, t *testing.T, client *fake.Clientset) {
+	tr, err := client.TektonV1beta1().TaskRuns("ns").Create(&v1beta1.TaskRun{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1beta1",
+			Kind:       "taskrun",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "Tekton-Result",
-			Namespace:   "default",
+			Name:        "Tekton-TaskRun",
+			Namespace:   "ns",
 			Annotations: map[string]string{"demo": "demo"},
-			UID:         "1",
+			UID:         "12345",
 		},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	pr := &v1beta1.PipelineRun{
+
+	// Wait for Result annotations to show up on the reconciled object.
+	tick := time.NewTicker(1 * time.Second)
+	select {
+	case <-tick.C:
+		tr, err = client.TektonV1beta1().TaskRuns("ns").Get(tr.GetName(), metav1.GetOptions{})
+		if err == nil && tr.Annotations[annotation.ResultID] != "" {
+			break
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out. Last TaskRun: %+v", tr)
+	}
+}
+
+func reconcilePipelineRun(ctx context.Context, t *testing.T, client *fake.Clientset) {
+	pr, err := client.TektonV1beta1().PipelineRuns("ns").Create(&v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1beta1",
+			Kind:       "pipelinerun",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "Tekton-Result",
-			Namespace:   "default",
+			Name:        "pr",
+			Namespace:   "ns",
 			Annotations: map[string]string{"demo": "demo"},
-			UID:         "2",
+			UID:         "12345",
 		},
-	}
-	d := pipelinetest.Data{
-		TaskRuns:     []*v1beta1.TaskRun{tr},
-		PipelineRuns: []*v1beta1.PipelineRun{pr},
-	}
-	ctx, tclients, cmw := test.GetFakeClients(t, d, client)
-	return &ReconcilerTest{
-		taskRun: tr,
-		trAsset: pipelinetest.Assets{
-			Controller: taskrun.NewController(ctx, cmw, client),
-			Clients:    tclients,
-		},
-		pipelineRun: pr,
-		prAsset: pipelinetest.Assets{
-			Controller: pipelinerun.NewController(ctx, cmw, client),
-			Clients:    tclients,
-		},
-		ctx:    ctx,
-		client: client,
-	}
-}
-
-func testUpdatePipelineRunToTheExistedResult(t *testing.T) {
-	tt := newReconcilerTest(t)
-	// Create a TaskRun
-	tr, err := test.ReconcileTaskRun(tt.ctx, tt.trAsset, tt.taskRun)
+	})
 	if err != nil {
-		t.Fatalf("Failed to get completed TaskRun %s: %v", tt.taskRun.Name, err)
-	}
-	resultID, ok := tr.Annotations[annotation.ResultID]
-	if !ok {
-		t.Fatalf("Expected completed TaskRun %s should be updated with a results_id field in annotations", tt.taskRun.Name)
-	}
-	trResult, err := tt.client.GetResult(tt.ctx, &pb.GetResultRequest{Name: resultID})
-	if err != nil {
-		t.Fatalf("Expected completed TaskRun %s not created in api server", tt.taskRun.Name)
+		t.Fatal(err)
 	}
 
-	path, err := annotation.AddResultID(trResult.GetName())
-	if err != nil {
-		t.Fatalf("Error jsonpatch for TaskRun Result %s: %v", trResult.GetName(), err)
-	}
-	// Give the PipelineRun the same Result ID as the TaskRun
-	if _, err := tt.prAsset.Clients.Pipeline.TektonV1beta1().PipelineRuns(tt.pipelineRun.Namespace).Patch(tt.pipelineRun.Name, types.JSONPatchType, path); err != nil {
-		t.Fatalf("Failed to apply result patch to PipelineRun: %v", err)
-	}
-
-	// Update the PipelineRun to the same Result
-	pr, err := test.ReconcilePipelineRun(tt.ctx, tt.prAsset, tt.pipelineRun)
-	if err != nil {
-		t.Fatalf("Failed to reconcile PipelineRun: %v", err)
-	}
-	prResult, err := tt.client.GetResult(tt.ctx, &pb.GetResultRequest{Name: resultID})
-	if err != nil {
-		t.Fatalf("Expected completed PipelineRun %s not updated in api server: %v", tt.pipelineRun.Name, err)
-	}
-	prProto, err := convert.ToPipelineRunProto(pr)
-	if err != nil {
-		t.Fatalf("Failed to convert to proto: %v", err)
-	}
-
-	want := trResult
-	want.Executions = append(want.Executions, &pb.Execution{Execution: &pb.Execution_PipelineRun{PipelineRun: prProto}})
-	if diff := cmp.Diff(want, prResult, protocmp.Transform()); diff != "" {
-		t.Fatalf("Expected completed PipelineRun should be upated in api server: %v", diff)
-	}
-}
-
-func testUpdateTaskRunToTheExistedResult(t *testing.T) {
-	tt := newReconcilerTest(t)
-	// Create a PipelineRun
-	pr, err := test.ReconcilePipelineRun(tt.ctx, tt.prAsset, tt.pipelineRun)
-	if err != nil {
-		t.Fatalf("Failed to get completed PipelineRun %s: %v", tt.pipelineRun.Name, err)
-	}
-	resultID, ok := pr.Annotations[annotation.ResultID]
-	if !ok {
-		t.Fatalf("Expected completed PipelineRun %s should be updated with a results_id field in annotations", tt.pipelineRun.Name)
-	}
-	prResult, err := tt.client.GetResult(tt.ctx, &pb.GetResultRequest{Name: resultID})
-	if err != nil {
-		t.Fatalf("Expected completed PipelineRun %s not created in api server", tt.pipelineRun.Name)
-	}
-
-	path, err := annotation.AddResultID(prResult.GetName())
-	if err != nil {
-		t.Fatalf("Error jsonpatch for PipelineRun Result %s: %v", prResult.GetName(), err)
-	}
-	// Give the TaskRun the same Result ID as the PipelineRun
-	if _, err := tt.trAsset.Clients.Pipeline.TektonV1beta1().TaskRuns(tt.taskRun.Namespace).Patch(tt.taskRun.Name, types.JSONPatchType, path); err != nil {
-		t.Fatalf("Failed to apply result patch to TaskRun: %v", err)
-	}
-
-	// Update the TaskRun to the same Result
-	tr, err := test.ReconcileTaskRun(tt.ctx, tt.trAsset, tt.taskRun)
-	if err != nil {
-		t.Fatalf("Failed to reconcile TaskRun: %v", err)
-	}
-	trResult, err := tt.client.GetResult(tt.ctx, &pb.GetResultRequest{Name: resultID})
-	if err != nil {
-		t.Fatalf("Expected completed TaskRun %s not updated in api server: %v", tt.taskRun.Name, err)
-	}
-	trProto, err := convert.ToTaskRunProto(tr)
-	if err != nil {
-		t.Fatalf("Failed to convert to proto: %v", err)
-	}
-
-	want := prResult
-	want.Executions = append(want.Executions, &pb.Execution{Execution: &pb.Execution_TaskRun{TaskRun: trProto}})
-	if diff := cmp.Diff(want, trResult, protocmp.Transform()); diff != "" {
-		t.Fatalf("Expected completed TaskRun should be upated in api server: %v", diff)
+	// Wait for Result annotations to show up on the reconciled object.
+	tick := time.NewTicker(1 * time.Second)
+	select {
+	case <-tick.C:
+		pr, err = client.TektonV1beta1().PipelineRuns("ns").Get(pr.GetName(), metav1.GetOptions{})
+		if err == nil && pr.Annotations[annotation.ResultID] != "" {
+			break
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out. Last PipelineRun: %+v", pr)
 	}
 }


### PR DESCRIPTION
Previously the reconciler test was functionaly similar to the
underlying Task/PipelineRun reconciler tests, since the test.Reconcile*
funcs would invoke the Reconcile func directly via the assets.

This changes the behavior of the test to start the controller and
informers, and only interface with the watcher via the Tekton client,
polling for the result annotation to verify that it was successful.
We can rely on the underlying typed reconciler tests to verify that the
result uploading is working as intended.