### PR TITLE
Implements the v1alpha2 ETAG

### DIFF
--- a/pkg/api/server/db/model.go
+++ b/pkg/api/server/db/model.go
@@ -28,9 +28,12 @@ type Result struct {
 	Parent      string `gorm:"primaryKey;index:results_by_name,priority:1"`
 	ID          string `gorm:"primaryKey"`
 	Name        string `gorm:"index:results_by_name,priority:2"`
+	Annotations Annotations
+
 	CreatedTime time.Time
 	UpdatedTime time.Time
-	Annotations Annotations
+
+	Etag string
 }
 
 func (r Result) String() string {
@@ -53,6 +56,8 @@ type Record struct {
 
 	CreatedTime time.Time
 	UpdatedTime time.Time
+
+	Etag string
 }
 
 // Annotations is a custom-defined type of a gorm model field.

--- a/pkg/api/server/v1alpha2/record/record_test.go
+++ b/pkg/api/server/v1alpha2/record/record_test.go
@@ -91,7 +91,6 @@ func TestParseName(t *testing.T) {
 			if tc.want == nil {
 				t.Fatalf("expected error, got: [%s, %s]", parent, name)
 			}
-
 			if parent != tc.want[0] || result != tc.want[1] || name != tc.want[2] {
 				t.Errorf("want: %v, got: [%s, %s, %s]", tc.want, parent, result, name)
 			}
@@ -115,8 +114,7 @@ func TestToStorage(t *testing.T) {
 				Data:        protoutil.Any(t, data),
 				CreatedTime: timestamppb.New(clock.Now()),
 				UpdatedTime: timestamppb.New(clock.Now()),
-				// These fields are ignored for now.
-				Etag: "tacocat",
+				Etag:        "tacocat",
 			},
 			want: &db.Record{
 				Parent:      "foo",
@@ -127,6 +125,7 @@ func TestToStorage(t *testing.T) {
 				Data:        protoutil.AnyBytes(t, data),
 				CreatedTime: clock.Now(),
 				UpdatedTime: clock.Now(),
+				Etag:        "tacocat",
 			},
 		},
 		{
@@ -176,15 +175,18 @@ func TestToAPI(t *testing.T) {
 				ID:          "a",
 				Data:        protoutil.AnyBytes(t, data),
 				CreatedTime: clock.Now(),
+				Etag:        "etag",
 			},
 			want: &pb.Record{
 				Name:        "foo/results/bar/records/baz",
 				Id:          "a",
 				Data:        protoutil.Any(t, data),
 				CreatedTime: timestamppb.New(clock.Now()),
+				Etag:        "etag",
 			},
 		},
 		{
+			name: "partial",
 			in: &db.Record{
 				Parent:     "foo",
 				ResultID:   "1",

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -64,6 +64,7 @@ func ToStorage(r *pb.Result) (*db.Result, error) {
 		UpdatedTime: r.UpdatedTime.AsTime(),
 		CreatedTime: r.CreatedTime.AsTime(),
 		Annotations: r.Annotations,
+		Etag:        r.Etag,
 	}
 	return result, nil
 }
@@ -77,6 +78,7 @@ func ToAPI(r *db.Result) *pb.Result {
 		CreatedTime: timestamppb.New(r.CreatedTime),
 		UpdatedTime: timestamppb.New(r.UpdatedTime),
 		Annotations: r.Annotations,
+		Etag:        r.Etag,
 	}
 }
 
@@ -86,4 +88,17 @@ func Match(r *pb.Result, prg cel.Program) (bool, error) {
 		return false, nil
 	}
 	return resultscel.Match(prg, "result", r)
+}
+
+// UpdateEtag updates the etag field of a result according to its content.
+// The result should at least have its `Id` and `UpdatedTime` fields set.
+func UpdateEtag(r *db.Result) error {
+	if r.ID == "" {
+		return fmt.Errorf("the ID field must be set")
+	}
+	if r.UpdatedTime.IsZero() {
+		return status.Error(codes.Internal, "the UpdatedTime field must be set")
+	}
+	r.Etag = fmt.Sprintf("%s-%v", r.ID, r.UpdatedTime.UnixNano())
+	return nil
 }

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -104,9 +104,7 @@ func TestToStorage(t *testing.T) {
 		CreatedTime: timestamppb.New(clock.Now()),
 		UpdatedTime: timestamppb.New(clock.Now()),
 		Annotations: map[string]string{"a": "b"},
-
-		// These fields are ignored for now.
-		Etag: "tacocat",
+		Etag:        "tacocat",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -118,6 +116,7 @@ func TestToStorage(t *testing.T) {
 		Annotations: map[string]string{"a": "b"},
 		CreatedTime: clock.Now(),
 		UpdatedTime: clock.Now(),
+		Etag:        "tacocat",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("-want,+got: %s", diff)
@@ -133,6 +132,7 @@ func TestToAPI(t *testing.T) {
 		CreatedTime: clock.Now(),
 		UpdatedTime: clock.Now(),
 		Annotations: ann,
+		Etag:        "etag",
 	})
 	want := &pb.Result{
 		Name:        "foo/results/bar",
@@ -140,6 +140,7 @@ func TestToAPI(t *testing.T) {
 		CreatedTime: timestamppb.New(clock.Now()),
 		UpdatedTime: timestamppb.New(clock.Now()),
 		Annotations: ann,
+		Etag:        "etag",
 	}
 	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
 		t.Errorf("-want,+got: %s", diff)

--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -81,7 +81,7 @@ func TestEnsureResult(t *testing.T) {
 				want := &pb.Result{
 					Name: name,
 				}
-				if diff := cmp.Diff(want, got, protocmp.Transform(), protocmp.IgnoreFields(want, "id", "created_time", "updated_time")); diff != "" {
+				if diff := cmp.Diff(want, got, protocmp.Transform(), protocmp.IgnoreFields(want, "id", "created_time", "updated_time", "etag")); diff != "" {
 					t.Errorf("Result diff (-want, +got):\n%s", diff)
 				}
 			})
@@ -129,7 +129,7 @@ func TestUpsertRecord(t *testing.T) {
 					t.Fatalf("upsertRecord: %v", err)
 				}
 				want := crdToRecord(t, name, o)
-				opts := []cmp.Option{protocmp.Transform(), protocmp.IgnoreFields(want, "id", "updated_time", "created_time")}
+				opts := []cmp.Option{protocmp.Transform(), protocmp.IgnoreFields(want, "id", "updated_time", "created_time", "etag")}
 				if diff := cmp.Diff(want, got, opts...); diff != "" {
 					t.Errorf("upsertRecord diff (-want, +got):\n%s", diff)
 				}

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -17,10 +17,12 @@ CREATE TABLE results (
 	id varchar(64),
 
 	name varchar(64),
+	annotations BLOB,
+
 	created_time timestamp default current_timestamp not null,
 	updated_time timestamp default current_timestamp not null,
 	
-	annotations BLOB,
+	etag varchar(128),
 
 	PRIMARY KEY(parent, id)
 );
@@ -37,6 +39,8 @@ CREATE TABLE records (
 
 	created_time timestamp default current_timestamp not null,
 	updated_time timestamp default current_timestamp not null,
+
+	etag varchar(128),
 
 	PRIMARY KEY(parent, result_id, id),
 	FOREIGN KEY(parent, result_id) REFERENCES results(parent, id) ON DELETE CASCADE


### PR DESCRIPTION
Implements the v1alpha2 ETAG

Makes the Etag field functional to avoid race condition problem when
updating results and records, see https://google.aip.dev/154 for details.
- Adds the `ETag` in the database schema and the gorm model.
- Makes sure ToStorage and ToAPI can convert the new field properly.
- Updates etag when creating and updating a Result or Record
- The Etag provided by an Update Request has to be aligned with its
  corresponding Etag that saved in the database.

Based on #33