### PR TITLE
Watcher: Automatically group records with known parent types.

### DIFF
--- a/docs/watcher/README.md
+++ b/docs/watcher/README.md
@@ -1,0 +1,20 @@
+# Result Watcher
+
+The Result Watcher is a Kubernetes Controller that watches for changes to certain Tekton types and automatically creates/updates their data in the Result API.
+
+## Supported Types
+
+The Watcher currently supports the following types:
+
+- `tekton.dev/v1beta1 TaskRun`
+- `tekton.dev/v1beta1 PipelineRun`
+
+## Result Grouping
+
+The Watcher uses annotations to automatically detect and group related Records into the same Result. The following annotations are recognized (in order of precedence):
+
+- `results.tekton.dev/result`
+- `triggers.tekton.dev/triggers-eventid`
+- `tekton.dev/pipelineRun`
+
+If no annotation is detected, the Watcher will automatically generate a new Result name for the object.

--- a/pkg/watcher/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/watcher/reconciler/pipelinerun/pipelinerun_test.go
@@ -73,7 +73,7 @@ func TestReconcile(t *testing.T) {
 			Kind:       "pipelinerun",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "Tekton-PipelineRun",
+			Name:        "pipelinerun",
 			Namespace:   "ns",
 			Annotations: map[string]string{"demo": "demo"},
 			UID:         "12345",

--- a/pkg/watcher/reconciler/taskrun/taskrun_test.go
+++ b/pkg/watcher/reconciler/taskrun/taskrun_test.go
@@ -73,7 +73,7 @@ func TestReconcile(t *testing.T) {
 			Kind:       "taskrun",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "Tekton-TaskRun",
+			Name:        "taskrun",
 			Namespace:   "ns",
 			Annotations: map[string]string{"demo": "demo"},
 			UID:         "12345",


### PR DESCRIPTION
Typically we want to group records together with other data related to
the same CI event - e.g. TaskRuns with the PipelineRun that created it,
PipelineRuns with any Trigger data that caused it to be created.

This change modifies the watcher to be aware of known annotations of
other Tekton components that would indicate a parent resource exists. If
detected, the Record will be grouped with the parent instead of creating
a new Result.

Also fixes a minor bug in the reconciler test where we were not polling
for results.

Fixes #40 