### PR TITLE
API: Allow uppercase letters in names.

### DIFF
--- a/pkg/api/server/v1alpha2/record/record.go
+++ b/pkg/api/server/v1alpha2/record/record.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	// NameRegex matches valid name specs for a Result.
-	NameRegex = regexp.MustCompile("(^[a-z0-9_-]{1,63})/results/([a-z0-9_-]{1,63})/records/([a-z0-9_-]{1,63}$)")
+	NameRegex = regexp.MustCompile("(^[a-zA-Z0-9_-]{1,63})/results/([a-zA-Z0-9_-]{1,63})/records/([a-zA-Z0-9_-]{1,63}$)")
 )
 
 // ParseName splits a full Result name into its individual (parent, result, name)

--- a/pkg/api/server/v1alpha2/record/record_test.go
+++ b/pkg/api/server/v1alpha2/record/record_test.go
@@ -47,6 +47,16 @@ func TestParseName(t *testing.T) {
 			want: []string{"results", "records", "records"},
 		},
 		{
+			name: "upper case",
+			in:   "A/results/B/records/C",
+			want: []string{"A", "B", "C"},
+		},
+		{
+			name: "mIxEd case",
+			in:   "Abc/results/aBc/records/abC",
+			want: []string{"Abc", "aBc", "abC"},
+		},
+		{
 			name: "missing name",
 			in:   "a/results/b/records/",
 		},
@@ -77,6 +87,10 @@ func TestParseName(t *testing.T) {
 		{
 			name: "invalid name",
 			in:   "a/results/b/records/c/d",
+		},
+		{
+			name: "invalid character",
+			in:   "💻/results/🐞/records/😭",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	// NameRegex matches valid name specs for a Result.
-	NameRegex = regexp.MustCompile("(^[a-z0-9_-]{1,63})/results/([a-z0-9_-]{1,63}$)")
+	NameRegex = regexp.MustCompile("(^[a-zA-Z0-9_-]{1,63})/results/([a-zA-Z0-9_-]{1,63}$)")
 )
 
 // ParseName splits a full Result name into its individual (parent, name)

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -49,6 +49,16 @@ func TestParseName(t *testing.T) {
 			want: []string{"results", "results"},
 		},
 		{
+			name: "upper case",
+			in:   "A/results/B",
+			want: []string{"A", "B"},
+		},
+		{
+			name: "mIxEd case",
+			in:   "Ab/results/aB",
+			want: []string{"Ab", "aB"},
+		},
+		{
 			name: "missing name",
 			in:   "a/results/",
 		},
@@ -75,6 +85,10 @@ func TestParseName(t *testing.T) {
 		{
 			name: "invalid name",
 			in:   "a/results/b/c",
+		},
+		{
+			name: "invalid character",
+			in:   "🌮/results/🐱",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This loosens the allowed name regex to also allow for uppercase
letters, which allows us to support additional valid k8s names that
conform to RFC 1123 (see
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/).

Also adds additional tests for invalid characters in names.

Fixes #42 