### PR TITLE
Watcher: Add flag for disabling annotation updates.

### DIFF
--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+// Config defines shared reconciler configuration options.
+type Config struct {
+	// Configures whether Tekton CRD objects should be updated with Result
+	// annotations during reconcile. Useful to enable for dry run modes.
+	DisableAnnotationUpdate bool
+}
+
+// GetDisableAnnotationupdate returns whether annotation updates should be
+// disabled. This is safe to call for missing configs.
+func (c *Config) GetDisableAnnotationUpdate() bool {
+	if c == nil {
+		return false
+	}
+	return c.DisableAnnotationUpdate
+}

--- a/pkg/watcher/reconciler/config_test.go
+++ b/pkg/watcher/reconciler/config_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import "testing"
+
+func TestGetDisableAnnotationUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		cfg  *Config
+		want bool
+	}{
+		{
+			cfg:  &Config{DisableAnnotationUpdate: true},
+			want: true,
+		},
+		{
+			cfg:  &Config{DisableAnnotationUpdate: false},
+			want: false,
+		},
+		{
+			cfg:  nil,
+			want: false,
+		},
+	} {
+		got := tc.cfg.GetDisableAnnotationUpdate()
+		if got != tc.want {
+			t.Errorf("Config %+v: want %t, got %t", tc.cfg, tc.want, got)
+		}
+	}
+}

--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -19,6 +19,7 @@ import (
 
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun"
+	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"k8s.io/client-go/tools/cache"
@@ -26,14 +27,19 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// NewController creates a Controller with provided context and configmap
+// NewController creates a Controller for watching PipelineRuns.
 func NewController(ctx context.Context, client pb.ResultsClient) *controller.Impl {
+	return NewControllerWithConfig(ctx, client, &reconciler.Config{})
+}
+
+func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *reconciler.Config) *controller.Impl {
 	logger := logging.FromContext(ctx)
 	pipelineRunInformer := pipelineruninformer.Get(ctx)
 	pipelineclientset := pipelineclient.Get(ctx)
 	c := &Reconciler{
 		client:            results.NewClient(client, "pipelinerun"),
 		pipelineclientset: pipelineclientset,
+		cfg:               cfg,
 	}
 
 	impl := controller.NewImpl(c, logger, "PipelineRunResultsWatcher")

--- a/pkg/watcher/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/watcher/reconciler/pipelinerun/pipelinerun.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
 	"github.com/tektoncd/results/pkg/watcher/results"
 	"go.uber.org/zap"
@@ -31,6 +32,7 @@ import (
 type Reconciler struct {
 	client            *results.Client
 	pipelineclientset versioned.Interface
+	cfg               *reconciler.Config
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
@@ -59,6 +61,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		log.Errorf("error updating Record: %v", err)
 		return err
+	}
+
+	if r.cfg.GetDisableAnnotationUpdate() {
+		// Don't update any annotations - nothing else to do.
+		return nil
 	}
 
 	if a := pr.GetAnnotations(); result.GetName() == a[annotation.Result] && record.GetName() == a[annotation.Record] {

--- a/pkg/watcher/reconciler/reconciler_test.go
+++ b/pkg/watcher/reconciler/reconciler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reconciler
+package reconciler_test
 
 import (
 	"context"

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -19,6 +19,7 @@ import (
 
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
+	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"k8s.io/client-go/tools/cache"
@@ -26,14 +27,19 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// NewController creates a Controller with provided context and configmap
+// NewController creates a Controller for watching TaskRuns.
 func NewController(ctx context.Context, client pb.ResultsClient) *controller.Impl {
+	return NewControllerWithConfig(ctx, client, &reconciler.Config{})
+}
+
+func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *reconciler.Config) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
 	pipelineclientset := pipelineclient.Get(ctx)
 	c := &Reconciler{
 		client:            results.NewClient(client, "taskrun"),
 		pipelineclientset: pipelineclientset,
+		cfg:               cfg,
 	}
 	impl := controller.NewImpl(c, logger, "TaskRunResultsWatcher")
 

--- a/pkg/watcher/reconciler/taskrun/taskrun.go
+++ b/pkg/watcher/reconciler/taskrun/taskrun.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
 	"github.com/tektoncd/results/pkg/watcher/results"
 	"go.uber.org/zap"
@@ -31,6 +32,7 @@ import (
 type Reconciler struct {
 	client            *results.Client
 	pipelineclientset versioned.Interface
+	cfg               *reconciler.Config
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
@@ -59,6 +61,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		log.Errorf("error updating Record: %v", err)
 		return err
+	}
+
+	if r.cfg.GetDisableAnnotationUpdate() {
+		// Don't update any annotations - nothing else to do.
+		return nil
 	}
 
 	if a := tr.GetAnnotations(); result.GetName() == a[annotation.Result] && record.GetName() == a[annotation.Record] {

--- a/pkg/watcher/results/results.go
+++ b/pkg/watcher/results/results.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package results
 
 import (

--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package results
 
 import (


### PR DESCRIPTION
This adds a flag to the watcher binary that allows the watcher to upload
results without annotating the original TaskRun/PipelineRun. This will
allow us to start shadowing results in the Tekton dogfooding cluster
without worrying about impacting any existing data.

/cc #41 