### PR TITLE
Revert "API: Allow uppercase letters in names."

### DIFF
--- a/pkg/api/server/v1alpha2/record/record.go
+++ b/pkg/api/server/v1alpha2/record/record.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	// NameRegex matches valid name specs for a Result.
-	NameRegex = regexp.MustCompile("(^[a-zA-Z0-9_-]{1,63})/results/([a-zA-Z0-9_-]{1,63})/records/([a-zA-Z0-9_-]{1,63}$)")
+	NameRegex = regexp.MustCompile("(^[a-z0-9_-]{1,63})/results/([a-z0-9_-]{1,63})/records/([a-z0-9_-]{1,63}$)")
 )
 
 // ParseName splits a full Result name into its individual (parent, result, name)

--- a/pkg/api/server/v1alpha2/record/record_test.go
+++ b/pkg/api/server/v1alpha2/record/record_test.go
@@ -47,16 +47,6 @@ func TestParseName(t *testing.T) {
 			want: []string{"results", "records", "records"},
 		},
 		{
-			name: "upper case",
-			in:   "A/results/B/records/C",
-			want: []string{"A", "B", "C"},
-		},
-		{
-			name: "mIxEd case",
-			in:   "Abc/results/aBc/records/abC",
-			want: []string{"Abc", "aBc", "abC"},
-		},
-		{
 			name: "missing name",
 			in:   "a/results/b/records/",
 		},
@@ -87,10 +77,6 @@ func TestParseName(t *testing.T) {
 		{
 			name: "invalid name",
 			in:   "a/results/b/records/c/d",
-		},
-		{
-			name: "invalid character",
-			in:   "💻/results/🐞/records/😭",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	// NameRegex matches valid name specs for a Result.
-	NameRegex = regexp.MustCompile("(^[a-zA-Z0-9_-]{1,63})/results/([a-zA-Z0-9_-]{1,63}$)")
+	NameRegex = regexp.MustCompile("(^[a-z0-9_-]{1,63})/results/([a-z0-9_-]{1,63}$)")
 )
 
 // ParseName splits a full Result name into its individual (parent, name)

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -49,16 +49,6 @@ func TestParseName(t *testing.T) {
 			want: []string{"results", "results"},
 		},
 		{
-			name: "upper case",
-			in:   "A/results/B",
-			want: []string{"A", "B"},
-		},
-		{
-			name: "mIxEd case",
-			in:   "Ab/results/aB",
-			want: []string{"Ab", "aB"},
-		},
-		{
 			name: "missing name",
 			in:   "a/results/",
 		},
@@ -85,10 +75,6 @@ func TestParseName(t *testing.T) {
 		{
 			name: "invalid name",
 			in:   "a/results/b/c",
-		},
-		{
-			name: "invalid character",
-			in:   "🌮/results/🐱",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This reverts commit 6ba1f3f8dbb8393f090fe8b1823e2d0a59571558.

I can't read - the [k8s name spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) explictly says that names are *only
lowercase*.

Other changes might need to be made in future PRs to be conformant with
RFC 952 - removal of '_', allow '.', increase allowed name part size to
255 characters. This depends on decisions made in
https://github.com/tektoncd/results/issues/48 (since we may also change
how we generate default names).