### PR TITLE
Implements DeleteRecord

### DIFF
--- a/pkg/api/server/v1alpha2/results_test.go
+++ b/pkg/api/server/v1alpha2/results_test.go
@@ -34,7 +34,7 @@ import (
 func TestCreateResult(t *testing.T) {
 	srv, err := New(test.NewDB(t))
 	if err != nil {
-		t.Fatalf("failed to create temp file for db: %v", err)
+		t.Fatalf("failed to create server: %v", err)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This commit implements the DeleteRecord endpoint. It firstly checks
whether the record exists, if does, deletes, otherwise returns NotFound.

Closes #9 