### PR TITLE
Add Tekton CI/Release configs.

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,36 @@
+
+ignore: |
+  ./tekton/vendor
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: enable
+  hyphens: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning
+
+  # accept both     key:
+  #                   - item
+  #
+  # and             key:
+  #                 - item
+  indentation:
+    indent-sequences: whatever

--- a/tekton/ci-run.yaml
+++ b/tekton/ci-run.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: results-ci-run-
+spec:
+  pipelineRef:
+    name: results-ci
+  params:
+    - name: revision
+      value: main
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tekton/ci.yaml
+++ b/tekton/ci.yaml
@@ -1,0 +1,64 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: results-ci
+spec:
+  params:
+    - name: package
+      description: package to build/test
+      default: ./...
+    - name: repo
+      description: Repo URL to clone.
+      default: https://github.com/tektoncd/results
+    - name: revision
+      description: The Git revision to checkout.
+      default: main
+  workspaces:
+    - name: ws
+  tasks:
+    - name: checkout
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.repo)
+        - name: revision
+          value: $(params.revision)
+      workspaces:
+        - name: output
+          workspace: ws
+    - name: unit-tests
+      runAfter: [checkout]
+      taskRef:
+        name: golang-test
+      params:
+        - name: package
+          value: $(params.package)
+      workspaces:
+        - name: source
+          workspace: ws
+    - name: build
+      runAfter: [checkout]
+      taskRef:
+        name: golang-build
+      params:
+        - name: package
+          value: $(params.package)
+      workspaces:
+        - name: source
+          workspace: ws

--- a/tekton/release-api.yaml
+++ b/tekton/release-api.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: results-release-api-
+spec:
+  serviceAccountName: tekton-releaser
+  pipelineRef:
+    name: results-release
+  params:
+    - name: revision
+      value: main
+    - name: package
+      value: github.com/tektoncd/results/cmd/api
+    - name: docker_repo
+      value: ko.local
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tekton/release-watcher.yaml
+++ b/tekton/release-watcher.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: results-release-watcher-
+spec:
+  serviceAccountName: tekton-releaser
+  pipelineRef:
+    name: results-release
+  params:
+    - name: revision
+      value: main
+    - name: package
+      value: github.com/tektoncd/results/cmd/watcher
+    - name: docker_repo
+      value: ko.local
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tekton/release.yaml
+++ b/tekton/release.yaml
@@ -1,0 +1,67 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: results-release
+spec:
+  params:
+    - name: package
+      description: package to release
+    - name: repo
+      description: Repo URL to clone.
+      default: https://github.com/tektoncd/results
+    - name: revision
+      description: The Git revision to checkout.
+      default: main
+    - name: docker_repo
+      default: "ko.local"
+  workspaces:
+    - name: ws
+  tasks:
+    - name: checkout
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.repo)
+        - name: revision
+          value: $(params.revision)
+      workspaces:
+        - name: output
+          workspace: ws
+    - name: unit-tests
+      runAfter: [checkout]
+      taskRef:
+        name: golang-test
+      params:
+        - name: package
+          value: $(params.package)
+      workspaces:
+        - name: source
+          workspace: ws
+    - name: build
+      runAfter: [unit-tests]
+      taskRef:
+        name: ko-publish
+      params:
+        - name: package
+          value: $(params.package)
+        - name: repo
+          value: $(params.docker_repo)
+      workspaces:
+        - name: source
+          workspace: ws

--- a/tekton/tasks/ko/ko.yaml
+++ b/tekton/tasks/ko/ko.yaml
@@ -1,0 +1,43 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: ko-publish
+spec:
+  description: >-
+    This Task is Golang task to publish ko projects.
+
+  params:
+    - name: package
+      description: package to publish
+    - name: repo
+      description: Docker repository to publish to.
+    - name: tag
+      default: latest
+  workspaces:
+    - name: source
+  steps:
+    - name: publish
+      image: gcr.io/tekton-releases/dogfooding/ko-gcloud@sha256:763e9474f0e722f00add5785a9cdccd9a001072978d86e962a52f45fccb46529
+      workingDir: $(workspaces.source.path)
+      script: |
+        gcloud auth list
+        gcloud auth configure-docker
+        gcloud auth print-access-token | ko login -u oauth2accesstoken --password-stdin us-docker.pkg.dev
+        ko publish $(params.package) -t $(params.tag)
+      env:
+        - name: KO_DOCKER_REPO
+          value: "$(params.repo)"

--- a/tekton/vendor/README.md
+++ b/tekton/vendor/README.md
@@ -1,0 +1,5 @@
+The images in this folder are vendored from the
+[Tekton Catalog](https://github.com/tektoncd/catalog).
+
+This is intended to be a helper utility to bootstrap local clusters for testing
+release configs.

--- a/tekton/vendor/vendor.sh
+++ b/tekton/vendor/vendor.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/golang-test/0.1/golang-test.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/golang-build/0.1/golang-build.yaml
+kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-clone/0.2/git-clone.yaml


### PR DESCRIPTION
This adds initial configs for building and deploying Docker images for
the API Server and Watcher.

Verified this works on a personal registry. TODO for figuring out where
in tekton-releases this should be pointed at.

This pipeline depends on GKE Workload Identity for automatically
retrieving credentials for pushing the image. Additional work might be
needed to make this GKE-agnostic (but since we currently use GKE/GCR for
Tekton dogfooding, this should be okay for now).

Partially addresses #27 