### PR TITLE
Add release script.

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+# Default to short SHA if release version not set.
+RELEASE_VERSION=${RELEASE_VERSION:-"$(git rev-parse --short HEAD)"}
+
+export KO_DOCKER_REPO=${KO_DOCKER_REPO:-"ko.local"}
+
+ko resolve -P -f ${ROOT}/config -t ${RELEASE_VERSION} | sed "s/devel/${RELEASE_VERSION}/g" > ${ROOT}/release/release.yaml


### PR DESCRIPTION
This script uses ko to generate a release yaml and publishes the images
to the specified docker repo.

This unblocks us short term to start making manual releases if
necessary, and long term we can run this as part of our release
pipeline.

Part of #27 