### PR TITLE
Use standard StorageClass for MySQL pvc.

### DIFF
--- a/config/200-mysql-pv.yaml
+++ b/config/200-mysql-pv.yaml
@@ -13,26 +13,12 @@
 # limitations under the License.
 
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: results-mysql-pv-volume
-  namespace: tekton-pipelines
-spec:
-  storageClassName: results-database
-  capacity:
-    storage: 20Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: "/mnt/data"
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: results-mysql-pv-claim
   namespace: tekton-pipelines
 spec:
-  storageClassName: results-database
+  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
This defers to the system default storage class when provisioning the PV
for result storage. This should avoid any environment specific issues
around the use of hostPath.

Manually tested this works on a fresh deploy to GKE.

Fixes #65 