### PR TITLE
Move top level README to docs.

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,7 +31,7 @@ $ ./test/e2e/01-install.sh  # installs pipelines, configures db, installs result
 ```
 
 `01-install.sh` uses the default kubectl context, so this can be ran on both
-kind or real Kubernetes clusters. See [test/e2e/README.md](test/e2e/README.md)
+kind or real Kubernetes clusters. See [test/e2e/README.md](/test/e2e/README.md)
 for configurable options for these scripts.
 
 ### Deploying individual components
@@ -99,7 +99,7 @@ $ go test ./...
 
 ### E2E Tests
 
-See [test/e2e/README.md](test/e2e/README.md)
+See [test/e2e/README.md](/test/e2e/README.md)
 
 ## Recommended Reading
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ server.
 The full motivation and design are available in
 [TEP-0021](https://github.com/tektoncd/community/blob/master/teps/0021-results-api.md).
 
-See [proto/v1alpha2](proto/v1alpha2) for the latest Results API spec.
+See [proto/v1alpha2](/proto/v1alpha2) for the latest Results API spec.
 
 ## Quickstart
 
@@ -22,7 +22,7 @@ from source.
 
 ## Data Model
 
-![results data model](docs/images/results.png)
+![results data model](images/results.png)
 
 - Records are individual instances of data. These will commonly be execution
   data (e.g. PipelineRun, TaskRuns), but could also reference additional data
@@ -42,7 +42,7 @@ examples of the data we intend to support).
 
 ## Helpful links
 
-- [Roadmap](docs/roadmap.md)
+- [Roadmap](roadmap.md)
 
 ## Contact
 


### PR DESCRIPTION
This is necessary for the Tekton website to render this page properly
(it assumes everything is rooted in 1 folder). See https://github.com/tektoncd/website/pull/230

GitHub supports rendering project READMEs stored in the docs folder
(https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-readmes)
so this should have minimal impact on the browser UX.