### PR TITLE
Add simple UI for visualizing Result data.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.4
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2
+	github.com/gorilla/mux v1.7.4
 	github.com/jonboulle/clockwork v0.1.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/onsi/ginkgo v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -649,6 +649,7 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=

--- a/tools/simpleui/README.md
+++ b/tools/simpleui/README.md
@@ -1,0 +1,18 @@
+# SimpleUI
+
+This folder contains a test HTTP server for rendering Results in a very basic
+UI.
+
+This is **not** intended to be a replacement UI for
+[dashboard](`https://github.com/tektoncd/dashboard) - this is only here for
+local testing to help visualize result data.
+
+## How to run
+
+```sh
+# Port forward API Server to make it available locally.
+# This should be ran in its own shell or backgrounded, since the command blocks.
+$ kubectl port-forward -n tekton-pipelines service/tekton-results-api-service 50051:50051
+# Start the HTTP server
+$ go run .
+```

--- a/tools/simpleui/main.go
+++ b/tools/simpleui/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc"
+)
+
+var (
+	resultTmpl = template.Must(template.New("results.html").ParseFiles("templates/results.html"))
+	recordTmpl = template.Must(template.New("records.html").
+			Funcs(template.FuncMap{
+			"textproto": textproto,
+		}).
+		ParseFiles("templates/records.html"))
+)
+
+func (u *ui) home(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Add namespace to URL (/<namespace>) ^^^")
+}
+
+func (u *ui) results(w http.ResponseWriter, r *http.Request) {
+	res, err := u.client.ListResults(r.Context(), &pb.ListResultsRequest{
+		Parent: strings.Trim(r.URL.Path, "/"),
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err)
+		return
+	}
+	if err := resultTmpl.Execute(w, res); err != nil {
+		return
+	}
+}
+
+func (u *ui) records(w http.ResponseWriter, r *http.Request) {
+	res, err := u.client.ListRecords(r.Context(), &pb.ListRecordsRequest{
+		Parent: strings.Trim(r.URL.Path, "/"),
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err)
+		return
+	}
+	if err := recordTmpl.Execute(w, res); err != nil {
+		return
+	}
+}
+
+type ui struct {
+	client pb.ResultsClient
+}
+
+func main() {
+	conn, err := grpc.Dial("localhost:50051", grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+	u := &ui{
+		client: pb.NewResultsClient(conn),
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", u.home)
+	r.HandleFunc("/{namespace}", u.results)
+	r.HandleFunc("/{namespace}/results/{name}", u.records)
+	http.Handle("/", r)
+
+	log.Println("Running on http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/tools/simpleui/template.go
+++ b/tools/simpleui/template.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	_ "github.com/tektoncd/results/proto/pipeline/v1beta1/pipeline_go_proto"
+)
+
+func textproto(a *anypb.Any) (string, error) {
+	m, err := a.UnmarshalNew()
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+	return prototext.Format(m), nil
+}

--- a/tools/simpleui/templates/records.html
+++ b/tools/simpleui/templates/records.html
@@ -1,0 +1,24 @@
+<html>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+    <body>
+        <h1>Records</h1>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Created</th>
+                    <th scope="col">Data</th>
+                </tr>
+            </thead>
+            {{range .Records}}
+            <tr>
+                <td>{{.Name}}</td>
+                <td>{{.Data.TypeUrl}}</td>
+                <td>{{.CreatedTime.AsTime}}</td>
+                <td><span style="white-space: pre-wrap"><code>{{textproto .Data}}</code></span></td>
+            </tr>
+            {{end}}
+        </table>
+    </body>
+</html>

--- a/tools/simpleui/templates/results.html
+++ b/tools/simpleui/templates/results.html
@@ -1,0 +1,20 @@
+<html>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+    <body>
+        <h1>Results</h1>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Created</th>
+                </tr>
+            </thead>
+            {{range .Results}}
+            <tr>
+                <td><a href="/{{.Name}}">{{.Name}}</a></td>
+                <td>{{.CreatedTime.AsTime}}</td>
+            </tr>
+            {{end}}
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
This folder contains a test HTTP server for rendering Results in a very basic
UI.

This is **not** intended to be a replacement UI for
[dashboard](https://github.com/tektoncd/dashboard) - this is only here for
local testing to help visualize result data.

This is only intended for testing, so testing rigor and polish are not
strictly enforced.