### PR TITLE
[watcher] Use MergePatch type instead of JSON Patch.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201202100533-7534955ac86b // indirect
-	gomodules.xyz/jsonpatch/v2 v2.1.0
 	google.golang.org/api v0.31.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154

--- a/pkg/watcher/reconciler/annotation/annotation.go
+++ b/pkg/watcher/reconciler/annotation/annotation.go
@@ -16,10 +16,6 @@ package annotation
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
-
-	"gomodules.xyz/jsonpatch/v2"
 )
 
 const (
@@ -27,29 +23,16 @@ const (
 	Record = "results.tekton.dev/record"
 )
 
-var (
-	resultPath = path(Result)
-	recordPath = path(Record)
-)
-
-func path(s string) string {
-	return fmt.Sprintf("/metadata/annotations/%s", strings.ReplaceAll(s, "/", "~1"))
-}
-
 // Add creates a jsonpatch path used for adding result / record identifiers
 // an object's annotations field.
 func Add(result, record string) ([]byte, error) {
-	patches := []jsonpatch.JsonPatchOperation{
-		{
-			Operation: "add",
-			Path:      resultPath,
-			Value:     result,
-		},
-		{
-			Operation: "add",
-			Path:      recordPath,
-			Value:     record,
+	data := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				Result: result,
+				Record: record,
+			},
 		},
 	}
-	return json.Marshal(patches)
+	return json.Marshal(data)
 }

--- a/pkg/watcher/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/watcher/reconciler/pipelinerun/pipelinerun.go
@@ -80,7 +80,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		log.Errorf("error adding Result annotations: %v", err)
 		return err
 	}
-	if _, err := r.pipelineclientset.TektonV1beta1().PipelineRuns(pr.GetNamespace()).Patch(pr.Name, types.JSONPatchType, patch); err != nil {
+	if _, err := r.pipelineclientset.TektonV1beta1().PipelineRuns(pr.GetNamespace()).Patch(pr.Name, types.MergePatchType, patch); err != nil {
 		log.Errorf("PipelineRun.Patch: %v", err)
 		return err
 	}

--- a/pkg/watcher/reconciler/taskrun/taskrun.go
+++ b/pkg/watcher/reconciler/taskrun/taskrun.go
@@ -80,7 +80,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		log.Errorf("error adding Result annotations: %v", err)
 		return err
 	}
-	if _, err := r.pipelineclientset.TektonV1beta1().TaskRuns(tr.GetNamespace()).Patch(tr.Name, types.JSONPatchType, patch); err != nil {
+	if _, err := r.pipelineclientset.TektonV1beta1().TaskRuns(tr.GetNamespace()).Patch(tr.Name, types.MergePatchType, patch); err != nil {
 		log.Errorf("TaskRun.Patch: %v", err)
 		return err
 	}


### PR DESCRIPTION
If a resource is missing an annotation field, the JSONPatch add will
fail because the parent is missing. Instead, use MergePatch to
automatically create, update, or add the annotation.

Fixes #76 