### PR TITLE
Enable TLS and use Service Account tokens in Watcher.

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -18,10 +18,12 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"flag"
+	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	creds "github.com/tektoncd/results/pkg/watcher/grpc"
@@ -29,9 +31,12 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/reconciler/pipelinerun"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/taskrun"
 	v1alpha2pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/transport"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -40,10 +45,16 @@ import (
 	_ "knative.dev/pkg/system/testing"
 )
 
+const (
+	// Service Account token path. See https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod
+	podTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
 var (
 	apiAddr          = flag.String("api_addr", "localhost:50051", "Address of API server to report to")
 	authMode         = flag.String("auth_mode", "", "Authentication mode to use when making requests. If not set, no additional credentials will be used in the request. Valid values: [google]")
 	disableCRDUpdate = flag.Bool("disable_crd_update", false, "Disables Tekton CRD annotation update on reconcile.")
+	authToken        = flag.String("token", "", "Authentication token to use in requests. If not specified, on-cluster configuration is assumed.")
 )
 
 func main() {
@@ -55,7 +66,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
-	log.Println("connected!")
 	defer conn.Close()
 	results := v1alpha2pb.NewResultsClient(conn)
 
@@ -74,20 +84,16 @@ func main() {
 }
 
 func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*grpc.ClientConn, error) {
-	opts := []grpc.DialOption{
-		grpc.WithBlock(),
-	}
-
-	// Setup TLS certs to the server. Do this once since this is likely going
-	// to be shared in multiple auth modes.
-	certs, err := x509.SystemCertPool()
+	// Load TLS certs
+	certs, err := loadCerts()
 	if err != nil {
 		log.Fatalf("error loading cert pool: %v", err)
 	}
-	cred := credentials.NewTLS(&tls.Config{
-		RootCAs: certs,
-	})
+	cred := credentials.NewClientTLSFromCert(certs, "")
 
+	opts := []grpc.DialOption{
+		grpc.WithBlock(),
+	}
 	// Add in additional credentials to requests if desired.
 	switch authMode {
 	case "google":
@@ -95,6 +101,17 @@ func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*
 			grpc.WithAuthority(apiAddr),
 			grpc.WithTransportCredentials(cred),
 			grpc.WithDefaultCallOptions(grpc.PerRPCCredentials(creds.Google())),
+		)
+	case "token":
+		var ts oauth2.TokenSource
+		if t := *authToken; t != "" {
+			ts = oauth2.StaticTokenSource(&oauth2.Token{AccessToken: t})
+		} else {
+			ts = transport.NewCachedFileTokenSource(podTokenPath)
+		}
+		opts = append(opts,
+			grpc.WithDefaultCallOptions(grpc.PerRPCCredentials(oauth.TokenSource{TokenSource: ts})),
+			grpc.WithTransportCredentials(cred),
 		)
 	case "insecure":
 		opts = append(opts, grpc.WithInsecure())
@@ -104,4 +121,27 @@ func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	return grpc.DialContext(ctx, apiAddr, opts...)
+}
+
+func loadCerts() (*x509.CertPool, error) {
+	// Setup TLS certs to the server.
+	f, err := os.Open("/etc/tls/tls.crt")
+	if err != nil {
+		log.Println("no local cluster cert found, defaulting to system pool...")
+		return x509.SystemCertPool()
+	}
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read TLS cert file: %v", err)
+	}
+
+	certs, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("error loading cert pool: %v", err)
+	}
+	if ok := certs.AppendCertsFromPEM(b); !ok {
+		return nil, fmt.Errorf("unable to add cert to pool")
+	}
+	return certs, nil
 }

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -60,7 +60,14 @@ spec:
               value: tekton-results-mysql.tekton-pipelines.svc.cluster.local
             - name: DB_NAME
               value: results
-
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/tls"
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tekton-results-tls
 ---
 apiVersion: v1
 kind: Service

--- a/config/default-clusterroles.yaml
+++ b/config/default-clusterroles.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-readonly
+rules:
+  - apiGroups: ["results.tekton.dev"]
+    resources: ["results", "records"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-readwrite
+rules:
+  - apiGroups: ["results.tekton.dev"]
+    resources: ["results", "records"]
+    verbs: ["create", "update", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-admin
+rules:
+  - apiGroups: ["results.tekton.dev"]
+    resources: ["results", "records"]
+    verbs: ["create", "update", "get", "list", "admin"]

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -47,5 +47,13 @@ spec:
               "-api_addr",
               "tekton-results-api-service.tekton-pipelines.svc.cluster.local:50051",
               "-auth_mode",
-              "insecure",
+              "token",
             ]
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/tls"
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tekton-results-tls

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,5 +1,90 @@
 # Results API
 
+## Authentication/Authorization
+
+The reference implementation of the Results API expects
+[cluster generated authentication tokens](https://kubernetes.io/docs/reference/access-authn-authz/authentication/)
+from the cluster it is running on. In most cases, using a service account will
+be the easiest way to interact with the API.
+
+[RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+is used to control access to API Resources.
+
+The following attributes are recognized:
+
+| Attribute | Values                            |
+| --------- | --------------------------------- |
+| apiGroups | results.tekton.dev                |
+| resources | results, records                  |
+| verbs     | create, get, list, update, delete |
+
+For example, a read-only Role might look like:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tekton-results-readonly
+rules:
+  - apiGroups: ["results.tekton.dev"]
+    resources: ["results", "records"]
+    verbs: ["get", "list"]
+```
+
+In the reference implementation, all permissions are scoped per namespace (this
+is what is used as the API parent resource).
+
+As a convenience, the following [ClusterRoles] are defined for common access
+patterns:
+
+| ClusterRole              | Description                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| tekton-results-readonly  | Read only access to all Result API resources                                   |
+| tekton-results-readwrite | Includes `tekton-results-readonly` + Create or update all Result API resources |
+| tekton-results-admin     | Includes `tekton-results-readwrite` + Allows deletion of Result API Resources  |
+
+### Troubleshooting
+
+The following command can be ran to query the cluster's permissions. This can be useful for debugging permission denied errors:
+
+```sh
+$ kubectl create --as=system:serviceaccount:tekton-pipelines:tekton-results-watcher -n tekton-pipelines -f - -o yaml << EOF
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+spec:
+  resourceAttributes:
+    group: results.tekton.dev
+    resource: results
+    verb: get
+EOF
+apiVersion: authorization.k8s.io/v1
+kind: SelfSubjectAccessReview
+metadata:
+  creationTimestamp: null
+  managedFields:
+  - apiVersion: authorization.k8s.io/v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:spec:
+        f:resourceAttributes:
+          .: {}
+          f:group: {}
+          f:resource: {}
+          f:verb: {}
+    manager: kubectl
+    operation: Update
+    time: "2021-02-02T22:37:32Z"
+spec:
+  resourceAttributes:
+    group: results.tekton.dev
+    resource: results
+    verb: get
+status:
+  allowed: true
+  reason: 'RBAC: allowed by ClusterRoleBinding "tekton-results-watcher" of ClusterRole
+    "tekton-results-watcher" to ServiceAccount "tekton-results-watcher/tekton-pipelines"'
+```
+
 ## Filtering
 
 The reference implementation of the Results API uses
@@ -22,10 +107,10 @@ Known types exposed to each RPC method are documented below.
 
 #### Cookbook
 
-| Filter Spec                                                                                                                                                                               | Description                                                                                      |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `record.name.startsWith("foo/results/bar")`                                                                                                                                               | Get all Records belonging to Result `foo/results/bar`                                            |
-| `type(record.data) == tekton.pipeline.v1beta1.TaskRun`                                                                                                                                    | Get all Records of type TaskRun                                                                  |
+| Filter Spec                                                                                                                                                                           | Description                                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `record.name.startsWith("foo/results/bar")`                                                                                                                                           | Get all Records belonging to Result `foo/results/bar`                                            |
+| `type(record.data) == tekton.pipeline.v1beta1.TaskRun`                                                                                                                                | Get all Records of type TaskRun                                                                  |
 | `type(record.data) == tekton.pipeline.v1beta1.TaskRun && record.data.metadata.name.contains("release") && record.data.spec.task_spec.steps.exists(step, step.name.contains("fetch"))` | Get TasksRuns with a name that contains "release" and at least 1 step name that contains "fetch" |
 
 ## Reading Records across Results

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,11 +24,31 @@
    $ kubectl create secret generic tekton-results-mysql --namespace="tekton-pipelines" --from-literal=user=root --from-literal=password=$(openssl rand -base64 20)
    ```
 
+3. Generate cert/key pair. Note: Feel free to use any cert management software to do this!
+
+   Tekton Results expects the cert/key pair to be stored in a [TLS Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
+
+   ```sh
+   # Generate new self-signed cert.
+   $ openssl req -x509 \
+   -newkey rsa:4096 \
+   -keyout key.pem \
+   -out cert.pem \
+   -days 365 \
+   -nodes \
+   -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local"
+   # Create new TLS Secret from cert.
+   $ kubectl create secret tls -n tekton-pipelines tekton-results-tls \
+   --cert=cert.pem \
+   --key=key.pem
+   ```
+
 ## Installing Tekton Results on Kubernetes
 
 COMING SOON!
 
 ### Installing from source
 
-See [DEVELOPMENT.md](../DEVELOPMENT.md) for how to install Tekton Results from
+See [DEVELOPMENT.md](DEVELOPMENT.md) for how to install Tekton Results from
 source.
+

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 	golang.org/x/mod v0.4.0 // indirect
+	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201202100533-7534955ac86b // indirect

--- a/pkg/api/server/v1alpha2/auth/rbac_test.go
+++ b/pkg/api/server/v1alpha2/auth/rbac_test.go
@@ -16,6 +16,7 @@ package auth_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	server "github.com/tektoncd/results/pkg/api/server/v1alpha2"
@@ -97,7 +98,10 @@ func TestRBAC(t *testing.T) {
 		},
 	} {
 		t.Run(tc.user, func(t *testing.T) {
-			ctx := metadata.AppendToOutgoingContext(ctx, "token", tc.token)
+			// Simulates a oauth.TokenSource. We avoid using the real
+			// oauth.TokenSource here since it requires a higher SecurityLevel
+			// + TLS.
+			ctx := metadata.AppendToOutgoingContext(ctx, "authorization", fmt.Sprintf("Bearer %s", tc.token))
 			if _, err := client.CreateResult(ctx, &pb.CreateResultRequest{
 				Parent: "foo",
 				Result: &pb.Result{

--- a/test/e2e/00-setup.sh
+++ b/test/e2e/00-setup.sh
@@ -16,7 +16,7 @@
 set -e
 
 export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"tekton-results"}
-KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.17.11}"
+KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.19.1}"
 
 kind create cluster --name="${KIND_CLUSTER_NAME}" --image="${KIND_IMAGE}" --wait=60s
 kubectl cluster-info --context "kind-${KIND_CLUSTER_NAME}"


### PR DESCRIPTION
- Configures watcher to use the Pod Service Account token
(https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
to authenticate to the API Server.
- Changes the authorization header format API Server expects to be
inline with gRPC TokenSource (OAuth2 Bearer).
- Since gRPC forbids usage of TokenSource transport without SSL enabled,
configures usage of TLS in gRPC client/server (see
https://grpc.io/docs/guides/auth/#with-server-authentication-ssltls).
  - By default, docs guide users to generate a self-signed key/cert
  pair.
- Includes premade ClusterRoles for common auth roles we expect (ro, rw,
admin).

Fixes #58 