### PR TITLE
[api] Add grpc server Prometheus metrics.

### DIFF
--- a/config/api.yaml
+++ b/config/api.yaml
@@ -78,6 +78,11 @@ spec:
   selector:
     app: tekton-results-api
   ports:
-    - protocol: TCP
+    - name: grpc
+      protocol: TCP
       port: 50051
       targetPort: 50051
+    - name: prometheus
+      protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -45,7 +45,8 @@ patterns:
 
 ### Troubleshooting
 
-The following command can be ran to query the cluster's permissions. This can be useful for debugging permission denied errors:
+The following command can be ran to query the cluster's permissions. This can be
+useful for debugging permission denied errors:
 
 ```sh
 $ kubectl create --as=system:serviceaccount:tekton-pipelines:tekton-results-watcher -n tekton-pipelines -f - -o yaml << EOF
@@ -118,3 +119,10 @@ Known types exposed to each RPC method are documented below.
 Records can be read across Results by specifying `-` as the Result name part
 (e.g. `default/results/-`). This can be used to read and filter matching Records
 without knowing the exact Result name.
+
+## Metrics
+
+The API Server includes an HTTP server for exposing gRPC server Prometheus metrics.
+By default, the Service exposes metrics on port `:8080`. For more
+details on the structure of the metrics, see
+https://github.com/grpc-ecosystem/go-grpc-prometheus#metrics.

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,9 +24,11 @@
    $ kubectl create secret generic tekton-results-mysql --namespace="tekton-pipelines" --from-literal=user=root --from-literal=password=$(openssl rand -base64 20)
    ```
 
-3. Generate cert/key pair. Note: Feel free to use any cert management software to do this!
+3. Generate cert/key pair. Note: Feel free to use any cert management software
+   to do this!
 
-   Tekton Results expects the cert/key pair to be stored in a [TLS Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
+   Tekton Results expects the cert/key pair to be stored in a
+   [TLS Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
 
    ```sh
    # Generate new self-signed cert.
@@ -60,4 +62,3 @@ $ kubectl apply -f https://storage.googleapis.com/tekton-releases/results/previo
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for how to install Tekton Results from
 source.
-

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,12 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.4
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/jonboulle/clockwork v0.1.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/onsi/ginkgo v1.14.1 // indirect
 	github.com/onsi/gomega v1.10.2 // indirect
+	github.com/prometheus/client_golang v1.6.0
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/tektoncd/pipeline v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -664,6 +664,7 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/test/e2e/01-install.sh
+++ b/test/e2e/01-install.sh
@@ -35,7 +35,7 @@ openssl req -x509 \
    -days 365 \
    -nodes \
    -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local"
-kubectl create secret tls -n tekton-pipelines tekton-results-tls --cert="/tmp/tekton-results-cert.pem" --key="/tmp/tekton-results-key.pem"
+kubectl create secret tls -n tekton-pipelines tekton-results-tls --cert="/tmp/tekton-results-cert.pem" --key="/tmp/tekton-results-key.pem" || true
 
 echo "Installing Tekton Results..."
 ko apply --filename="${ROOT}/config/"


### PR DESCRIPTION
This adds a gRPC interceptor and HTTP server to expose gRPC metrics that
can be consumed by Prometheus.

See https://github.com/grpc-ecosystem/go-grpc-prometheus for more details on setup/configuration.

Fixes #74 