### PR TITLE
Add hugo frontmatter labels to README.md.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: "Results"
+linkTitle: "Results
+weight: 2
+description: >
+  Result storage for Tekton CI/CD data.
+cascade:
+  github_project_repo: https://github.com/tektoncd/results
+---
+-->
 # Tekton Results
 
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/tektoncd/results)


### PR DESCRIPTION
This helps give information for rendering docs on tekton.dev. See
https://gohugo.io/content-management/front-matter/ for full
documentation and
https://github.com/tektoncd/pipeline/blob/master/docs/README.md for an
example of how this is used elsewhere in Tekton.