### PR TITLE
Fix typo in README.md frontmatter.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 <!--
 ---
 title: "Results"
-linkTitle: "Results
+linkTitle: "Results"
 weight: 2
 description: >
   Result storage for Tekton CI/CD data.


### PR DESCRIPTION
I think this is causing the errors when trying to generate the
tekton.dev docs - see https://app.netlify.com/sites/tekton/deploys/602ea13db960a80008be8adb

Part of #28 