### PR TITLE
Add kustomize support for e2e tests.

### DIFF
--- a/config/default-clusterroles.yaml
+++ b/config/default-clusterroles.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: hello
-spec:
-  pipelineSpec:
-    tasks:
-      - name: hello
-        taskSpec:
-          steps:
-            - name: hello
-              image: ubuntu
-              script: "echo hello world!"
+resources:
+- 100-api-serviceaccount.yaml
+- 100-mysql-init.yaml
+- 100-watcher-serviceaccount.yaml
+- 200-mysql-pv.yaml
+- 201-mysql-deployment.yaml
+- api.yaml
+- default-clusterroles.yaml
+- watcher.yaml

--- a/test/e2e/01-install.sh
+++ b/test/e2e/01-install.sh
@@ -38,7 +38,7 @@ openssl req -x509 \
 kubectl create secret tls -n tekton-pipelines tekton-results-tls --cert="/tmp/tekton-results-cert.pem" --key="/tmp/tekton-results-key.pem" || true
 
 echo "Installing Tekton Results..."
-ko apply --filename="${ROOT}/config/"
+kustomize build "${ROOT}/test/e2e/kustomize" | ko apply -f -
 
 echo "Waiting for deployments to be ready..."
 kubectl wait deployment "tekton-results-mysql" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"

--- a/test/e2e/kustomize/kustomization.yaml
+++ b/test/e2e/kustomize/kustomization.yaml
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: hello
-spec:
-  pipelineSpec:
-    tasks:
-      - name: hello
-        taskSpec:
-          steps:
-            - name: hello
-              image: ubuntu
-              script: "echo hello world!"
+bases:
+- ../../../config/
+patchesJson6902:
+- target:
+    group: apps
+    version: v1 # apiVersion
+    kind: Deployment
+    name: tekton-results-watcher
+    namespace: tekton-pipelines
+  path: watcher.yaml

--- a/test/e2e/kustomize/watcher.yaml
+++ b/test/e2e/kustomize/watcher.yaml
@@ -12,16 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: hello
-spec:
-  pipelineSpec:
-    tasks:
-      - name: hello
-        taskSpec:
-          steps:
-            - name: hello
-              image: ubuntu
-              script: "echo hello world!"
+# This is effectively a no-op, but exists as an example of how to perform
+# overlays.
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-disable_crd_update"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "false"


### PR DESCRIPTION
For e2e tests, we want to match the upstream deployment as close as
possible. However, there will often be times where we need to make
minor modifications to the e2e tests to enable/modify settings.

The main motivator for this are upcoming e2e tests for automatic Run
cleanup (#59). We want to be able to significantly reduce the grace period for
Run deletion (e.g. O(seconds)) so that we can speed up test execution.
This kind of setting is probably not acceptable for typical users, who
would likely want O(minutes) if not O(hours).

This currently adds a flag that is effectively a no-op, since it is the
default value of the flag anyway.