### PR TITLE
Add Subject Alternative Name to test certificate script

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -38,7 +38,8 @@
    -out cert.pem \
    -days 365 \
    -nodes \
-   -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local"
+   -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local" \
+   -addext "subjectAltName = DNS:tekton-results-api-service.tekton-pipelines.svc.cluster.local"
    # Create new TLS Secret from cert.
    $ kubectl create secret tls -n tekton-pipelines tekton-results-tls \
    --cert=cert.pem \

--- a/test/e2e/01-install.sh
+++ b/test/e2e/01-install.sh
@@ -34,7 +34,8 @@ openssl req -x509 \
    -out "/tmp/tekton-results-cert.pem" \
    -days 365 \
    -nodes \
-   -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local"
+   -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local" \
+   -addext "subjectAltName = DNS:tekton-results-api-service.tekton-pipelines.svc.cluster.local"
 kubectl create secret tls -n tekton-pipelines tekton-results-tls --cert="/tmp/tekton-results-cert.pem" --key="/tmp/tekton-results-key.pem" || true
 
 echo "Installing Tekton Results..."


### PR DESCRIPTION
Prior to this commit we generated a test certificate with
openssl using the -subj flag. Depending on the go version
and environment variables this could cause issues because
the CN certificate field is deprecated in favor of the SAN field.

This commit adds the -addext flag to additionally include a
Subject Alternative Names field to the cert.