### PR TITLE
Document applying all with kustomize and use `kubectl kustomize` instead

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,12 +36,22 @@ for configurable options for these scripts.
 
 ### Deploying individual components
 
-You can redeploy individual components via ko. Just make sure to use
+You can redeploy individual components via ko. Just make sure to
 [configure ko with kind](https://github.com/google/ko/blob/master/README.md#with-kind).
 
 ```sh
 $ export KO_DOCKER_REPO=kind.local
 $ ko apply -f config/watcher.yaml
+```
+
+### Re-deploying all Results components
+
+You can redeploy all components with kubectl and ko. Just make sure to
+[configure ko with kind](https://github.com/google/ko/blob/master/README.md#with-kind).
+
+```sh
+$ export KO_DOCKER_REPO=kind.local
+$ kubectl kustomize ./config | ko apply -f -
 ```
 
 ## Debugging

--- a/test/e2e/01-install.sh
+++ b/test/e2e/01-install.sh
@@ -63,7 +63,7 @@ set -e
 kubectl create secret tls -n tekton-pipelines tekton-results-tls --cert="/tmp/tekton-results-cert.pem" --key="/tmp/tekton-results-key.pem" || true
 
 echo "Installing Tekton Results..."
-kustomize build "${ROOT}/test/e2e/kustomize" | ko apply -f -
+kubectl kustomize "${ROOT}/test/e2e/kustomize" | ko apply -f -
 
 echo "Waiting for deployments to be ready..."
 kubectl wait deployment "tekton-results-mysql" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"


### PR DESCRIPTION
I forgot we added the kustomization and started seeing
the following error when `ko apply`ing the `./config` directory:

```
error: error validating "STDIN": error validating data: [apiVersion not
set, kind not set]; if you choose to ignore these errors, turn validation
off with --validate=false
```

This happens because the kustomization.yaml in the config directory isn't
formatted like a kubernetes resource and `ko` tries reading it like one when
applying all the files in that dir.  Added a note to the development doc to
capture applying all.

Also didn't have `kustomize` installed but it turns out `kubectl` comes with
it since 0.14 (current stable version is 0.20.4), so I updated the e2e script
to use `kubectl`'s built-in version.