### PR TITLE
Add results-release service account.

### DIFF
--- a/tekton/release-run.yaml
+++ b/tekton/release-run.yaml
@@ -18,7 +18,7 @@ kind: PipelineRun
 metadata:
   generateName: results-release-api-
 spec:
-  serviceAccountName: release-right-meow
+  serviceAccountName: results-release
   pipelineRef:
     name: results-release
   params:

--- a/tekton/serviceaccount.yaml
+++ b/tekton/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: results-release@tekton-releases.iam.gserviceaccount.com
+  name: results-release
+  namespace: default


### PR DESCRIPTION
This service account includes the Workload Identity annotations
(https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to) to map this to a correspond GCP Service Account.

Workload Identity is already enabled for the dogfooding cluster.