### PR TITLE
docs/installation.md: Update latest release to v0.2.0.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -49,7 +49,7 @@
 ## Installing latest release
 
 ```sh
-$ kubectl apply -f https://storage.googleapis.com/tekton-releases/results/latest/release.yaml
+$ kubectl apply -f https://storage.googleapis.com/tekton-releases/results/previous/v0.2.0/release.yaml
 ```
 
 ## Installing specific release


### PR DESCRIPTION
Instead of using `latest` alias, this changes the docs to point to the static
release files for the latest installation. My hope is to leverage this
to allow for checksumming to prevent situations like
https://about.codecov.io/security-update/ where the "latest" config was
compromised without anyone realizing.