### PR TITLE
Use release script in release pipeline.

### DIFF
--- a/tekton/release.yaml
+++ b/tekton/release.yaml
@@ -73,7 +73,8 @@ spec:
             script: |
               gcloud auth list
               gcloud auth configure-docker gcr.io,us-docker.pkg.dev
-              kubectl kustomize $(workspaces.source.path)/config | ko resolve -P -f - -t $(params.tag) > $(workspaces.source.path)/release.yaml
+
+              $(workspaces.source.path)/release/release.sh
             env:
               - name: KO_DOCKER_REPO
                 value: "$(params.repo)"
@@ -99,9 +100,8 @@ spec:
         steps:
           - name: upload
             image: gcr.io/google.com/cloudsdktool/cloud-sdk:310.0.0@sha256:cb03669fcdb9191d55a6200f2911fff3baec0b8c39b156d95b68aabe975ac506 #tag: 310.0.0
-            script:
-              gsutil cp $(workspaces.source.path)/release.yaml
-              $(params.bucket)/results/previous/$(params.version)/release.yaml
+            script: |
+              gsutil cp $(workspaces.source.path)/release/release.yaml $(params.bucket)/results/previous/$(params.version)/release.yaml
       params:
         - name: version
           value: $(params.version)


### PR DESCRIPTION
This modifies the release pipeline to use release/release.sh as the
source of truth for release logic.

Fixes #115 