### PR TITLE
release.sh: Use kustomize to generate release yaml.

### DIFF
--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -20,3 +20,6 @@ resources:
 - api.yaml
 - default-clusterroles.yaml
 - watcher.yaml
+commonLabels:
+  app.kubernetes.io/part-of: tekton-results
+  app.kubernetes.io/version: devel

--- a/release/kustomization.yaml
+++ b/release/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+  - ../config
+commonLabels:
+  # Leave this field as an environment variable - this is templated out during
+  # the release process to label all resources with the proper version.
+  app.kubernetes.io/version: ${RELEASE_VERSION}

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,11 +1,16 @@
 #! /bin/bash
 
-set -e
+set -ex
 
 ROOT="$(git rev-parse --show-toplevel)"
 # Default to short SHA if release version not set.
-RELEASE_VERSION=${RELEASE_VERSION:-"$(git rev-parse --short HEAD)"}
+export RELEASE_VERSION=${RELEASE_VERSION:-"$(git rev-parse --short HEAD)"}
 
 export KO_DOCKER_REPO=${KO_DOCKER_REPO:-"ko.local"}
 
-ko resolve -P -f ${ROOT}/config -t ${RELEASE_VERSION} | sed "s/devel/${RELEASE_VERSION}/g" > ${ROOT}/release/release.yaml
+RELEASE_DIR="${ROOT}/release"
+# Apply templated values from environment.
+envsubst < ${RELEASE_DIR}/kustomization.yaml | tee ${RELEASE_DIR}/kustomization.yaml  
+
+# Apply kustomiation + build images + generate yaml
+kubectl kustomize ${RELEASE_DIR} | ko resolve -P -f - -t ${RELEASE_VERSION} > ${RELEASE_DIR}/release.yaml


### PR DESCRIPTION
This uses envsubst + kustomize to apply any overlays to resources as part of the
release process.

envsubst is used to evaluate environment variables in place before
handing off to kustomize, since kustomize does not support reading from
stdin (https://github.com/kubernetes-sigs/kustomize/issues/2985).