### PR TITLE
release: Use sed instead of envsubst

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -10,7 +10,7 @@ export KO_DOCKER_REPO=${KO_DOCKER_REPO:-"ko.local"}
 
 RELEASE_DIR="${ROOT}/release"
 # Apply templated values from environment.
-envsubst < ${RELEASE_DIR}/kustomization.yaml | tee ${RELEASE_DIR}/kustomization.yaml  
+sed -i "s/devel$/${RELEASE_VERSION}/g" ${RELEASE_DIR}/kustomization.yaml  
 
 # Apply kustomiation + build images + generate yaml
 kubectl kustomize ${RELEASE_DIR} | ko resolve -P -f - -t ${RELEASE_VERSION} > ${RELEASE_DIR}/release.yaml


### PR DESCRIPTION
envsubst is not available in the ko-gcloud docker image we use for
releases, so revert back to the sed strategy from before.