### PR TITLE
Use kustomize namePrefix to ensure consistent naming for resources.

### DIFF
--- a/config/100-api-serviceaccount.yaml
+++ b/config/100-api-serviceaccount.yaml
@@ -15,13 +15,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: tekton-results-api
+  name: api
   namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-results-api
+  name: api
 rules:
   # Results API needs to be able to verify incoming auth tokens.
   - apiGroups: ["authentication.k8s.io"]
@@ -35,10 +35,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tekton-results-api
+  name: api
 subjects:
   - kind: ServiceAccount
-    name: tekton-results-api
+    name: api
     namespace: tekton-pipelines
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/100-watcher-serviceaccount.yaml
+++ b/config/100-watcher-serviceaccount.yaml
@@ -15,13 +15,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: tekton-results-watcher
+  name: watcher
   namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-results-watcher
+  name: watcher
 rules:
   # Watcher needs to be able to create new and update existing results.
   - apiGroups: ["results.tekton.dev"]
@@ -40,12 +40,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tekton-results-watcher
+  name: watcher
 subjects:
   - kind: ServiceAccount
-    name: tekton-results-watcher
+    name: watcher
     namespace: tekton-pipelines
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tekton-results-watcher
+  name: watcher

--- a/config/201-sql-deployment.yaml
+++ b/config/201-sql-deployment.yaml
@@ -15,10 +15,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: tekton-results-postgres
+  name: postgres
   namespace: tekton-pipelines
   labels:
-    app: postgres
+    app.kubernetes.io/name: tekton-results-postgres
 data:
   POSTGRES_DB: tekton-results
 ---
@@ -27,16 +27,18 @@ kind: StatefulSet
 metadata:
   name: postgres
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-postgres
 spec:
   serviceName: "postgres"
   replicas: 1
   selector:
     matchLabels:
-      app: postgres
+      app.kubernetes.io/name: tekton-results-postgres
   template:
     metadata:
       labels:
-        app: postgres
+        app.kubernetes.io/name: tekton-results-postgres
     spec:
       containers:
       - name: postgres
@@ -73,11 +75,11 @@ metadata:
   name: postgres-service
   namespace: tekton-pipelines
   labels:
-    app: postgres
+    app.kubernetes.io/name: tekton-results-postgres
 spec:
   ports:
   - port: 5432
     name: postgres
   type: NodePort
   selector:
-    app: postgres
+    app.kubernetes.io/name: tekton-results-postgres

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -15,32 +15,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tekton-results-api
+  name: api
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: tekton-results
-    app.kubernetes.io/component: api
-    results.tekton.dev/release: "devel"
-    version: "devel"
+    app.kubernetes.io/name: tekton-results-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-results-api
+      app.kubernetes.io/name: tekton-results-api
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-results-api
-        app.kubernetes.io/name: tekton-results
-        app.kubernetes.io/component: api
-        results.tekton.dev/release: "devel"
-        version: "devel"
+        app.kubernetes.io/name: tekton-results-api
     spec:
-      serviceAccountName: tekton-results-api
+      serviceAccountName: api
       containers:
-        - name: tekton-results-api
+        - name: api
           image: ko://github.com/tektoncd/results/cmd/api
           env:
             # See cmd/api/README.md for documentation of these vars.
@@ -57,7 +50,7 @@ spec:
             - name: DB_PROTOCOL
               value: tcp
             - name: DB_ADDR
-              value: postgres-service.tekton-pipelines.svc.cluster.local
+              value: tekton-results-postgres-service.tekton-pipelines.svc.cluster.local
             - name: DB_NAME
               value: tekton-results
           volumeMounts:
@@ -72,11 +65,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: tekton-results-api-service
+  name: api-service
   namespace: tekton-pipelines
 spec:
   selector:
-    app: tekton-results-api
+    app.kubernetes.io/name: tekton-results-api
   ports:
     - name: grpc
       protocol: TCP

--- a/config/default-clusterroles.yaml
+++ b/config/default-clusterroles.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-results-readonly
+  name: readonly
 rules:
   - apiGroups: ["results.tekton.dev"]
     resources: ["results", "records"]
@@ -24,7 +24,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-results-readwrite
+  name: readwrite
 rules:
   - apiGroups: ["results.tekton.dev"]
     resources: ["results", "records"]
@@ -33,7 +33,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: tekton-results-admin
+  name: admin
 rules:
   - apiGroups: ["results.tekton.dev"]
     resources: ["results", "records"]

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
 commonLabels:
   app.kubernetes.io/part-of: tekton-results
   app.kubernetes.io/version: devel
+namePrefix: tekton-results-

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -15,32 +15,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tekton-results-watcher
+  name: watcher
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: tekton-results
-    app.kubernetes.io/component: watcher
-    results.tekton.dev/release: "devel"
-    version: "devel"
+    app.kubernetes.io/name: tekton-results-watcher
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-results-watcher
+      app.kubernetes.io/name: tekton-results-watcher
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-results-watcher
-        app.kubernetes.io/name: tekton-results
-        app.kubernetes.io/component: watcher
-        results.tekton.dev/release: "devel"
-        version: "devel"
+        app.kubernetes.io/name: tekton-results-watcher
     spec:
-      serviceAccountName: tekton-results-watcher
+      serviceAccountName: watcher
       containers:
-        - name: tekton-results-watcher
+        - name: watcher
           image: ko://github.com/tektoncd/results/cmd/watcher
           args:
             [


### PR DESCRIPTION
This automatically prefixes resource names with 'tekton-results-` so
that all resources will have consistent naming. Previously, some
resources slipped through and didn't have the prefix (i.e. postgres).

This commit also updates some of the common app.kubernetes.io labels to
be more consistent as well.