### PR TITLE
docs: name of the secret

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -28,7 +28,7 @@
    to do this!
 
    Tekton Results expects the cert/key pair to be stored in a
-   [TLS Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).
+   [TLS Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) named `tekton-results-tls`.
 
    ```sh
    # Generate new self-signed cert.


### PR DESCRIPTION
I'm assuming ( based on release.yaml ) that the name of the tls secret is tekton-results-tls ?

Signed-off-by: Shoubhik Bose <shbose@redhat.com>