### PR TITLE
Use kustomize labels instead of commonLabels.

### DIFF
--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -20,7 +20,22 @@ resources:
 - api.yaml
 - default-clusterroles.yaml
 - watcher.yaml
-commonLabels:
-  app.kubernetes.io/part-of: tekton-results
-  app.kubernetes.io/version: devel
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: tekton-results
+  - pairs:
+      app.kubernetes.io/version: devel
+    includeSelectors: false
+    fields:
+      # Include labels in template fields that are filtered out by includeSelectors.
+      # These are additive, derived from the kustomize commonLabel default.
+      # See https://github.com/kubernetes-sigs/kustomize/blob/f61b075d3bd670b7bcd5d58ce13e88a6f25977f2/api/konfig/builtinpluginconsts/commonlabels.go for the default values.
+      # See https://github.com/kubernetes-sigs/kustomize/blob/f61b075d3bd670b7bcd5d58ce13e88a6f25977f2/api/internal/target/kusttarget_configplugin.go#L263-L268 for the filtering.
+      - path: spec/template/metadata/labels
+        create: true
+        kind: Deployment
+      - path: spec/template/metadata/labels
+        create: true
+        group: apps
+        kind: StatefulSet
 namePrefix: tekton-results-


### PR DESCRIPTION
Common labels sets a ton of labels by default [1] that are additive and
can't be disabled [2]. This PR switches to using the labels field
[3] to disable labelling selectors an only label metadata and
template/metadata fields.

This field is fairly new and isn't documented in the kustomize docs
yet, but seems to be the recommended solution moving forward [4] (also
docs appear to be incoming).

[1] https://github.com/kubernetes-sigs/kustomize/blob/f61b075d3bd670b7bcd5d58ce13e88a6f25977f2/api/konfig/builtinpluginconsts/commonlabels.go
[2] https://github.com/kubernetes-sigs/kustomize/issues/817
[3] https://github.com/kubernetes-sigs/kustomize/blob/10026758d314920e8fa3c9c526525d8577d39617/api/types/labels.go
[4] https://github.com/kubernetes-sigs/kustomize/issues/1009

Fixes #145 