### PR TITLE
configure postgres to use the volume mount for data persistence

### DIFF
--- a/config/201-sql-deployment.yaml
+++ b/config/201-sql-deployment.yaml
@@ -48,6 +48,9 @@ spec:
               name: tekton-results-postgres
           - secretRef:
               name: tekton-results-postgres
+        env:
+          - name: PGDATA
+            value: /var/data/postgres
         ports:
         - containerPort: 5432
           name: postgredb


### PR DESCRIPTION
Hey,

By default postgres uses `/var/lib/postgresql/data` for persistence. Because this is not backed by the PV (mounted to `/var/data`), all data is lost when restarting the postgres pod. This is rather unfortunate 😉

This PR changes this by defining PGDATA.

Best regards,
Fabian