### PR TITLE
e2e: Update client-go calls to use ctx based signatures.

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -5,7 +5,7 @@
 ```sh
 $ ./00-setup.sh
 $ ./01-install.sh
-$ ./02-test.sh
+$ go test --tags=e2e .
 ```
 
 ## Dependencies


### PR DESCRIPTION
This should have been updated when we bumped the API version awhile
back, but was missed. Good news this is an easy fix and this code hasn't
bitrotted too badly. Bad news is CI missed this and will require
additional investigation.

Also updates README to use correct test command in Quickstart.