### PR TITLE
Add Uber/Automaxprocs to autoset GOMAXPROCS to CPU quota

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -24,6 +24,14 @@ import (
 	"net/http"
 	"os"
 
+	// Go runtime is unaware of CPU quota which means it will set GOMAXPROCS
+	// to underlying host vm node. This high value means that GO runtime
+	// scheduler assumes that it has more threads and does context switching
+	// when it might work with fewer threads.
+	// This doesn't happen# with our other controllers and services because
+	// sharedmain already import this package for them.
+	_ "go.uber.org/automaxprocs"
+
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	v1alpha2 "github.com/tektoncd/results/pkg/api/server/v1alpha2"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/prometheus/client_golang v1.11.0
 	github.com/tektoncd/pipeline v0.29.0
+	go.uber.org/automaxprocs v1.4.0 // indirect
 	go.uber.org/zap v1.19.1
 	golang.org/x/oauth2 v0.0.0-20211028175245-ba495a64dcb5
 	google.golang.org/api v0.60.0


### PR DESCRIPTION
Go runtime is unaware of CPU quota which means it will set GOMAXPROCS
to underlying host vm node. This high value means that GO runtime
scheduler assumes that it has more threads and does context switching
when it might work with fewer threads.
This doesn't happen with our other controllers and services because
sharedmain already import this package for them (that's why it's there in
[go.sum](https://github.com/tektoncd/results/blob/9312200317e70cc33f09a7e674c16915c118b835/go.sum#L1161)) . 

