### PR TITLE
Implement Record Summaries.

### DIFF
--- a/pkg/api/server/db/model.go
+++ b/pkg/api/server/db/model.go
@@ -33,7 +33,19 @@ type Result struct {
 	CreatedTime time.Time
 	UpdatedTime time.Time
 
+	Summary RecordSummary `gorm:"embedded;embeddedPrefix:recordsummary_"`
+
 	Etag string
+}
+
+// RecordSummary is the database model of a Result.RecordSummary.
+type RecordSummary struct {
+	Record      string
+	Type        string
+	StartTime   *time.Time
+	EndTime     *time.Time
+	Status      int32
+	Annotations Annotations
 }
 
 func (r Result) String() string {

--- a/pkg/api/server/test/db.go
+++ b/pkg/api/server/test/db.go
@@ -72,6 +72,8 @@ func NewDB(t *testing.T) *gorm.DB {
 			LogLevel: logger.Info,
 			Colorful: true,
 		}),
+		// Constraints not implemented on sqlite
+		DisableForeignKeyConstraintWhenMigrating: true,
 	})
 	if err != nil {
 		t.Fatalf("failed to open the results.db: %v", err)

--- a/pkg/api/server/v1alpha2/result/result.go
+++ b/pkg/api/server/v1alpha2/result/result.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cel-go/cel"
 	resultscel "github.com/tektoncd/results/pkg/api/server/cel"
 	"github.com/tektoncd/results/pkg/api/server/db"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -88,6 +89,13 @@ func ToStorage(r *pb.Result) (*db.Result, error) {
 		if s.GetRecord() == "" || s.GetType() == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "record and type fields required for RecordSummary")
 		}
+		if !record.NameRegex.MatchString(s.GetRecord()) {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid record format")
+		}
+		if err := record.ValidateType(s.GetType()); err != nil {
+			return nil, err
+		}
+
 		summary := db.RecordSummary{
 			Record:      s.GetRecord(),
 			Type:        s.GetType(),

--- a/pkg/api/server/v1alpha2/result/result_test.go
+++ b/pkg/api/server/v1alpha2/result/result_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/ptr"
 
 	cw "github.com/jonboulle/clockwork"
 	"github.com/tektoncd/results/pkg/api/server/cel"
@@ -113,6 +114,14 @@ func TestToStorage(t *testing.T) {
 				UpdatedTime: timestamppb.New(clock.Now()),
 				Annotations: map[string]string{"a": "b"},
 				Etag:        "tacocat",
+				Summary: &pb.RecordSummary{
+					Record:      "foo",
+					Type:        "bar",
+					StartTime:   timestamppb.New(clock.Now()),
+					EndTime:     timestamppb.New(clock.Now()),
+					Status:      pb.RecordSummary_SUCCESS,
+					Annotations: map[string]string{"c": "d"},
+				},
 			},
 			want: &db.Result{
 				Parent:      "foo",
@@ -122,6 +131,14 @@ func TestToStorage(t *testing.T) {
 				CreatedTime: clock.Now(),
 				UpdatedTime: clock.Now(),
 				Etag:        "tacocat",
+				Summary: db.RecordSummary{
+					Record:      "foo",
+					Type:        "bar",
+					StartTime:   ptr.Time(clock.Now()),
+					EndTime:     ptr.Time(clock.Now()),
+					Status:      1,
+					Annotations: map[string]string{"c": "d"},
+				},
 			},
 		},
 		{

--- a/pkg/api/server/v1alpha2/results_test.go
+++ b/pkg/api/server/v1alpha2/results_test.go
@@ -122,10 +122,22 @@ func TestUpdateResult(t *testing.T) {
 		errcode codes.Code
 	}{
 		{
-			name:   "test success",
-			update: &pb.Result{Annotations: map[string]string{"foo": "bar"}},
-			etag:   mockEtag(lastID+1, clock.Now().UnixNano()),
-			expect: &pb.Result{Annotations: map[string]string{"foo": "bar"}},
+			name: "test success",
+			update: &pb.Result{
+				Annotations: map[string]string{"foo": "bar"},
+				Summary: &pb.RecordSummary{
+					Record: "foo",
+					Type:   "bar",
+				},
+			},
+			etag: mockEtag(lastID+1, clock.Now().UnixNano()),
+			expect: &pb.Result{
+				Annotations: map[string]string{"foo": "bar"},
+				Summary: &pb.RecordSummary{
+					Record: "foo",
+					Type:   "bar",
+				},
+			},
 		},
 		{
 			name:   "test update with empty result",
@@ -146,6 +158,11 @@ func TestUpdateResult(t *testing.T) {
 			name:    "test update with invalid etag",
 			etag:    "invalid etag",
 			errcode: codes.FailedPrecondition,
+		},
+		{
+			name:    "result summary with no record/type",
+			update:  &pb.Result{Summary: &pb.RecordSummary{}},
+			errcode: codes.InvalidArgument,
 		},
 	}
 	for idx, tc := range tt {

--- a/pkg/api/server/v1alpha2/server.go
+++ b/pkg/api/server/v1alpha2/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	cw "github.com/jonboulle/clockwork"
 	resultscel "github.com/tektoncd/results/pkg/api/server/cel"
+	model "github.com/tektoncd/results/pkg/api/server/db"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/auth"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"gorm.io/gorm"
@@ -51,6 +52,9 @@ type Server struct {
 
 // New set up environment for the api server
 func New(db *gorm.DB, opts ...Option) (*Server, error) {
+	if err := db.AutoMigrate(&model.Result{}, &model.Record{}); err != nil {
+		return nil, fmt.Errorf("error automigrating DB: %w", err)
+	}
 	env, err := resultscel.NewEnv()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)

--- a/pkg/internal/protoutil/protoutil.go
+++ b/pkg/internal/protoutil/protoutil.go
@@ -18,9 +18,12 @@ package protoutil
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	fbpb "google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -58,4 +61,13 @@ func ClearOutputOnly(pb proto.Message) {
 		}
 		return true
 	})
+}
+
+// IgnoreResultOutputOnly ignores all fields marked OUTPUT_ONLY during cmp
+// comparisions.
+func IgnoreResultOutputOnly() cmp.Option {
+	// We might be able to something fancy with protocmp / cmp to filter
+	// by the actual extension value, but for now this is straightforward
+	// and works.
+	return protocmp.IgnoreFields(&pb.Result{}, "update_time", "updated_time", "etag", "uid", "id", "create_time", "created_time")
 }

--- a/pkg/watcher/convert/convert.go
+++ b/pkg/watcher/convert/convert.go
@@ -22,9 +22,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	rpb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/apis"
 )
 
 func ToProto(in runtime.Object) (*rpb.Any, error) {
@@ -37,14 +41,88 @@ func ToProto(in runtime.Object) (*rpb.Any, error) {
 		return nil, err
 	}
 
-	// We do not know of any formalized spec for identifying objects across API
-	// versions. Standard GVK string formatting does not produce something that's
-	// payload friendly (includes spaces).
-	// To get around this we append API Version + Kind
-	// (e.g. tekton.dev/v1beta1.TaskRun).
-	v, k := in.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	return &rpb.Any{
-		Type:  fmt.Sprintf("%s.%s", v, k),
+		Type:  TypeName(in),
 		Value: b,
 	}, nil
+}
+
+// TypeName returns a string representation of type Object type.
+// We do not know of any formalized spec for identifying objects across API
+// versions. Standard GVK string formatting does not produce something that's
+// payload friendly (i.e. includes spaces).
+// To get around this we append API Version + Kind
+// (e.g. tekton.dev/v1beta1.TaskRun).
+func TypeName(in runtime.Object) string {
+	gvk := in.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		// GVK not explicitly set in the object, fall back to scheme-based
+		// lookup.
+		var err error
+		gvk, err = InferGVK(in)
+		// Avoid returning back "." if the GVK doesn't contain any info.
+		if err != nil || gvk.Empty() {
+			return ""
+		}
+	}
+	v, k := gvk.ToAPIVersionAndKind()
+	return fmt.Sprintf("%s.%s", v, k)
+}
+
+// InferGVK infers the GroupVersionKind from the Object via schemes. Currently
+// only the Tekton scheme is supported.
+func InferGVK(o runtime.Object) (schema.GroupVersionKind, error) {
+	gvks, _, err := scheme.Scheme.ObjectKinds(o)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	// This could potentially match a few different ones (not exactly sure
+	// when this would happen), but generally shouldn't because we're using
+	// the direct types from the Tekton package.
+	if len(gvks) == 0 {
+		return schema.GroupVersionKind{}, fmt.Errorf("could not determine GroupVersionKind for object")
+	}
+	return gvks[0], nil
+}
+
+// Status maps a Run condition to a general Record status.
+func Status(ca apis.ConditionAccessor) rpb.RecordSummary_Status {
+	c := ca.GetCondition(apis.ConditionSucceeded)
+	if c == nil {
+		return rpb.RecordSummary_UNKNOWN
+	}
+
+	switch v1beta1.TaskRunReason(c.Reason) {
+	case v1beta1.TaskRunReasonSuccessful:
+		return rpb.RecordSummary_SUCCESS
+	case v1beta1.TaskRunReasonFailed:
+		return rpb.RecordSummary_FAILURE
+	case v1beta1.TaskRunReasonTimedOut:
+		return rpb.RecordSummary_TIMEOUT
+	case v1beta1.TaskRunReasonCancelled:
+		return rpb.RecordSummary_CANCELLED
+	case v1beta1.TaskRunReasonRunning, v1beta1.TaskRunReasonStarted:
+		return rpb.RecordSummary_UNKNOWN
+	}
+
+	switch v1beta1.PipelineRunReason(c.Reason) {
+	case v1beta1.PipelineRunReasonSuccessful, v1beta1.PipelineRunReasonCompleted:
+		return rpb.RecordSummary_SUCCESS
+	case v1beta1.PipelineRunReasonFailed:
+		return rpb.RecordSummary_FAILURE
+	case v1beta1.PipelineRunReasonTimedOut:
+		return rpb.RecordSummary_TIMEOUT
+	case v1beta1.PipelineRunReasonCancelled:
+		return rpb.RecordSummary_CANCELLED
+	case v1beta1.PipelineRunReasonRunning, v1beta1.PipelineRunReasonStarted, v1beta1.PipelineRunReasonPending, v1beta1.PipelineRunReasonStopping, v1beta1.PipelineRunReasonCancelledRunningFinally, v1beta1.PipelineRunReasonStoppedRunningFinally:
+		return rpb.RecordSummary_UNKNOWN
+	}
+
+	switch c.Reason {
+	case pod.ReasonCouldntGetTask, pod.ReasonFailedResolution, pod.ReasonFailedValidation, pod.ReasonExceededResourceQuota, pod.ReasonExceededNodeResources, pod.ReasonCreateContainerConfigError, pod.ReasonPodCreationFailed:
+		return rpb.RecordSummary_FAILURE
+	case pod.ReasonPending:
+		return rpb.RecordSummary_UNKNOWN
+	}
+	return rpb.RecordSummary_UNKNOWN
 }

--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -38,6 +38,7 @@ func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *
 		client:    client,
 		lister:    informer.Lister(),
 		k8sclient: pipelineclient.Get(ctx),
+		cfg:       cfg,
 	}
 
 	impl := controller.NewContext(ctx, c, controller.ControllerOptions{

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -38,6 +38,7 @@ func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *
 		client:    client,
 		lister:    informer.Lister(),
 		k8sclient: pipelineclient.Get(ctx),
+		cfg:       cfg,
 	}
 
 	impl := controller.NewContext(ctx, c, controller.ControllerOptions{

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -24,6 +24,13 @@ CREATE TABLE results (
 	
 	etag varchar(128),
 
+	recordsummary_record varchar(128),
+	recordsummary_type varchar(128),
+	recordsummary_start_time timestamp,
+	recordsummary_end_time timestamp,
+	recordsummary_status int,
+	recordsummary_annotations jsonb,
+
 	PRIMARY KEY(parent, id)
 );
 CREATE UNIQUE INDEX results_by_name ON results(parent, name);

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -43,7 +43,8 @@ CREATE TABLE records (
 	result_name varchar(64),
 	name varchar(64),
 
-	type varchar(128),
+	-- Napkin Math (with a bit of buffer): 256 (DNS Subdomain) * 3 (Group + Version + Kind)
+	type varchar(768),
 	data jsonb,
 
 	created_time timestamp default current_timestamp not null,

--- a/schema/results.sql
+++ b/schema/results.sql
@@ -24,8 +24,8 @@ CREATE TABLE results (
 	
 	etag varchar(128),
 
-	recordsummary_record varchar(128),
-	recordsummary_type varchar(128),
+	recordsummary_record varchar(256),
+	recordsummary_type varchar(768),
 	recordsummary_start_time timestamp,
 	recordsummary_end_time timestamp,
 	recordsummary_status int,


### PR DESCRIPTION
This implements Record Summaries in both the API and Watcher.

Record Summaries allow for clients to associate simplified information
to their Results. The purpose of this is to allow Results to capture
basic high level information such as status and start/end times without
needing to perform an additional API call.

The API does not enforce that the data must match the underlying
Records, because how the data maps to the Records is type specific.
Clients are responsible for ensuring freshness. Cluster Watcher handles
this for Tekton Pipeline/TaskRun types today.

Fixes #147 