### PR TITLE
watcher: Add back missing reconciler config values.

### DIFF
--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -38,6 +38,7 @@ func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *
 		client:    client,
 		lister:    informer.Lister(),
 		k8sclient: pipelineclient.Get(ctx),
+		cfg:       cfg,
 	}
 
 	impl := controller.NewContext(ctx, c, controller.ControllerOptions{

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -38,6 +38,7 @@ func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *
 		client:    client,
 		lister:    informer.Lister(),
 		k8sclient: pipelineclient.Get(ctx),
+		cfg:       cfg,
 	}
 
 	impl := controller.NewContext(ctx, c, controller.ControllerOptions{


### PR DESCRIPTION
This was accidentally removed in a previous commit.