### PR TITLE
Add results-info ConfigMap and supporting roles

### DIFF
--- a/config/config-info.yaml
+++ b/config/config-info.yaml
@@ -1,0 +1,63 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-info
+data:
+  # Contains results version which can be queried by external
+  # tools such as CLI. Elevated permissions are already given to
+  # this ConfigMap such that even if we don't have access to
+  # other resources in the namespace we still can have access to
+  # this ConfigMap.
+  version: devel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-info
+rules:
+    # All system:authenticated users needs to have access
+    # of the results-info ConfigMap even if they don't
+    # have access to the other resources present in the
+    # installed namespace.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["tekton-results-info"]
+    verbs: ["get", "describe"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: info
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-info
+subjects:
+    # Giving all system:authenticated users the access of the
+    # ConfigMap which contains version information.
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: info

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - api.yaml
 - default-clusterroles.yaml
 - watcher.yaml
+- config-info.yaml
 labels:
   - pairs:
       app.kubernetes.io/part-of: tekton-results

--- a/release/release.sh
+++ b/release/release.sh
@@ -10,7 +10,8 @@ export KO_DOCKER_REPO=${KO_DOCKER_REPO:-"ko.local"}
 
 RELEASE_DIR="${ROOT}/release"
 # Apply templated values from environment.
-sed -i "s/devel$/${RELEASE_VERSION}/g" ${RELEASE_DIR}/kustomization.yaml  
+sed -i "s/devel$/${RELEASE_VERSION}/g" ${RELEASE_DIR}/kustomization.yaml
+sed -i "s/devel$/${RELEASE_VERSION}/g" ${ROOT}/config/config-info.yaml  
 
 # Apply kustomiation + build images + generate yaml
 kubectl kustomize ${RELEASE_DIR} | ko resolve -P -f - -t ${RELEASE_VERSION} > ${RELEASE_DIR}/release.yaml


### PR DESCRIPTION
This commit adds a `results-info` ConfigMap which contains the version
fo Results installed on the cluster. This is primarily meant to be read
by external tools such as `tkn`.

Adding role and rolebindings so that any system authenticated user can
query this configmap to check the version.

Signed-off-by: vinamra28 <jvinamra776@gmail.com>