### PR TITLE
Allow setting SSLMODE for connections to database by env variable

### DIFF
--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -3,12 +3,14 @@
 ## Variables
 
 | Environment Variable | Description                     | Example                                      |
-| -------------------- | ------------------------------- | -------------------------------------------- |
+|----------------------|---------------------------------|----------------------------------------------|
 | DB_USER              | MySQL Database user             | user                                         |
 | DB_PASSWORD          | MySQL Database Password         | hunter2                                      |
 | DB_PROTOCOL          | MySQL Database Network Protocol | unix                                         |
 | DB_ADDR              | MySQL Database address          | /cloudsql/my-project:us-east1:tekton-results |
 | DB_NAME              | MySQL Database name             | tekton_results                               |
+| DB_SSLMODE           | Database SSL mode               | verify-full                                  |
+
 
 Values derived from MySQL DSN (see
 https://github.com/go-sql-driver/mysql#dsn-data-source-name)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -58,7 +58,12 @@ func main() {
 	// Connect to the database.
 	// DSN derived from https://pkg.go.dev/gorm.io/driver/postgres
 
-	dbURI := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=5432", os.Getenv("DB_ADDR"), user, pass, os.Getenv("DB_NAME"))
+	sslmode := os.Getenv("DB_SSLMODE")
+	if sslmode == "" {
+		sslmode = "disable"
+	}
+
+	dbURI := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=5432 sslmode=%s", os.Getenv("DB_ADDR"), user, pass, os.Getenv("DB_NAME"), os.Getenv("DB_SSLMODE"))
 	db, err := gorm.Open(postgres.Open(dbURI), &gorm.Config{})
 	if err != nil {
 		log.Fatalf("failed to open the results.db: %v", err)


### PR DESCRIPTION
Allow setting `SSLMODE` by setting environment variable
`DB_SSLMODE=verify-full`

https://www.postgresql.org/docs/current/libpq-ssl.html
