### PR TITLE
Fix Postgres permission issue

### DIFF
--- a/config/201-sql-deployment.yaml
+++ b/config/201-sql-deployment.yaml
@@ -50,13 +50,13 @@ spec:
               name: tekton-results-postgres
         env:
           - name: PGDATA
-            value: /var/data/postgres
+            value: /var/lib/postgresql/data/pgdata
         ports:
         - containerPort: 5432
           name: postgredb
         volumeMounts:
         - name: postgredb
-          mountPath: /var/data
+          mountPath: /var/lib/postgresql/data
         - name: sql-initdb
           mountPath: /docker-entrypoint-initdb.d
       volumes:


### PR DESCRIPTION
Postgres deployments gives permission issue in some deployments.
`fixing permissions on existing directory /var/lib/postgresql/data
... initdb: error: could not change permissions of directory `
Also, align the postgres with tekton Hub postgres deployment.