### PR TITLE
Read the parent name from the results annotation when it's set

### DIFF
--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -140,6 +140,40 @@ func TestResultName(t *testing.T) {
 	}
 }
 
+func TestParentName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   metav1.Object
+		want string
+	}{{
+		name: "default to the object's namespace when the results annotation is unset",
+		in: &metav1.ObjectMeta{
+			Namespace: "dev",
+		},
+		want: "dev",
+	},
+		{
+			name: "extract the parent name from the result annotation",
+			in: &metav1.ObjectMeta{
+				Namespace: "dev",
+				Annotations: map[string]string{
+					annotation.Result: "foo/results/bar",
+				},
+			},
+			want: "foo",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parentName(test.in)
+			if test.want != got {
+				t.Errorf("parentName: want %s, got %s", test.want, got)
+			}
+		})
+	}
+}
+
 func TestEnsureResult(t *testing.T) {
 	ctx := logtest.TestContextWithLogger(t)
 	client := client(t)


### PR DESCRIPTION
Closes https://github.com/tektoncd/results/issues/231.

Nowadays the Watcher always uses the object's namespace as the parent name
regardless the value of the results annotation. This pull request alters this
behavior by making the watcher to read the parent name from the results
annotation when it's present.