### PR TITLE
Enable high availability through Knative leader election support

### DIFF
--- a/config/100-watcher-serviceaccount.yaml
+++ b/config/100-watcher-serviceaccount.yaml
@@ -36,6 +36,10 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
+  # Required for enabling leader election.
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/config-leader-election.yaml
+++ b/config/config-leader-election.yaml
@@ -1,0 +1,50 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-leader-election
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -19,28 +19,28 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-logging
 data:
-    zap-logger-config: |
-      {
-        "level": "info",
-        "development": false,
-        "outputPaths": ["stdout"],
-        "errorOutputPaths": ["stderr"],
-        "encoding": "json",
-        "encoderConfig": {
-          "timeKey": "time",
-          "levelKey": "level",
-          "nameKey": "logger",
-          "callerKey": "caller",
-          "messageKey": "msg",
-          "stacktraceKey": "stacktrace",
-          "lineEnding": "",
-          "levelEncoder": "",
-          "timeEncoder": "iso8601",
-          "durationEncoder": "string",
-          "callerEncoder": ""
-        }
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "time",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "string",
+        "callerEncoder": ""
       }
+    }
 
-    # Log level overrides
-    # Changes are be picked up immediately.
-    loglevel.watcher: "info"
+  # Log level overrides
+  # Changes are be picked up immediately.
+  loglevel.watcher: "info"

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -1,0 +1,46 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-logging
+data:
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "time",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "string",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # Changes are be picked up immediately.
+    loglevel.watcher: "info"

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -1,0 +1,59 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-observability
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using Stackdriver will incur additional charges.
+    metrics.backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used and metrics will be sent to the cluster's project if this field is
+    # not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
+    # to send metrics to Stackdriver using "global" resource type and custom
+    # metric type. Setting this flag to "true" could cause extra Stackdriver
+    # charge.  If metrics.backend-destination is not Stackdriver, this is
+    # ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+    metrics.taskrun.level: "task"
+    metrics.taskrun.duration-type: "histogram"
+    metrics.pipelinerun.level: "pipeline"
+    metrics.pipelinerun.duration-type: "histogram"

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -21,6 +21,9 @@ resources:
 - default-clusterroles.yaml
 - watcher.yaml
 - config-info.yaml
+- config-leader-election.yaml
+- config-logging.yaml
+- config-observability.yaml
 labels:
   - pairs:
       app.kubernetes.io/part-of: tekton-results

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -42,6 +42,24 @@ spec:
               "-auth_mode",
               "token",
             ]
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: tekton-results-config-logging
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-results-config-leader-election
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: tekton-results-config-observability
+            - name: METRICS_DOMAIN
+              value: tekton.dev/results
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
           volumeMounts:
             - name: tls
               mountPath: "/etc/tls"
@@ -50,3 +68,17 @@ spec:
         - name: tls
           secret:
             secretName: tekton-results-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: watcher
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+  - name: profiling
+    port: 8008
+  selector:
+    app.kubernetes.io/name: tekton-results-watcher

--- a/pkg/watcher/reconciler/leaderelection/leader_election.go
+++ b/pkg/watcher/reconciler/leaderelection/leader_election.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package leaderelection provides a few utilities to help us to enable leader
+// election support in the Watcher controllers.
+package leaderelection
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/reconciler"
+)
+
+// Lister is a generic signature of Lister.List functions, by allowing us to
+// support various listers in the NewLeaderAwareFuncs function below.
+type Lister[O metav1.Object] func(labels.Selector) ([]O, error)
+
+// NewLeaderAwareFuncs returns a new reconciler.LeaderAwareFuncs object to be
+// used in our controllers.
+func NewLeaderAwareFuncs[O metav1.Object](lister Lister[O]) reconciler.LeaderAwareFuncs {
+	return reconciler.LeaderAwareFuncs{
+		PromoteFunc: func(bucket reconciler.Bucket, enqueue func(reconciler.Bucket, types.NamespacedName)) error {
+			objects, err := lister(labels.Everything())
+			if err != nil {
+				return err
+			}
+			for _, object := range objects {
+				enqueue(bucket, types.NamespacedName{
+					Namespace: object.GetNamespace(),
+					Name:      object.GetName(),
+				})
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -20,6 +20,7 @@ import (
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
+	"github.com/tektoncd/results/pkg/watcher/reconciler/leaderelection"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
@@ -33,12 +34,14 @@ func NewController(ctx context.Context, client pb.ResultsClient) *controller.Imp
 
 func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *reconciler.Config) *controller.Impl {
 	informer := pipelineruninformer.Get(ctx)
+	lister := informer.Lister()
 
 	c := &Reconciler{
-		client:    client,
-		lister:    informer.Lister(),
-		k8sclient: pipelineclient.Get(ctx),
-		cfg:       cfg,
+		LeaderAwareFuncs: leaderelection.NewLeaderAwareFuncs(lister.List),
+		client:           client,
+		lister:           lister,
+		k8sclient:        pipelineclient.Get(ctx),
+		cfg:              cfg,
 	}
 
 	impl := controller.NewContext(ctx, c, controller.ControllerOptions{

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -10,17 +10,26 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/reconciler/dynamic"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	knativereconciler "knative.dev/pkg/reconciler"
 )
 
 type Reconciler struct {
+	// Inline LeaderAwareFuncs to support leader election.
+	knativereconciler.LeaderAwareFuncs
+
 	client    pb.ResultsClient
 	lister    v1beta1.PipelineRunLister
 	k8sclient versioned.Interface
 	cfg       *reconciler.Config
 	enqueue   func(interface{}, time.Duration)
 }
+
+// Check that our Reconciler is LeaderAware.
+var _ knativereconciler.LeaderAware = (*Reconciler)(nil)
 
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	log := logging.FromContext(ctx)
@@ -31,6 +40,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		log.Errorf("invalid resource key: %s", key)
 		return nil
 	}
+
+	if !r.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
+		log.Info("Skipping PipelineRun key because this instance isn't its leader")
+		return controller.NewSkipKey(key)
+	}
+
 	pr, err := r.lister.PipelineRuns(namespace).Get(name)
 	if err != nil {
 		return err

--- a/pkg/watcher/reconciler/taskrun/reconciler.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler.go
@@ -4,23 +4,33 @@ import (
 	"context"
 	"time"
 
+	"knative.dev/pkg/controller"
+	knativereconciler "knative.dev/pkg/reconciler"
+
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/dynamic"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/logging"
 )
 
 type Reconciler struct {
+	// Inline LeaderAwareFuncs to support leader election.
+	knativereconciler.LeaderAwareFuncs
+
 	client    pb.ResultsClient
 	lister    v1beta1.TaskRunLister
 	k8sclient versioned.Interface
 	cfg       *reconciler.Config
 	enqueue   func(interface{}, time.Duration)
 }
+
+// Check that our Reconciler is LeaderAware.
+var _ knativereconciler.LeaderAware = (*Reconciler)(nil)
 
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	log := logging.FromContext(ctx)
@@ -31,7 +41,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		log.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-	pr, err := r.lister.TaskRuns(namespace).Get(name)
+
+	if !r.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
+		log.Info("Skipping TaskRun key because this instance isn't its leader")
+		return controller.NewSkipKey(key)
+	}
+
+	tr, err := r.lister.TaskRuns(namespace).Get(name)
 	if err != nil {
 		return err
 	}
@@ -41,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	}
 
 	dyn := dynamic.NewDynamicReconciler(r.client, k8sclient, r.cfg, r.enqueue)
-	if err := dyn.Reconcile(ctx, pr); err != nil {
+	if err := dyn.Reconcile(ctx, tr); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What

- Enable high availability by making Watcher controllers leader aware. This allows the two forms of leader election (standard and statefulset-based) provided by Knative to be easily used in the Watcher.
- Add the threadiness flag to the Watcher binary. It allows users to tweak the number of workers allocated to process the controller's worker queue.
- Add the tekton-results-watcher Service. This is mostly a convenience to users who want to enable the statefulset-based leader election mechanism.
- Add ConfigMaps to customize logging, leader election and observability. The
config-leader-election ConfigMap allows users to tweak the leader election
mechanism. The other two ones make Results more homogeneous with Tekton
Pipeline project.

## Why

This pull request resolves https://github.com/tektoncd/results/issues/241, which
contains more details on why this feature is relevant. Essentially, it allows
users to tweak the Watcher controller to deal with higher loads more easily.

## Additional information

I tested those changes in a local Kind cluster and they're working as
expected. When the standard leader election mode is enabled, one replica
reconciles PipelineRuns and TaskRuns while the other one does nothing. When the
statefulset mode is enabled with three replicas for instance, all instances
reconcile different keys simultaneously.