### PR TITLE
Enhance the support for reading Results and Records across multiple collections

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -140,10 +140,14 @@ Fields supported in `order_by`:
 | `created_time` |
 | `updated_time` |
 
+## Reading results across parents
+
+Results can be read across parents by specifying `-` as the parent name. This is useful for listing all results stored in the system without a prior knowledge about the available parents.
+
 ## Reading Records across Results
 
-Records can be read across Results by specifying `-` as the Result name part
-(e.g. `default/results/-`). This can be used to read and filter matching Records
+Records can be read across Results by specifying `-` as the Result name part or across parents by specifying `-` as the parent name.
+(e.g. `default/results/-` or `-/results/-`). This can be used to read and filter matching Records
 without knowing the exact Result name.
 
 ## Metrics

--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -202,9 +202,12 @@ func (s *Server) getFilteredPaginatedSortedRecords(ctx context.Context, parent, 
 	for len(out) < pageSize {
 		batchSize := batcher.Next()
 		dbrecords := make([]*db.Record, 0, batchSize)
-		q := s.db.WithContext(ctx).Where("parent = ? AND id > ?", parent, start)
+		q := s.db.WithContext(ctx).Where("id > ?", start)
 		// Specifying `-` allows users to read Records across Results.
 		// See https://google.aip.dev/159 for more details.
+		if parent != "-" {
+			q = q.Where("parent = ?", parent)
+		}
 		if result != "-" {
 			q = q.Where("result_name = ?", result)
 		}

--- a/pkg/api/server/v1alpha2/records_test.go
+++ b/pkg/api/server/v1alpha2/records_test.go
@@ -326,6 +326,24 @@ func TestListRecords(t *testing.T) {
 			},
 		},
 		{
+			name: "list all records without knowing the result name",
+			req: &pb.ListRecordsRequest{
+				Parent: "foo/results/-",
+			},
+			want: &pb.ListRecordsResponse{
+				Records: records,
+			},
+		},
+		{
+			name: "list all records without knowing the parent and the result name",
+			req: &pb.ListRecordsRequest{
+				Parent: "-/results/-",
+			},
+			want: &pb.ListRecordsResponse{
+				Records: records,
+			},
+		},
+		{
 			// TODO: We should return NOT_FOUND in the future.
 			name: "missing parent",
 			req: &pb.ListRecordsRequest{

--- a/pkg/api/server/v1alpha2/results.go
+++ b/pkg/api/server/v1alpha2/results.go
@@ -237,7 +237,13 @@ func (s *Server) getFilteredPaginatedSortedResults(ctx context.Context, parent s
 	for len(out) < pageSize {
 		batchSize := batcher.Next()
 		dbresults := make([]*db.Result, 0, batchSize)
-		q := s.db.WithContext(ctx).Where("parent = ? AND id > ?", parent, start)
+		q := s.db.WithContext(ctx).Where("id > ?", start)
+		// Specifying `-` allows users to read Results from any parent.
+		// See https://google.aip.dev/159 for more details.
+		if parent != "-" {
+			q = q.Where("parent = ?", parent)
+		}
+
 		if sortOrder != "" {
 			q.Order(sortOrder)
 		}

--- a/pkg/api/server/v1alpha2/results_test.go
+++ b/pkg/api/server/v1alpha2/results_test.go
@@ -407,6 +407,16 @@ func TestListResults(t *testing.T) {
 			status: codes.OK,
 		},
 		{
+			name: "list all results without knowing the parent name",
+			req: &pb.ListResultsRequest{
+				Parent: "-",
+			},
+			want: &pb.ListResultsResponse{
+				Results: results,
+			},
+			status: codes.OK,
+		},
+		{
 			name: "list all w/ pagination token",
 			req: &pb.ListResultsRequest{
 				Parent:   parent,


### PR DESCRIPTION
## What

This pull request resolves https://github.com/tektoncd/results/issues/248, which
provides a more detailed explanation about the rationale. Essentially, these
changes allow users to list results across parents and list records across
results without a prior knowledge of the parent name.