### PR TITLE
Improve coverage of E2E tests

### DIFF
--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -137,7 +137,11 @@ func (s *Server) ListRecords(ctx context.Context, req *pb.ListRecordsRequest) (*
 	if req.GetParent() == "" {
 		return nil, status.Error(codes.InvalidArgument, "parent missing")
 	}
-	if err := s.auth.Check(ctx, req.GetParent(), auth.ResourceRecords, auth.PermissionList); err != nil {
+	parent, _, err := result.ParseName(req.GetParent())
+	if err != nil {
+		return nil, err
+	}
+	if err := s.auth.Check(ctx, parent, auth.ResourceRecords, auth.PermissionList); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/grpc_client.go
+++ b/test/e2e/grpc_client.go
@@ -1,0 +1,90 @@
+// Copyright 2022 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/credentials/oauth"
+	"k8s.io/client-go/transport"
+
+	resultsv1alpha2 "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+const (
+	certFile                  = "/tmp/tekton-results-cert.pem"
+	apiServerName             = "tekton-results-api-service.tekton-pipelines.svc.cluster.local"
+	apiServerAddress          = "localhost:50051"
+	allNamespacesReadAccess   = "/tmp/tekton-results/tokens/all-namespaces-read-access"
+	singleNamespaceReadAccess = "/tmp/tekton-results/tokens/single-namespace-read-access"
+)
+
+// newResultsClient creates a new Results GRPC client to talk to the Results API
+// server.
+func newResultsClient(t *testing.T, accessTokenPath string) resultsv1alpha2.ResultsClient {
+	t.Helper()
+
+	certPool, err := loadCertificates()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := openConnection(certPool, accessTokenPath)
+	if err != nil {
+		t.Fatalf("Error connecting to the Results API server: %v", err)
+	}
+
+	return resultsv1alpha2.NewResultsClient(conn)
+}
+
+func loadCertificates() (*x509.CertPool, error) {
+	certPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("error loading system cert pool: %w", err)
+	}
+
+	cert, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if !certPool.AppendCertsFromPEM(cert) {
+		return nil, errors.New("unable to append certificate to cert pool")
+	}
+
+	return certPool, nil
+}
+
+func openConnection(certPool *x509.CertPool, accessTokenPath string) (*grpc.ClientConn, error) {
+	transportCredentials := credentials.NewClientTLSFromCert(certPool, apiServerName)
+	tokenSource := transport.NewCachedFileTokenSource(accessTokenPath)
+	opts := []grpc.DialOption{
+		grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(grpc.PerRPCCredentials(oauth.TokenSource{TokenSource: tokenSource})),
+		grpc.WithTransportCredentials(transportCredentials),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return grpc.DialContext(ctx, apiServerAddress, opts...)
+}

--- a/test/e2e/kind-cluster.yaml
+++ b/test/e2e/kind-cluster.yaml
@@ -18,7 +18,12 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - &node
   role: control-plane
+  # Set a fixed Kubernetes version.
   image: kindest/node:v1.22.13@sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959
+
+# Merge the same definition as the control-plane to reuse the same Kindest image
+# in the data-plane. We'll set specific values of the data-plane afterwards.
+# For further details on merge keys, please refer to https://learnxinyminutes.com/docs/yaml/.
 - <<: *node
   role: worker
   extraPortMappings:

--- a/test/e2e/kustomize/api-server.yaml
+++ b/test/e2e/kustomize/api-server.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Tekton Authors
+# Copyright 2022 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# see: https://kind.sigs.k8s.io/docs/user/configuration/
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- &node
-  role: control-plane
-  image: kindest/node:v1.22.13@sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959
-- <<: *node
-  role: worker
-  extraPortMappings:
-    # API GRPC server
-    - containerPort: 30000
-      hostPort: 50051
+- op: replace
+  path: /spec/ports/0
+  value:
+    name: grpc
+    port: 50051
+    nodePort: 30000
+- op: add
+  path: /spec/type
+  value: NodePort

--- a/test/e2e/kustomize/kustomization.yaml
+++ b/test/e2e/kustomize/kustomization.yaml
@@ -14,11 +14,19 @@
 
 bases:
 - ../../../config/
+resources:
+- rbac.yaml
 patchesJson6902:
 - target:
     group: apps
-    version: v1 # apiVersion
+    version: v1
     kind: Deployment
     name: tekton-results-watcher
     namespace: tekton-pipelines
   path: watcher.yaml
+- target:
+    version: v1
+    kind: Service
+    name: tekton-results-api-service
+    namespace: tekton-pipelines
+  path: api-server.yaml

--- a/test/e2e/kustomize/rbac.yaml
+++ b/test/e2e/kustomize/rbac.yaml
@@ -16,11 +16,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: all-namespaces-read-access
+  namespace: default
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: single-namespace-read-access
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/e2e/kustomize/rbac.yaml
+++ b/test/e2e/kustomize/rbac.yaml
@@ -1,0 +1,49 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: all-namespaces-read-access
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: single-namespace-read-access
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: all-namespaces-read-access
+subjects:
+  - kind: ServiceAccount
+    name: all-namespaces-read-access
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-readonly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: single-namespace-read-access
+subjects:
+  - kind: ServiceAccount
+    name: single-namespace-read-access
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-readonly

--- a/test/e2e/kustomize/rbac.yaml
+++ b/test/e2e/kustomize/rbac.yaml
@@ -41,6 +41,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: single-namespace-read-access
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: single-namespace-read-access


### PR DESCRIPTION
Resolves https://github.com/tektoncd/results/issues/142.

## What

- Write E2E test cases for the changes introduced on
https://github.com/tektoncd/results/pull/249. In addition, basic listing
operations were covered.
- Fix a bug in the authorization flow for the ListRecords operation. The parent
passed to the `Check` method was incorrect and if one created a Role to restrict
the access to a single namespace, the API server would always return an
unauthenticated error. The fix is covered in a newlycreated E2E test case.
- Pin Kubernetes v1.22 in the Kind config. By doing so, users may run newer
versions of Kind and the tests will run on a cluster that uses a known
Kubernetes version. Note that Knative no longer supports the Kubernetes version
used by default in the Kind v0.10 (which is mentioned in the E2E documentation).

## Additional information

There are two already existing E2E test cases failing consistently. I'm going to
open a new pull request to fix them to make changes more granular.