### PR TITLE
Fix resource deletion and refactor watcher

### DIFF
--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -48,7 +48,6 @@ func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *
 		Logger:        logging.FromContext(ctx),
 		WorkQueueName: "PipelineRuns",
 	})
-	c.enqueue = impl.EnqueueAfter
 
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    impl.Enqueue,

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -48,7 +48,6 @@ func NewControllerWithConfig(ctx context.Context, client pb.ResultsClient, cfg *
 		Logger:        logging.FromContext(ctx),
 		WorkQueueName: "TaskRuns",
 	})
-	c.enqueue = impl.EnqueueAfter
 
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    impl.Enqueue,


### PR DESCRIPTION
## What

This pull request resolves https://github.com/tektoncd/results/issues/254. The
following fixes and improvements were made:

- Fix object deletion upon completion: apparently, the main cause of the
instability was the use of the record to determine the time at which the Run
object had been updated. I changed the watcher to use the
`Status.CompletionTime` since this approach seems to be more
reliable. Currently, if the Tekton
pipelines controller resyncs the object and transitions the status, the object
will change, the record will be updated and this will cause discrepancies in the
verification of the grace period expiration.
- The aforementioned change fixes end-to-end tests. Now, the test suite is
passing consistently in my machine (this
[pr](https://github.com/tektoncd/results/pull/253) should be merged as well
since it fixes other issues in the current e2e setup).
- Improve logs emitted by the watcher: favor structured logging since it
simplifies a lot the debugging with log indexer tools such as Splunk and others.
- Refactor the controller's code to make it simpler and hopefully, easier to
reason about. I tried to make things more uniform and meaningful for new
collaborators. One of the most relevant changes was removing the enqueue
function that was being passed around and replacing the approach with the
knative's `controller.NewRequeueAfter` function which returns an error that
tells knative to requeue the key after a given duration.