### PR TITLE
Added compatibility with priviliged pod security level

### DIFF
--- a/config/201-sql-deployment.yaml
+++ b/config/201-sql-deployment.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres@sha256:6647385dd9ae11aa2216bf55c54d126b0a85637b3cf4039ef24e3234113588e3  # 13.3
+        image: bitnami/postgresql@sha256:23b9a21460fefdd83accd0f864e734c88bebc67c86ee752a97b77dd4843907f0  # 13.3.0
         envFrom:
           - configMapRef:
               name: tekton-results-postgres
@@ -59,6 +59,16 @@ spec:
           mountPath: /var/lib/postgresql/data
         - name: sql-initdb
           mountPath: /docker-entrypoint-initdb.d
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
       volumes:
         - name: sql-initdb
           configMap:

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -58,6 +58,16 @@ spec:
             - name: tls
               mountPath: "/etc/tls"
               readOnly: true
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
       volumes:
         - name: config
           configMap:

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -64,6 +64,16 @@ spec:
             - name: tls
               mountPath: "/etc/tls"
               readOnly: true
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
       volumes:
         - name: tls
           secret:


### PR DESCRIPTION
Since tekton installation now enforces the pod security level to be restricted I altered the deployment templates a bit and added the needed security settings.

I also swapped out the postgres image to the one offered by bitnami since they make non-root images. A non-root image is necessary for the restricted pod policy. I did not touched the  the version the keep the change minimal.