### PR TITLE
deployment with restricted pod policy 

### DIFF
--- a/config/201-sql-deployment.yaml
+++ b/config/201-sql-deployment.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres@sha256:6647385dd9ae11aa2216bf55c54d126b0a85637b3cf4039ef24e3234113588e3  # 13.3
+        image: bitnami/postgresql@sha256:23b9a21460fefdd83accd0f864e734c88bebc67c86ee752a97b77dd4843907f0  # 13.3.0
         envFrom:
           - configMapRef:
               name: tekton-results-postgres
@@ -59,6 +59,16 @@ spec:
           mountPath: /var/lib/postgresql/data
         - name: sql-initdb
           mountPath: /docker-entrypoint-initdb.d
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
       volumes:
         - name: sql-initdb
           configMap:

--- a/config/201-sql-deployment.yaml
+++ b/config/201-sql-deployment.yaml
@@ -48,15 +48,12 @@ spec:
               name: tekton-results-postgres
           - secretRef:
               name: tekton-results-postgres
-        env:
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
         ports:
         - containerPort: 5432
           name: postgredb
         volumeMounts:
         - name: postgredb
-          mountPath: /var/lib/postgresql/data
+          mountPath: /bitnami/postgresql
         - name: sql-initdb
           mountPath: /docker-entrypoint-initdb.d
         securityContext:

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -58,6 +58,16 @@ spec:
             - name: tls
               mountPath: "/etc/tls"
               readOnly: true
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
       volumes:
         - name: config
           configMap:

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -41,12 +41,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: tekton-results-postgres
-                  key: POSTGRES_USER
+                  key: POSTGRESQL_USER
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: tekton-results-postgres
-                  key: POSTGRES_PASSWORD
+                  key: POSTGRESQL_PASSWORD
             - name: DB_HOST
               value: tekton-results-postgres-service.tekton-pipelines.svc.cluster.local
             - name: DB_NAME

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -64,6 +64,16 @@ spec:
             - name: tls
               mountPath: "/etc/tls"
               readOnly: true
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
       volumes:
         - name: tls
           secret:

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,14 +14,14 @@
    - namespace: `tekton-pipelines`
    - name: `tekton-results-postgres`
    - contains the fields:
-     - `POSTGRES_USER=postgres`
-     - `POSTGRES_PASSWORD=<your password>`
+     - `POSTGRESQL_USER=postgres`
+     - `POSTGRESQL_PASSWORD=<your password>`
 
    If you are not using a particular password management strategy, the following
    command will generate a random password for you:
 
    ```sh
-   $ kubectl create secret generic tekton-results-postgres --namespace="tekton-pipelines" --from-literal=POSTGRES_USER=postgres --from-literal=POSTGRES_PASSWORD=$(openssl rand -base64 20)
+   $ kubectl create secret generic tekton-results-postgres --namespace="tekton-pipelines" --from-literal=POSTGRESQL_USER=postgres --from-literal=POSTGRESQL_PASSWORD=$(openssl rand -base64 20)
    ```
 
 3. Generate cert/key pair. Note: Feel free to use any cert management software


### PR DESCRIPTION
Since tekton installation now enforces the pod security level to be restricted I altered the deployment templates a bit and added the needed security settings.

I also swapped out the postgres image to the one offered by bitnami since they make non-root images. A non-root image is necessary for the restricted pod policy. I did not touched the the version the keep the change minimal.

(sorry for duplicate PR, wrong one is closed)