### PR TITLE
Fix api config location and e2e tests

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -62,6 +62,7 @@ type ConfigFile struct {
 func main() {
 
 	viper.AddConfigPath("./env")
+	viper.AddConfigPath("/env")
 	viper.SetConfigName("config")
 	viper.SetConfigType("env")
 

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -53,7 +53,7 @@ spec:
               value: tekton-results
           volumeMounts:
             - name: config
-              mountPath: /home/nonroot/env
+              mountPath: /env
               readOnly: true
             - name: tls
               mountPath: "/etc/tls"

--- a/test/e2e/00-setup.sh
+++ b/test/e2e/00-setup.sh
@@ -19,5 +19,5 @@ export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"tekton-results"}
 
 ROOT="$(git rev-parse --show-toplevel)"
 
-kind create cluster --loglevel=debug --config "${ROOT}/test/e2e/kind-cluster.yaml" --name=${KIND_CLUSTER_NAME} --wait=60s
+kind create cluster --verbosity 3 --config "${ROOT}/test/e2e/kind-cluster.yaml" --name=${KIND_CLUSTER_NAME} --wait=60s
 kind export kubeconfig

--- a/test/e2e/01-install.sh
+++ b/test/e2e/01-install.sh
@@ -70,10 +70,11 @@ tokens_dir=/tmp/tekton-results/tokens
 mkdir -p $tokens_dir
 service_accounts=(all-namespaces-read-access single-namespace-read-access)
 for service_account in ${service_accounts[@]}; do
-    kubectl get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$service_account')].data.token}"|base64 --decode > $tokens_dir/$service_account
+    kubectl create token $service_account > $tokens_dir/$service_account
     echo "Created $tokens_dir/$service_account"
 done
 
 echo "Waiting for deployments to be ready..."
-kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"
-kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="60s"
+kubectl wait pod "tekton-results-postgres-0" --namespace="tekton-pipelines" --for="condition=Ready" --timeout="120s"
+kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
+kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -38,7 +38,7 @@ main() {
 
     # Build static binaries; otherwise go test complains.
     export CGO_ENABLED=0
-    go test --tags=e2e ${REPO}/test/e2e/...
+    go test -v -count=1 --tags=e2e ${REPO}/test/e2e/...
 }
 
 main


### PR DESCRIPTION
The api config location was inconsistent between the code and deployment manifest. The new location was chosen based on
https://github.com/GoogleContainerTools/distroless/issues/718. Kubernetes v1.25 uses new types of tokens for the service accounts which are not automatically created.
Bump test deployment timeout causing sporadic failures.