### PR TITLE
Enable REST endpoints if logging is on

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -187,6 +187,13 @@ func main() {
 		log.Fatal("Error registering gRPC server endpoint: ", err)
 	}
 
+	if configFile.LOGS_API {
+		err = v1alpha2pb.RegisterLogsHandlerFromEndpoint(ctx, mux, ":"+configFile.GRPC_PORT, opts)
+		if err != nil {
+			log.Fatal("Error registering gRPC server endpoints for log: ", err)
+		}
+	}
+
 	// Start REST proxy server
 	log.Infof("REST server Listening on: %s", configFile.REST_PORT)
 	if tlsError != nil {


### PR DESCRIPTION
Signed-off-by: Avinal Kumar <avinal@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR enables REST Endpoint for streaming logs if the logging is turned on

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](CONTRIBUTING.md) for more details._

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
