### PR TITLE
Fix DEVELOPMENT documentation

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -82,8 +82,11 @@ $ grpc_cli ls --channel_creds_type=ssl --ssl_target=tekton-results-api-service.t
 grpc.reflection.v1alpha.ServerReflection
 tekton.results.v1alpha2.Results
 
+# Create gRPC access token
+$ export GRPC_ACCESS_TOKEN=$(kubectl create token tekton-results-debug -n tekton-pipelines)
+
 # Makes a request to the Results service.
-$ grpc_cli call --channel_creds_type=ssl --ssl_target=tekton-results-api-service.tekton-pipelines.svc.cluster.local --call_creds=access_token=$(kubectl get secrets -n tekton-pipelines -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='tekton-results-debug')].data.token}"|base64 --decode) localhost:50051 tekton.results.v1alpha2.Results.ListResults 'parent: "default"'
+$ grpc_cli call --channel_creds_type=ssl --ssl_target=tekton-results-api-service.tekton-pipelines.svc.cluster.local --call_creds=access_token=$GRPC_ACCESS_TOKEN localhost:50051 tekton.results.v1alpha2.Results.ListResults 'parent: "default"'
 connecting to localhost:50051
 results {
   name: "default/results/9b7714d0-cbd3-40c6-87ec-bcbd9f199985"
@@ -146,13 +149,13 @@ data:
 
 Log levels supported by Zap logger are:
 
-debug - fine-grained debugging
-info - normal logging
-warn - unexpected but non-critical errors
-error - critical errors; unexpected during normal operation
-dpanic - in debug mode, trigger a panic (crash)
-panic - trigger a panic (crash)
-fatal - immediately exit with exit status 1 (failure)
+- debug - fine-grained debugging
+- info - normal logging
+- warn - unexpected but non-critical errors
+- error - critical errors; unexpected during normal operation
+- dpanic - in debug mode, trigger a panic (crash)
+- panic - trigger a panic (crash)
+- fatal - immediately exit with exit status 1 (failure)
 
 ## Recommended Reading
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -153,6 +153,6 @@ without knowing the exact Result name.
 ## Metrics
 
 The API Server includes an HTTP server for exposing gRPC server Prometheus
-metrics. By default, the Service exposes metrics on port `:8080`. For more
+metrics. By default, the Service exposes metrics on port `:9090`. For more
 details on the structure of the metrics, see
 https://github.com/grpc-ecosystem/go-grpc-prometheus#metrics.


### PR DESCRIPTION
Fix `create token` command, works with latest version of k8s.
Fix logging levels list.