### PR TITLE
Wait until all TaskRuns are ready for deletion to delete the PipelineRun

### DIFF
--- a/pkg/watcher/reconciler/annotation/annotation_test.go
+++ b/pkg/watcher/reconciler/annotation/annotation_test.go
@@ -1,0 +1,249 @@
+// Copyright 2023 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestPatch(t *testing.T) {
+	const (
+		fakeResultID = "foo/results/bar"
+		fakeRecordID = "foo/results/bar/records/baz"
+	)
+
+	annotations := []Annotation{{
+		Name:  Result,
+		Value: fakeResultID,
+	},
+		{
+			Name:  Record,
+			Value: fakeRecordID,
+		},
+	}
+
+	tests := []struct {
+		name string
+		in   func() metav1.Object
+		want mergePatch
+	}{{
+		name: "create a patch containing only the result and record identifiers since the object is a PipelineRun",
+		in: func() metav1.Object {
+			return &pipelinev1beta1.PipelineRun{}
+		},
+		want: mergePatch{
+			Metadata: metadata{
+				Annotations: map[string]string{
+					Result: fakeResultID,
+					Record: fakeRecordID,
+				},
+			},
+		},
+	},
+		{
+			name: "create a patch containing only the result and record identifiers since the TaskRun isn't owned by a PipelineRun",
+			in: func() metav1.Object {
+				return &pipelinev1beta1.TaskRun{}
+			},
+			want: mergePatch{
+				Metadata: metadata{
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						Record: fakeRecordID,
+					},
+				},
+			},
+		},
+		{
+			name: "create a patch containing only the result and record identifiers since the TaskRun isn't done yet",
+			in: func() metav1.Object {
+				return &pipelinev1beta1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							UID: types.UID("UID"),
+						},
+						},
+					},
+				}
+			},
+			want: mergePatch{
+				Metadata: metadata{
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						Record: fakeRecordID,
+					},
+				},
+			},
+		},
+		{
+			name: "mark the TaskRun as ready for deletion since it's owned by a PipelineRun and is done",
+			in: func() metav1.Object {
+				taskRun := &pipelinev1beta1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{{
+							UID: types.UID("UID"),
+						},
+						},
+					},
+				}
+				taskRun.Status.MarkResourceFailed(pipelinev1beta1.TaskRunReasonFailed, errors.New("Failed"))
+				return taskRun
+			},
+			want: mergePatch{
+				Metadata: metadata{
+					Annotations: map[string]string{
+						Result:                fakeResultID,
+						Record:                fakeRecordID,
+						ChildReadyForDeletion: "true",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			object := test.in()
+			patch, err := Patch(object, annotations...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var got mergePatch
+			if err := json.Unmarshal(patch, &got); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsPatched(t *testing.T) {
+	const (
+		fakeResultID = "foo/results/bar"
+		fakeRecordID = "foo/results/bar/records/baz"
+	)
+
+	annotations := []Annotation{{
+		Name:  Result,
+		Value: fakeResultID,
+	},
+		{
+			Name:  Record,
+			Value: fakeRecordID,
+		},
+	}
+
+	tests := []struct {
+		name string
+		in   func() metav1.Object
+		want bool
+	}{{
+		name: "result and record identifiers are missing in the PipelineRun",
+		in: func() metav1.Object {
+			return &pipelinev1beta1.PipelineRun{}
+		},
+		want: false,
+	},
+		{
+			name: "the record identifier is missing in the PipelineRun",
+			in: func() metav1.Object {
+				return &pipelinev1beta1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							Result: fakeResultID,
+						},
+					},
+				}
+			},
+			want: false,
+		},
+		{
+			name: "the PipelineRun contains all relevant annotations",
+			in: func() metav1.Object {
+				return &pipelinev1beta1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							Result: fakeResultID,
+							Record: fakeRecordID,
+						},
+					},
+				}
+			},
+			want: true,
+		},
+		{
+			name: "the TaskRun contains all relevant annotations",
+			in: func() metav1.Object {
+				taskRun := &pipelinev1beta1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							Result:                fakeResultID,
+							Record:                fakeRecordID,
+							ChildReadyForDeletion: "true",
+						},
+						OwnerReferences: []metav1.OwnerReference{{
+							UID: types.UID("UID"),
+						},
+						},
+					},
+				}
+				taskRun.Status.MarkResourceFailed(pipelinev1beta1.TaskRunReasonFailed, errors.New("Failed"))
+				return taskRun
+			},
+			want: true,
+		},
+		{
+			name: "the TaskRun should be marked as ready to be deleted",
+			in: func() metav1.Object {
+				taskRun := &pipelinev1beta1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							Result: fakeResultID,
+							Record: fakeRecordID,
+						},
+						OwnerReferences: []metav1.OwnerReference{{
+							UID: types.UID("UID"),
+						},
+						},
+					},
+				}
+				taskRun.Status.MarkResourceFailed(pipelinev1beta1.TaskRunReasonFailed, errors.New("Failed"))
+				return taskRun
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			object := test.in()
+			got := IsPatched(object, annotations...)
+			if test.want != got {
+				t.Errorf("Want %t, but got %t", test.want, got)
+			}
+		})
+	}
+}

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -1,13 +1,30 @@
+// Copyright 2020 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pipelinerun
 
 import (
 	"context"
 	"fmt"
 
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	"github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	pipelinev1beta1listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
+	resultsannotation "github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/dynamic"
+	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,11 +39,12 @@ type Reconciler struct {
 	// Inline LeaderAwareFuncs to support leader election.
 	knativereconciler.LeaderAwareFuncs
 
-	resultsClient  pb.ResultsClient
-	logsClient     pb.LogsClient
-	lister         v1beta1.PipelineRunLister
-	pipelineClient versioned.Interface
-	cfg            *reconciler.Config
+	resultsClient     pb.ResultsClient
+	logsClient        pb.LogsClient
+	pipelineRunLister pipelinev1beta1listers.PipelineRunLister
+	taskRunLister     pipelinev1beta1listers.TaskRunLister
+	pipelineClient    versioned.Interface
+	cfg               *reconciler.Config
 }
 
 // Check that our Reconciler is LeaderAware.
@@ -34,6 +52,7 @@ var _ knativereconciler.LeaderAware = (*Reconciler)(nil)
 
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx).With(zap.String("results.tekton.dev/kind", "PipelineRun"))
+	logger.Info("Reconciling PipelineRun")
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -46,9 +65,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return controller.NewSkipKey(key)
 	}
 
-	logger.Info("Reconciling PipelineRun")
-
-	pr, err := r.lister.PipelineRuns(namespace).Get(name)
+	pr, err := r.pipelineRunLister.PipelineRuns(namespace).Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Debug("Skipping key: object is no longer available")
@@ -62,9 +79,79 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 	}
 
 	dyn := dynamic.NewDynamicReconciler(r.resultsClient, r.logsClient, pipelineRunClient, r.cfg)
+	// Tell the dynamic reconciler to wait until all underlying TaskRuns are
+	// ready for deletion before deleting the PipelineRun. This guarantees
+	// that the TaskRuns will not be deleted before their final state being
+	// properly archived into the API server.
+	dyn.IsReadyForDeletionFunc = r.areAllUnderlyingTaskRunsReadyForDeletion
+
 	if err := dyn.Reconcile(logging.WithLogger(ctx, logger), pr); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (r *Reconciler) areAllUnderlyingTaskRunsReadyForDeletion(ctx context.Context, object results.Object) (bool, error) {
+	pipelineRun, ok := object.(*pipelinev1beta1.PipelineRun)
+	if !ok {
+		return false, fmt.Errorf("unexpected object (must not happen): want %T, but got %T", &pipelinev1beta1.PipelineRun{}, object)
+	}
+
+	logger := logging.FromContext(ctx)
+
+	// Support both minimal and full embedded status (see the TODO comment
+	// below).
+	if len(pipelineRun.Status.ChildReferences) > 0 {
+		for _, reference := range pipelineRun.Status.ChildReferences {
+			taskRun, err := r.taskRunLister.TaskRuns(pipelineRun.Namespace).Get(reference.Name)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// Let's assume that the TaskRun in
+					// question is gone and therefore, we
+					// can safely ignore it.
+					logger.Debugf("TaskRun %s/%s is no longer available - ignoring", pipelineRun.Namespace, reference.Name)
+					continue
+				}
+				return false, fmt.Errorf("error reading TaskRun from the indexer: %w", err)
+			}
+			if !isMarkedAsReadyForDeletion(taskRun) {
+				logger.Debugf("TaskRun %s/%s isn't yet ready to be deleted - the annotation %s is missing", taskRun.Namespace, taskRun.Name, resultsannotation.ChildReadyForDeletion)
+				return false, nil
+			}
+		}
+	} else {
+		// TODO(alan-ghelardi): remove this else once we support only
+		// Tekton v1 API since the full embedded status will no longer
+		// be supported.
+		for taskRunName := range pipelineRun.Status.TaskRuns {
+			taskRun, err := r.taskRunLister.TaskRuns(pipelineRun.Namespace).Get(taskRunName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// Let's assume that the TaskRun in
+					// question is gone and therefore, we
+					// can safely ignore it.
+					logger.Debugf("TaskRun %s/%s is no longer available - ignoring", pipelineRun.Namespace, taskRunName)
+					continue
+				}
+				return false, fmt.Errorf("error reading TaskRun from the indexer: %w", err)
+			}
+			if !isMarkedAsReadyForDeletion(taskRun) {
+				logger.Debugf("TaskRun %s/%s isn't yet ready to be deleted - the annotation %s is missing", taskRun.Namespace, taskRun.Name, resultsannotation.ChildReadyForDeletion)
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func isMarkedAsReadyForDeletion(taskRun *pipelinev1beta1.TaskRun) bool {
+	if taskRun.Annotations == nil {
+		return false
+	}
+	if _, found := taskRun.Annotations[resultsannotation.ChildReadyForDeletion]; found {
+		return true
+	}
+	return false
 }

--- a/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
@@ -1,0 +1,143 @@
+// Copyright 2023 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipelinerun
+
+import (
+	"context"
+	"testing"
+
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelinev1beta1listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	resultsannotation "github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
+	"go.uber.org/zap/zaptest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/logging"
+)
+
+func TestAreAllUnderlyingTaskRunsReadyForDeletion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *pipelinev1beta1.PipelineRun
+		want bool
+	}{{
+		name: "all underlying TaskRuns are ready to be deleted",
+		in: &pipelinev1beta1.PipelineRun{
+			Status: pipelinev1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: pipelinev1beta1.PipelineRunStatusFields{
+					ChildReferences: []pipelinev1beta1.ChildStatusReference{{
+						Name: "foo",
+					},
+					},
+				},
+			},
+		},
+		want: true,
+	},
+		{
+			name: "one TaskRun is ready to be deleted whereas the other is not",
+			in: &pipelinev1beta1.PipelineRun{
+				Status: pipelinev1beta1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1beta1.PipelineRunStatusFields{
+						ChildReferences: []pipelinev1beta1.ChildStatusReference{{
+							Name: "foo",
+						},
+							{
+								Name: "bar",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "consider that missing TaskRuns can be deleted",
+			in: &pipelinev1beta1.PipelineRun{
+				Status: pipelinev1beta1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1beta1.PipelineRunStatusFields{
+						ChildReferences: []pipelinev1beta1.ChildStatusReference{{
+							Name: "foo",
+						},
+							{
+								Name: "baz",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "support full embedded status",
+			in: &pipelinev1beta1.PipelineRun{
+				Status: pipelinev1beta1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1beta1.PipelineRunStatusFields{
+						TaskRuns: map[string]*pipelinev1beta1.PipelineRunTaskRunStatus{
+							"bar": &pipelinev1beta1.PipelineRunTaskRunStatus{},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	indexer := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
+
+	// Put a few objects into the indexer.
+	if err := indexer.Add(&pipelinev1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: corev1.NamespaceDefault,
+			Annotations: map[string]string{
+				resultsannotation.ChildReadyForDeletion: "true",
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := indexer.Add(&pipelinev1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: corev1.NamespaceDefault,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reconciler := &Reconciler{
+				taskRunLister: pipelinev1beta1listers.NewTaskRunLister(indexer),
+			}
+
+			test.in.Namespace = corev1.NamespaceDefault
+
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+			got, err := reconciler.areAllUnderlyingTaskRunsReadyForDeletion(ctx, test.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if test.want != got {
+				t.Fatalf("Want %t, but got %t", test.want, got)
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,17 +21,19 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"os"
-	"path"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	resultsv1alpha2 "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"time"
+
+	"os"
+	"path"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
@@ -106,7 +108,7 @@ func TestTaskRun(t *testing.T) {
 		}
 	})
 
-	t.Run("Run Cleanup", func(t *testing.T) {
+	t.Run("TaskRun Cleanup", func(t *testing.T) {
 		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
 			tr, err := c.TaskRuns(ns).Get(ctx, tr.GetName(), metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {
@@ -140,21 +142,36 @@ func TestPipelineRun(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	// Wait for Result ID to show up.
-	if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
-		pr, err := c.PipelineRuns(ns).Get(ctx, pr.GetName(), metav1.GetOptions{})
-		if err != nil {
-			t.Logf("Get: %v", err)
+	t.Run("result annotations", func(t *testing.T) {
+		// Wait for Result ID to show up.
+		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+			pr, err := c.PipelineRuns(ns).Get(ctx, pr.GetName(), metav1.GetOptions{})
+			if err != nil {
+				t.Logf("Get: %v", err)
+				return false, nil
+			}
+			if r, ok := pr.GetAnnotations()["results.tekton.dev/result"]; ok {
+				t.Logf("Found Result: %s", r)
+				return true, nil
+			}
 			return false, nil
+		}); err != nil {
+			t.Fatalf("error waiting for Result ID: %v", err)
 		}
-		if r, ok := pr.GetAnnotations()["results.tekton.dev/result"]; ok {
-			t.Logf("Found Result: %s", r)
-			return true, nil
+	})
+
+	t.Run("PipelineRun cleanup", func(t *testing.T) {
+		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+			pr, err := c.PipelineRuns(ns).Get(ctx, pr.GetName(), metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return true, nil
+			}
+			t.Logf("Get: %+v, %v", pr.GetName(), err)
+			return false, nil
+		}); err != nil {
+			t.Fatalf("error waiting PipelineRun to be deleted: %v", err)
 		}
-		return false, nil
-	}); err != nil {
-		t.Fatalf("error waiting for Result ID: %v", err)
-	}
+	})
 }
 
 func clientConfig(t *testing.T) *rest.Config {
@@ -172,6 +189,93 @@ func clientConfig(t *testing.T) *rest.Config {
 func clientTekton(t *testing.T) *clientset.TektonV1beta1Client {
 	t.Helper()
 	return clientset.NewForConfigOrDie(clientConfig(t))
+}
+
+func TestGRPCLogging(t *testing.T) {
+	ctx := context.Background()
+
+	// ignore old logs
+	sinceTime := metav1.Now()
+	podLogOptions := corev1.PodLogOptions{
+		SinceTime: &sinceTime,
+	}
+
+	matcher := "\"grpc.method\":\"ListResults\""
+
+	client := newResultsClient(t, allNamespacesReadAccessPath)
+
+	t.Run("Log entry is found when not expected", func(t *testing.T) {
+		resultsApiLogs, err := getResultsApiLogs(ctx, &podLogOptions, t)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(resultsApiLogs, matcher) {
+			t.Logf("No log match %s when there should not be\n", matcher)
+		} else {
+			t.Errorf("Found log match for %s in logs %s when there should not be", matcher, resultsApiLogs)
+		}
+	})
+
+	t.Run("Log entry is found when expected", func(t *testing.T) {
+
+		_, err := client.ListResults(ctx, &resultsv1alpha2.ListResultsRequest{Parent: "default"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resultsApiLogs, err := getResultsApiLogs(ctx, &podLogOptions, t)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if strings.Contains(resultsApiLogs, matcher) {
+			t.Logf("Found log match %s\n", matcher)
+		} else {
+			t.Errorf("No match for %s in logs %s", matcher, resultsApiLogs)
+		}
+	})
+}
+
+// Returns a string of api pods logs concatenated
+func getResultsApiLogs(ctx context.Context, podLogOptions *corev1.PodLogOptions, t *testing.T) (string, error) {
+	t.Helper()
+	const apiPodBasename = "tekton-results-api"
+	const nsResults = "tekton-pipelines"
+
+	clientset := kubernetes.NewForConfigOrDie(clientConfig(t))
+
+	pods, err := clientset.CoreV1().Pods(nsResults).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	numApiPods := 0
+	var apiPodsLogs []string
+	for _, pod := range pods.Items {
+		// find api pods
+		if strings.HasPrefix(pod.Name, apiPodBasename) {
+			numApiPods++
+			// read pod logs
+			podLogRequest := clientset.CoreV1().Pods(nsResults).GetLogs(pod.Name, podLogOptions)
+			stream, err := podLogRequest.Stream(ctx)
+			if err != nil {
+				return "", err
+			}
+			defer stream.Close()
+			podLogBytes, err := ioutil.ReadAll(stream)
+			if err != nil {
+				return "", err
+			}
+			apiPodsLogs = append(apiPodsLogs, string(podLogBytes))
+		}
+	}
+
+	if numApiPods == 0 {
+		return "", errors.New("No " + apiPodBasename + "pod found")
+	}
+
+	return strings.Join(apiPodsLogs, ""), nil
 }
 
 func TestListResults(t *testing.T) {
@@ -329,91 +433,4 @@ func recordNames(t *testing.T, records []*resultsv1alpha2.Record) []string {
 		ret = append(ret, record.GetName())
 	}
 	return ret
-}
-
-func TestGRPCLogging(t *testing.T) {
-	ctx := context.Background()
-
-	// ignore old logs
-	sinceTime := metav1.Now()
-	podLogOptions := corev1.PodLogOptions{
-		SinceTime: &sinceTime,
-	}
-
-	matcher := "\"grpc.method\":\"ListResults\""
-
-	client := newResultsClient(t, allNamespacesReadAccessPath)
-
-	t.Run("Log entry is found when not expected", func(t *testing.T) {
-		resultsApiLogs, err := getResultsApiLogs(ctx, &podLogOptions, t)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !strings.Contains(resultsApiLogs, matcher) {
-			t.Logf("No log match %s when there should not be\n", matcher)
-		} else {
-			t.Errorf("Found log match for %s in logs %s when there should not be", matcher, resultsApiLogs)
-		}
-	})
-
-	t.Run("Log entry is found when expected", func(t *testing.T) {
-
-		_, err := client.ListResults(ctx, &resultsv1alpha2.ListResultsRequest{Parent: "default"})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		resultsApiLogs, err := getResultsApiLogs(ctx, &podLogOptions, t)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if strings.Contains(resultsApiLogs, matcher) {
-			t.Logf("Found log match %s\n", matcher)
-		} else {
-			t.Errorf("No match for %s in logs %s", matcher, resultsApiLogs)
-		}
-	})
-}
-
-// Returns a string of api pods logs concatenated
-func getResultsApiLogs(ctx context.Context, podLogOptions *corev1.PodLogOptions, t *testing.T) (string, error) {
-	t.Helper()
-	const apiPodBasename = "tekton-results-api"
-	const nsResults = "tekton-pipelines"
-
-	clientset := kubernetes.NewForConfigOrDie(clientConfig(t))
-
-	pods, err := clientset.CoreV1().Pods(nsResults).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	numApiPods := 0
-	var apiPodsLogs []string
-	for _, pod := range pods.Items {
-		// find api pods
-		if strings.HasPrefix(pod.Name, apiPodBasename) {
-			numApiPods++
-			// read pod logs
-			podLogRequest := clientset.CoreV1().Pods(nsResults).GetLogs(pod.Name, podLogOptions)
-			stream, err := podLogRequest.Stream(ctx)
-			if err != nil {
-				return "", err
-			}
-			defer stream.Close()
-			podLogBytes, err := ioutil.ReadAll(stream)
-			if err != nil {
-				return "", err
-			}
-			apiPodsLogs = append(apiPodsLogs, string(podLogBytes))
-		}
-	}
-
-	if numApiPods == 0 {
-		return "", errors.New("No " + apiPodBasename + "pod found")
-	}
-
-	return strings.Join(apiPodsLogs, ""), nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

Resolves https://github.com/tektoncd/results/issues/332.

This is a race condition that shows up in larger clusters with a high
churn. Without some mechanism that allows to the PipelineRun controller to wait
until all TaskRuns that make up a PipelineRun to be done and up to date in the
API, the controller may end up deleting the PipelineRun (and consequentially,
all underlying TaskRuns) while their TaskRuns haven't yet inserted into the
database or are in an intermediate state.

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The PipelineRun controller now waits until all TaskRuns associated to a PipelineRun are done and up to date in the API server to delete the PipelineRun and consequentially, all TaskRuns in cascade. If the configured grace period to delete objects is very short (useful in larger clusters with high churn) and there's a lag in the controller's work queue, this guarantees that dependent objects (such as TaskRuns) won't be deleted while they're in an intermediate state in the Results API server.
```

## Implementation details

Create the results.tekton.dev/childReadyForDeletion annotation. The TaskRun
controller (and eventually, other controllers that watch "child" resources)
patches the TaskRun with this annotation once it's done and up to date in the
API. The PipelineRun controller looks for this annotation in all TaskRuns
associated to a PipelineRun before deleting it.

A new E2E test was added to make sure that PipelineRuns can be properly deleted.
The function IsReadyForDeletion, added to the dynamic reconciler, allows each
controller to assign a predicate that must be satisfied in order to a given
object to be considered eligible for deletion.
