### PR TITLE
Fix the select statement to leverage the existing records_by_name index

### DIFF
--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -123,9 +123,14 @@ func (s *Server) GetRecord(ctx context.Context, req *pb.GetRecordRequest) (*pb.R
 }
 
 func getRecord(txn *gorm.DB, parent, result, name string) (*db.Record, error) {
+	// Note: set the Parent, ResultName and Name fields in the model used to
+	// query the database to take advantage of the records_by_name composite
+	// index. Although the Name is an unique value as well, leveraging the
+	// index speeds up the query significantly. See
+	// https://github.com/tektoncd/results/issues/336.
 	store := &db.Record{}
 	q := txn.
-		Where(&db.Record{Result: db.Result{Parent: parent, Name: result}, Name: name}).
+		Where(&db.Record{Parent: parent, ResultName: result, Name: name}).
 		First(store)
 	if err := errors.Wrap(q.Error); err != nil {
 		return nil, err


### PR DESCRIPTION
Resolves https://github.com/tektoncd/results/issues/336 which contains further
details on the rationale.

This is a low-hanging fruit, but causes a huge impact in terms of performance at
scale. After this fix, the GetRecord operation started to use the indexed
columns to find records and we reduced the CPU utilization of our Postgres
instance from almost 100% to around 3% during high peaks.