### PR TITLE
Fix go generate: Protobuf generation

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -4,6 +4,5 @@
 2. Rebuild the generated Go code
 
 ```sh
-$ cd v1alpha2
-$ go generate ./proto/
+$ go generate -v ./...
 ```


### PR DESCRIPTION
Put `.` in place of `./proto` from command. go generate doesn't work in Fedora 37(go 1.19.5).