### PR TITLE
Fix: Error message for GetResult handler

### DIFF
--- a/pkg/api/server/v1alpha2/results.go
+++ b/pkg/api/server/v1alpha2/results.go
@@ -285,8 +285,11 @@ func (s *Server) getFilteredPaginatedSortedResults(ctx context.Context, parent s
 
 func getResultByParentName(gdb *gorm.DB, parent, name string) (*db.Result, error) {
 	r := &db.Result{}
-	if err := errors.Wrap(gdb.Where(&db.Result{Parent: parent, Name: name}).First(r).Error); err != nil {
-		return nil, status.Errorf(status.Code(err), "failed to query on database: %v", err)
+	q := gdb.
+		Where(&db.Result{Parent: parent, Name: name}).
+		First(r)
+	if err := errors.Wrap(q.Error); err != nil {
+		return nil, err
 	}
 	return r, nil
 }


### PR DESCRIPTION
Fixes #337

Fix error message for GetResult handler.

Current: Shows wrapped RPC error message
`{"code":5, "message":"failed to query on database: rpc error: code = NotFound desc = record not found", "details":[]}`

Expected: Standard message
`{"code":5, "message":"record not found", "details":[]}`

## Release Note

```release-note
Fix GetResult to return the standard "record not found" error if the database query does not find a result.
```