### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+# Changes
+
+<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
+# Submitter Checklist
+
+These are the criteria that every PR should meet, please check them off as you review them:
+
+- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
+- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
+- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
+- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
+- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
+- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
+- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
+- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release
+
+# Release Notes
+
+<!--
+Does your PR contain User facing changes?
+
+If so, briefly describe them here so we can include this description in the
+release notes for the next release!
+
+For pull requests with a release note:
+
+```release-note
+Your release note here
+```
+
+For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
+
+```release-note
+action required: your release note here
+```
+
+Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
+
+```release-note
+NONE
+```
+-->
+
+<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->


### PR DESCRIPTION

# Changes

- The tektoncd organization provides a default pull request template
https://github.com/tektoncd/.github/blob/main/.github/PULL_REQUEST_TEMPLATE/default.md
This commit adds a pull request template specific to tekton results.
- fixes #322 

/kind cleanup

## Action Item

- [ ] needs actions on prow release plugin, refer: https://github.com/tektoncd/community/blob/main/standards.md#pull-request-description

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

