### PR TITLE
Remove ppc64le and s390x release unittest

### DIFF
--- a/tekton/release.yaml
+++ b/tekton/release.yaml
@@ -56,39 +56,9 @@ spec:
       workspaces:
         - name: source
           workspace: ws
-    - name: unit-tests-ppc64le
-      runAfter: [checkout]
-      taskRef:
-        name: golang-test
-      params:
-        - name: package
-          value: $(workspaces.source.path)/...
-        - name: GOARCH
-          value: ppc64le
-        - name: flags
-          value: "-cover -v"
-      workspaces:
-        - name: source
-          workspace: ws
-    - name: unit-tests-s390x
-      runAfter: [checkout]
-      taskRef:
-        name: golang-test
-      params:
-        - name: package
-          value: $(workspaces.source.path)/...
-        - name: GOARCH
-          value: s390x
-        - name: flags
-          value: "-cover -v"
-      workspaces:
-        - name: source
-          workspace: ws
     - name: publish-image
       runAfter:
         - unit-tests
-        - unit-tests-ppc64le
-        - unit-tests-s390x
       taskSpec:
         params:
           - name: repo


### PR DESCRIPTION
Arch-specific unit tests can't be run. We have only one arch available during release.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
