### PR TITLE
Add release config to bucket's latest folder

### DIFF
--- a/tekton/release.yaml
+++ b/tekton/release.yaml
@@ -103,6 +103,7 @@ spec:
             image: gcr.io/google.com/cloudsdktool/cloud-sdk:310.0.0@sha256:cb03669fcdb9191d55a6200f2911fff3baec0b8c39b156d95b68aabe975ac506 #tag: 310.0.0
             script: |
               gsutil cp $(workspaces.source.path)/release/release.yaml $(params.bucket)/results/previous/$(params.version)/release.yaml
+              gsutil cp $(workspaces.source.path)/release/release.yaml $(params.bucket)/results/latest/release.yaml
       params:
         - name: version
           value: $(params.version)


### PR DESCRIPTION
Before v0.5.0, release configs were stored only in the previous/{version} folder. Now, the user can get the latest release.yaml by running
```
kc apply -f https://storage.googleapis.com/tekton-releases/results/latest/release.yaml
```
This is similar to other projects.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes



```release-note
NONE
```
