### PR TITLE
Fix: API Server panics when bearer token with invalid JWT format is passed

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -226,6 +226,7 @@ func determineAuth(ctx context.Context) (context.Context, error) {
 		ctxzap.AddFields(ctx,
 			zap.String("grpc.user", "unknown"),
 		)
+		return ctx, nil
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok {

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/metadata"
+	"io"
+	"strings"
+	"testing"
+)
+
+func Test_determineAuth(t *testing.T) {
+	validToken, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.RegisteredClaims{
+		Subject: "sayan",
+		Issuer:  "redhat",
+	}).SignedString([]byte("secret"))
+
+	invalidToken := "invalid-token-format"
+
+	tests := []struct {
+		name string
+		md   metadata.MD
+		want string
+	}{
+		{
+			name: "missing token",
+			md:   metadata.MD{},
+			want: "\"grpc.user\":\"unknown\"",
+		},
+		{
+			name: "invalid token",
+			md:   metadata.Pairs("authorization", "Bearer "+invalidToken),
+			want: "\"grpc.user\":\"unknown\"",
+		},
+		{
+			name: "valid token",
+			md:   metadata.Pairs("authorization", "Bearer "+validToken),
+			want: "\"grpc.user\":\"sayan\",\"grpc.issuer\":\"redhat\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			ctx := contextWithLogger(&b)
+			_, err := determineAuth(metadata.NewIncomingContext(ctx, tc.md))
+			l := ctxzap.Extract(ctx)
+			l.Info(tc.name)
+			if err != nil {
+				t.Fatalf("No error expected, but received error: %v", err)
+			}
+			if !strings.Contains(b.String(), tc.want) {
+				t.Fatalf("Log doesn't contain the string: %s", tc.want)
+			}
+		})
+	}
+}
+
+func contextWithLogger(w io.Writer) context.Context {
+	encoder := zapcore.NewJSONEncoder(zap.NewDevelopmentConfig().EncoderConfig)
+	writer := zapcore.AddSync(w)
+	logger := zap.New(zapcore.NewCore(encoder, writer, zapcore.DebugLevel))
+	return ctxzap.ToContext(context.Background(), logger)
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
There's an unhandled error in the custom gRPC interceptor which logs user details. A `return` statement is required in the JWT parsing block. 

Fixes #420 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixes API Server panics when a bearer token with invalid JWT format is passed.
```