### PR TITLE
Add unique labels to api and watcher services

### DIFF
--- a/config/base/api.yaml
+++ b/config/base/api.yaml
@@ -79,6 +79,8 @@ kind: Service
 metadata:
   name: api-service
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-api
 spec:
   selector:
     app.kubernetes.io/name: tekton-results-api

--- a/config/base/watcher.yaml
+++ b/config/base/watcher.yaml
@@ -84,6 +84,8 @@ kind: Service
 metadata:
   name: watcher
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-results-watcher
 spec:
   ports:
   - name: metrics


### PR DESCRIPTION
# Changes

Added unique labels to the api and watcher services. One use case for having them is to match each service in ServiceMonitor for metrics collection. Both api and watcher already expose Prometheues metrics.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Added unique labels to api and watcher services.
```

