### PR TITLE
Allow users/integrators to pass arbitrary keys/values through Result and RecordSummary annotations

### DIFF
--- a/docs/watcher/README.md
+++ b/docs/watcher/README.md
@@ -36,3 +36,24 @@ precedence):
 
 If no annotation is detected, the Watcher will automatically generate a new
 Result name for the Object.
+
+## Passing arbitrary key/values to Results
+
+Users and/or integrators can pass arbitrary keys/values to Results by adding special annotations to PipelineRuns and TaskRuns:
+
+- `results.tekton.dev/resultAnnotations`: a JSON object (string->string) to be stored into thee `Result.Annotations` field.
+- `results.tekton.dev/recordSummaryAnnotations`: a JSON object (string->string) to be stored into thee `Result.Summary.Annotations` field.
+
+Once the Watcher detects those annotations in the observed object, it passes the keys/values to the respective fields of the underlying Result. Those annotations can be used to store relevant metadata (e.g. the Git commit SHA that triggered a PipelineRun) into Results and may be used later to retrieve the objects from the API server. For instance:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: hello-run-
+  annotations:
+    results.tekton.dev/resultAnnotations: |-
+      {"repo": "tektoncd/results", "commit": "1a6b908"}
+    results.tekton.dev/recordSummaryAnnotations: |-
+      {"foo": "bar"}
+```

--- a/pkg/watcher/reconciler/annotation/annotation.go
+++ b/pkg/watcher/reconciler/annotation/annotation.go
@@ -30,6 +30,14 @@ const (
 
 	Log = "results.tekton.dev/log"
 
+	// Integrators should add this annotation to objects in order to store
+	// arbitrary keys/values into the Result.Annotations field.
+	ResultAnnotations = "results.tekton.dev/resultAnnotations"
+
+	// Integrators should add this annotation to objects in order to store
+	// arbitrary keys/values into the Result.Summary.Annotations field.
+	RecordSummaryAnnotations = "results.tekton.dev/recordSummaryAnnotations"
+
 	// Annotation that signals to the controller that a given child object
 	// (e.g. TaskRun owned by a PipelineRun) is done and up to date in the
 	// API server and therefore, ready to be garbage collected.

--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -344,6 +344,39 @@ func TestEnsureResult_RecordSummaryUpdate(t *testing.T) {
 	}
 }
 
+func TestAnnotations(t *testing.T) {
+	ctx := logtest.TestContextWithLogger(t)
+	client := client(t)
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotation.ResultAnnotations:        `{"x": "y"}`,
+				annotation.RecordSummaryAnnotations: `{"foo":"bar"}`,
+			},
+			UID: types.UID("1"),
+		},
+	}
+
+	result, err := client.ensureResult(ctx, pipelineRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(map[string]string{
+		"x": "y",
+	}, result.Annotations); diff != "" {
+		t.Errorf("Result.Annotations: mismatch (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(map[string]string{
+		"foo": "bar",
+	}, result.Summary.Annotations); diff != "" {
+		t.Errorf("Result.Summary.Annotations: mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestUpsertRecord(t *testing.T) {
 	ctx := context.Background()
 	client := client(t)

--- a/test/e2e/testdata/pipelinerun.yaml
+++ b/test/e2e/testdata/pipelinerun.yaml
@@ -16,6 +16,11 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: hello
+  annotations:
+    results.tekton.dev/resultAnnotations: |-
+      {"repo": "tektoncd/results", "commit": "1a6b908"}
+    results.tekton.dev/recordSummaryAnnotations: |-
+      {"foo": "bar"}
 spec:
   pipelineSpec:
     tasks:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

Resolves https://github.com/tektoncd/results/issues/343.

Users can pass arbitrary keys/values to the Result.Annotations and
Result.Summary.Annotations fields by adding certain annotations to their
PipelineRuns and TaskRuns.


<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question,
tep -->

/feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Allow users/integrators to pass arbitrary keys/values to the Result.Annotations
and Result.Summary.Annotations fields, by adding the newly created annotations
results.tekton.dev/resultAnnotations and
results.tekton.dev/recordSummaryAnnotations to their PipelineRuns and TaskRuns.

Those annotations can be used to store relevant metadata (e.g. repository name,
Git commit SHA, pull request number among others) along with results into the
database, in order to be used later to retrieve those resources via the API.
```



<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->