### PR TITLE
Update kustomization files to latest standard

### DIFF
--- a/config/components/local-db/kustomization.yaml
+++ b/config/components/local-db/kustomization.yaml
@@ -22,5 +22,9 @@ kind: Component
 resources:
 - 201-sql-deployment.yaml
 
-patchesStrategicMerge:
-- api.yaml
+patches:
+- target:
+    kind: Deployment
+    name: api
+    namespace: tekton-pipelines
+  path: api.yaml

--- a/release/kustomization.yaml
+++ b/release/kustomization.yaml
@@ -1,6 +1,10 @@
-bases:
-  - ../config/overlays/default-local-db
-commonLabels:
   # Leave this field as an environment variable - this is templated out during
   # the release process to label all resources with the proper version.
-  app.kubernetes.io/version: devel
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../config/overlays/default-local-db
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/version: devel

--- a/test/e2e/kustomize/kustomization.yaml
+++ b/test/e2e/kustomize/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
 - ../../../config/overlays/default-local-db
 - rbac.yaml
 
-patchesJson6902:
+patches:
 - target:
     group: apps
     version: v1


### PR DESCRIPTION
This removes deprecation warning when applying kustomize to the files.

There should be no impact on any functionality. This was verified by making sure that the output of `kustomize build path/to/dir` was identical before and after the change.

The only change detected is that `config/components/local-db` would previously exit in error (`Error: no matches for Id Deployment.v1.apps/api.tekton-pipelines; failed to find unique target for patch Deployment.v1.apps/api.tekton-pipelines`), but is built successfully after the change. I believe this is not a breaking change as the kustomization.yaml in that directory was not intended to be used by itself.


# Changes

cleanup.

This PR cleans up the kustomization.yaml to remove deprecation warnings output by kustomize on the latest version (v5.0.1).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [X] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [X] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

No user facing changes.

```release-note
NONE
```
