### PR TITLE
Add overlay for enabling logs

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,35 @@
+# Tekton Results Kustomization
+
+The `/config` directory contains [kustomization](https://kustomize.io/) files
+that can be used to deploy Tekton Results on Kubernetes.
+The directories are structured as follows:
+
+- `base`: holds the core deployments and configurations for Results.
+- `components`: contains patches and additional resources to enable specific
+  features.
+- `overlays`: contains concrete implementations with a specific feature set
+  enabled.
+
+## Deploying with a Kustomization
+
+Results can be deployed from source by running the following:
+
+```sh
+kubectl kustomize config/overlays/<overlay> | ko apply -f - 
+```
+
+_Note: the steps above assume that you have a development environment set up
+with `kubectl` and `ko`. See [DEVELOPMENT.md](../docs/DEVELOPMENT.md) for more information._
+
+## Contributing a new Kustomization
+
+New Kustomizations should adhere to the following guidelines:
+
+- Functionality should be enabled through a kustomize [Component], added in the `components` directory.
+- An overlay that deploys Results with the capability enabled should be added to the `overlays` directory.
+- The overlay should contain a `kustomization.yaml` file that has the following:
+  - Begins with `../../base` as a Resource.
+  - Adds/enables functionality with components, referencing a directory in the `../../components` folder.
+  - Adds `../../components/metadata` as the final Component.
+
+Be sure to test your overlay and components before submitting a pull request.

--- a/config/components/logs-file/api.yaml
+++ b/config/components/logs-file/api.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/components/logs-file/api.yaml
+++ b/config/components/logs-file/api.yaml
@@ -1,0 +1,38 @@
+# Copyright 2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: tekton-pipelines
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: LOGS_API
+              value: "true"
+            - name: LOGS_TYPE
+              value: "File"
+            - name: LOGS_PATH
+              value: /tekton-results/logs
+          volumeMounts:
+            - name: pipeline-logs
+              mountPath: /tekton-results/logs
+      volumes:
+        - name: pipeline-logs
+          persistentVolumeClaim:
+            claimName: logs

--- a/config/components/logs-file/kustomization.yaml
+++ b/config/components/logs-file/kustomization.yaml
@@ -18,14 +18,11 @@
 # A RWO persistent volume claim of 1Gi is provided
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-
 resources:
-- pvc.yaml
-
+  - pvc.yaml
 patches:
-- path: api.yaml
-  target:
-    kind: Deployment
-    name: api
-    namespace: tekton-pipelines
-
+  - path: api.yaml
+    target:
+      kind: Deployment
+      name: api
+      namespace: tekton-pipelines

--- a/config/components/logs-file/kustomization.yaml
+++ b/config/components/logs-file/kustomization.yaml
@@ -1,0 +1,31 @@
+# Copyright 2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# logs-file Component
+#
+# Enables the logs API with block storage.
+# A RWO persistent volume claim of 1Gi is provided
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- pvc.yaml
+
+patches:
+- path: api.yaml
+  target:
+    kind: Deployment
+    name: api
+    namespace: tekton-pipelines
+

--- a/config/components/logs-file/pvc.yaml
+++ b/config/components/logs-file/pvc.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: logs
+  namespace: tekton-pipelines
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/config/components/logs-file/pvc.yaml
+++ b/config/components/logs-file/pvc.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/config/overlays/default-local-db/kustomization.yaml
+++ b/config/overlays/default-local-db/kustomization.yaml
@@ -17,10 +17,8 @@
 # Creates a Kustomization that deploys Results with a local PostGres database.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../../base
-
 components:
   - ../../components/local-db
   - ../../components/metadata

--- a/config/overlays/logs-local-db/kustomization.yaml
+++ b/config/overlays/logs-local-db/kustomization.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# logs-local-db overlay
+#
+# Creates a Kustomization that deploys Results with a local PostGres database
+# and log storage backed by a PersistentVolumeClaim
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/local-db
+  - ../../components/logs-file
+  - ../../components/metadata

--- a/config/overlays/logs-local-db/kustomization.yaml
+++ b/config/overlays/logs-local-db/kustomization.yaml
@@ -18,10 +18,8 @@
 # and log storage backed by a PersistentVolumeClaim
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
   - ../../base
-
 components:
   - ../../components/local-db
   - ../../components/logs-file


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

- Added a component to enable the logs feature with PVC-based storage.
- Added an overlay which deploys Results with a local database, and logs enabled with PVC storage.
- Added a README which documents how to deploy with a kustomization and contribute new kustomizations.

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
The logs feature with PVC storage can be deployed and tested through a new "logs-local-db" kustomization.
```

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
