### PR TITLE
Restore cleanup after e2e tests

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -25,7 +25,7 @@ set -x;
 cleanup() {
     kind delete cluster || true
 }
-#trap cleanup EXIT
+trap cleanup EXIT
 
 main() {
     export KO_DOCKER_REPO="kind.local"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The cleanup command was unintentionally commented out. Restoring the cleanup, so we don't have to do it manually after each run.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
