### PR TITLE
Add e2e tests for logs API

### DIFF
--- a/test/e2e/client/rest.go
+++ b/test/e2e/client/rest.go
@@ -23,6 +23,9 @@ const (
 	listRecordsPath   = "/apis/results.tekton.dev/v1alpha2/parents/%s/records"
 	getRecordPath     = "/apis/results.tekton.dev/v1alpha2/parents/%s"
 	deleteRecordPath  = "/apis/results.tekton.dev/v1alpha2/parents/%s"
+	listLogsPath      = "/apis/results.tekton.dev/v1alpha2/parents/%s/logs"
+	getLogPath        = "/apis/results.tekton.dev/v1alpha2/parents/%s"
+	deleteLogPath     = "/apis/results.tekton.dev/v1alpha2/parents/%s"
 )
 
 type RESTClient interface {
@@ -32,6 +35,9 @@ type RESTClient interface {
 	GetRecord(ctx context.Context, in *v1alpha2.GetRecordRequest) (*v1alpha2.Record, error)
 	ListRecords(ctx context.Context, in *v1alpha2.ListRecordsRequest) (*v1alpha2.ListRecordsResponse, error)
 	DeleteRecord(ctx context.Context, in *v1alpha2.DeleteRecordRequest) (*emptypb.Empty, error)
+	GetLog(ctx context.Context, in *v1alpha2.GetLogRequest) (*v1alpha2.Log, error)
+	ListLogs(ctx context.Context, in *v1alpha2.ListRecordsRequest) (*v1alpha2.ListRecordsResponse, error)
+	DeleteLog(ctx context.Context, in *v1alpha2.DeleteLogRequest) (*emptypb.Empty, error)
 }
 
 type restClient struct {
@@ -111,6 +117,21 @@ func (c *restClient) ListRecords(ctx context.Context, in *v1alpha2.ListRecordsRe
 func (c *restClient) DeleteRecord(ctx context.Context, in *v1alpha2.DeleteRecordRequest) (*emptypb.Empty, error) {
 	out := &emptypb.Empty{}
 	return &emptypb.Empty{}, c.send(ctx, http.MethodDelete, fmt.Sprintf(deleteRecordPath, in.Name), in, out)
+}
+
+func (c *restClient) GetLog(ctx context.Context, in *v1alpha2.GetLogRequest) (*v1alpha2.Log, error) {
+	out := &v1alpha2.Log{}
+	return out, c.send(ctx, http.MethodGet, fmt.Sprintf(getLogPath, in.Name), in, out)
+}
+
+func (c *restClient) ListLogs(ctx context.Context, in *v1alpha2.ListRecordsRequest) (*v1alpha2.ListRecordsResponse, error) {
+	out := &v1alpha2.ListRecordsResponse{}
+	return out, c.send(ctx, http.MethodGet, fmt.Sprintf(listLogsPath, in.Parent), in, out)
+}
+
+func (c *restClient) DeleteLog(ctx context.Context, in *v1alpha2.DeleteLogRequest) (*emptypb.Empty, error) {
+	out := &emptypb.Empty{}
+	return &emptypb.Empty{}, c.send(ctx, http.MethodDelete, fmt.Sprintf(deleteLogPath, in.Name), in, out)
 }
 
 func (c *restClient) send(ctx context.Context, method, path string, in, out proto.Message) error {

--- a/test/e2e/kind-cluster.yaml
+++ b/test/e2e/kind-cluster.yaml
@@ -22,10 +22,13 @@ nodes:
   image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
 
 # Merge the same definition as the control-plane to reuse the same Kindest image
-# in the data-plane. We'll set specific values of the data-plane afterwards.
+# in the data-plane. We'll set specific values of the data-plane afterward.
 # For further details on merge keys, please refer to https://learnxinyminutes.com/docs/yaml/.
 - <<: *node
   role: worker
+  extraMounts:
+    - hostPath: /tmp/tekton-results/data
+      containerPath: /data
   extraPortMappings:
     # API gRPC and REST server
     - containerPort: 30080

--- a/test/e2e/kustomize/kustomization.yaml
+++ b/test/e2e/kustomize/kustomization.yaml
@@ -15,6 +15,7 @@
 resources:
 - ../../../config/overlays/default-local-db
 - rbac.yaml
+- persistent-volume.yaml
 
 patches:
 - target:

--- a/test/e2e/kustomize/persistent-volume.yaml
+++ b/test/e2e/kustomize/persistent-volume.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tekton-results
+  namespace: tekton-pipelines
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /logs/


### PR DESCRIPTION
# Changes

Add e2e test for ListLogs, GetLog, DeleteLog using gRPC and REST.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```