### PR TITLE
Fix file permission mismatch for Postgres statefulset

### DIFF
--- a/config/components/local-db/201-sql-deployment.yaml
+++ b/config/components/local-db/201-sql-deployment.yaml
@@ -64,6 +64,8 @@ spec:
               - ALL
             add:
               - NET_BIND_SERVICE
+      securityContext:
+        fsGroup: 1001
   volumeClaimTemplates:
   - metadata:
       name: postgredb


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This fix the issue https://github.com/tektoncd/results/issues/522
Kubelet will modify the ownership and permissions of volume to 1001 which Postgres uses after setting `securityContext.fsGroup`.
This pr will helper users who want to try out Results not encounter file permission issues. 

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist
/kind bug
These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
