### PR TITLE
fix NOT operator in CEL filtering

### DIFF
--- a/pkg/api/server/cel2sql/convert_test.go
+++ b/pkg/api/server/cel2sql/convert_test.go
@@ -75,6 +75,16 @@ func TestConvertRecordExpressions(t *testing.T) {
 			want: "POSITION('foo' IN (data->'metadata'->>'name')) <> 0",
 		},
 		{
+			name: "not contains string function",
+			in:   `!(data.metadata.annotations.contains("foo"))`,
+			want: "NOT POSITION('foo' IN (data->'metadata'->>'annotations')) <> 0",
+		},
+		{
+			name: "complex not expressions",
+			in:   `!(data.metadata.annotations.contains("foo")) && data.metadata.name.endsWith("bar")`,
+			want: "NOT POSITION('foo' IN (data->'metadata'->>'annotations')) <> 0 AND (data->'metadata'->>'name') LIKE '%' || 'bar'",
+		},
+		{
 			name: "endsWith string function",
 			in:   `data.metadata.name.endsWith("bar")`,
 			want: "(data->'metadata'->>'name') LIKE '%' || 'bar'",
@@ -225,6 +235,11 @@ func TestConvertResultExpressions(t *testing.T) {
 			name: "Result.Summary.Annotations",
 			in:   `summary.annotations["branch"] == "main"`,
 			want: `recordsummary_annotations @> '{"branch":"main"}'::jsonb`,
+		},
+		{
+			name: "not Result.Summary.Annotations",
+			in:   `!(summary.annotations["branch"] == "main")`,
+			want: `NOT recordsummary_annotations @> '{"branch":"main"}'::jsonb`,
 		},
 		{
 			name: "Result.Summary.Annotations",

--- a/pkg/api/server/cel2sql/interpreter.go
+++ b/pkg/api/server/cel2sql/interpreter.go
@@ -293,7 +293,6 @@ func (i *interpreter) interpretUnaryCallExpr(expr *exprpb.Expr_Call) error {
 	if err := i.interpretExpr(expr.Args[0]); err != nil {
 		return err
 	}
-	i.query.WriteString(space)
 	return nil
 }
 

--- a/pkg/api/server/cel2sql/operators.go
+++ b/pkg/api/server/cel2sql/operators.go
@@ -20,13 +20,12 @@ import (
 
 var (
 	unaryOperators = map[string]string{
-		operators.Negate: "NOT",
+		operators.LogicalNot: "NOT",
 	}
 
 	binaryOperators = map[string]string{
 		operators.LogicalAnd:    "AND",
 		operators.LogicalOr:     "OR",
-		operators.LogicalNot:    "NOT",
 		operators.Equals:        "=",
 		operators.NotEquals:     "<>",
 		operators.Less:          "<",


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->
- NOT is correctly added to unary operators
- remove negate, it is not required/useful in non numeric filters/expressions
- added unit tests for NOT operator
- fixes #498

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
fix NOT operator crashing API server
```

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
