### PR TITLE
Fix status 404 for LIST records

### DIFF
--- a/pkg/api/server/v1alpha2/records.go
+++ b/pkg/api/server/v1alpha2/records.go
@@ -164,14 +164,6 @@ func (s *Server) ListRecords(ctx context.Context, req *pb.ListRecordsRequest) (*
 		return nil, err
 	}
 
-	// If we found no records, check if result exists so we can return NotFound
-	if len(records) == 0 {
-		_, err := getResultByParentName(s.db, parent, resultName)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &pb.ListRecordsResponse{
 		Records:       records,
 		NextPageToken: nextPageToken,

--- a/pkg/api/server/v1alpha2/records_test.go
+++ b/pkg/api/server/v1alpha2/records_test.go
@@ -387,13 +387,6 @@ func TestListRecords(t *testing.T) {
 			},
 		},
 		{
-			name: "missing parent",
-			req: &pb.ListRecordsRequest{
-				Parent: "foo/results/baz",
-			},
-			status: codes.NotFound,
-		},
-		{
 			name: "filter by record property",
 			req: &pb.ListRecordsRequest{
 				Parent: result.GetName(),
@@ -423,6 +416,17 @@ func TestListRecords(t *testing.T) {
 			want: &pb.ListRecordsResponse{
 				Records: sortedTaskRunsByUID,
 			},
+		},
+		{
+			name: "filter doesn't match any records",
+			req: &pb.ListRecordsRequest{
+				Parent: "foo/results/-",
+				Filter: `data.metadata.name == "unknown"`,
+			},
+			want: &pb.ListRecordsResponse{
+				Records: []*pb.Record{},
+			},
+			status: codes.OK,
 		},
 		// Errors
 		{


### PR DESCRIPTION
# Changes

Removed check from ListRecord method which searches for result name when the record lister returns empty array. This was incorrect because a "-" can be used as result name to list records across multiple results.

Fixes #560 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
ACTION REQUIRED: List records will return 200 - OK status and empty array in response when the filter criteria doesn't match any records
```