### PR TITLE
[CLI] Fix empty value for commandline flag

### DIFF
--- a/tools/tkn-results/cmd/root.go
+++ b/tools/tkn-results/cmd/root.go
@@ -79,6 +79,7 @@ func Root() *cobra.Command {
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	viper.BindPFlags(cmd.PersistentFlags())
+	cobra.OnInitialize(config.Init)
 
 	return cmd
 }

--- a/tools/tkn-results/internal/config/config.go
+++ b/tools/tkn-results/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"log"
 
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -52,7 +51,7 @@ type ServiceAccount struct {
 	Name      string
 }
 
-func init() {
+func Init() {
 	viper.SetConfigName("results")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath("$HOME/.config/tkn")
@@ -63,10 +62,6 @@ func init() {
 }
 
 func setConfig() error {
-	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-		return err
-	}
-
 	for k := range env {
 		if err := viper.BindEnv(k); err != nil {
 			return err

--- a/tools/tkn-results/internal/config/config_test.go
+++ b/tools/tkn-results/internal/config/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestParseFileConfig(t *testing.T) {
 	viper.SetConfigFile("./testdata/config.yaml")
-
+	setConfig()
 	testConfig(t, &Config{
 		Address: "a",
 		Token:   "b",
@@ -26,9 +26,9 @@ func TestParseFileConfig(t *testing.T) {
 
 func TestEnvVarConfig(t *testing.T) {
 	viper.SetConfigFile("./testdata/empty.yaml")
-
 	t.Setenv(EnvSSLRootFilePath, "a")
 	t.Setenv(EnvSSLServerNameOverride, "b")
+	setConfig()
 
 	testConfig(t, &Config{
 		SSL: SSLConfig{
@@ -39,9 +39,9 @@ func TestEnvVarConfig(t *testing.T) {
 }
 func TestFlagConfig(t *testing.T) {
 	viper.SetConfigFile("./testdata/config.yaml")
-
 	viper.Set("addr", "1")
 	viper.Set("token", "2")
+	setConfig()
 
 	testConfig(t, &Config{
 		Address: "1",


### PR DESCRIPTION
tkn-result was receiving the empty value from the commandline. This fixes that by initializing after flags are set.

Fixes: #582 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
