### PR TITLE
Fix flag passing when config file isn't present

### DIFF
--- a/tools/tkn-results/internal/config/config.go
+++ b/tools/tkn-results/internal/config/config.go
@@ -89,10 +89,9 @@ func setConfig() error {
 			return err
 		}
 	} else {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			return nil
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return err
 		}
-		return err
 	}
 
 	// Flags should override other values.


### PR DESCRIPTION
Don't return if the file is missing. CMD continues with the flag processing.
Fixes #617

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

