### PR TITLE
Make sure gRPC connection is closed

### DIFF
--- a/pkg/watcher/reconciler/dynamic/dynamic.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic.go
@@ -343,6 +343,8 @@ func (r *Reconciler) sendLog(ctx context.Context, o results.Object) error {
 
 func (r *Reconciler) streamLogs(ctx context.Context, o results.Object, logType, logName string) error {
 	logger := logging.FromContext(ctx)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	logsClient, err := r.resultsClient.UpdateLog(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create UpdateLog client: %v", err)


### PR DESCRIPTION
# Changes

In the error case the gRPC stream is closed. By using a new context and cancelling it when the function is finished we should guarentee that the gRPC context is closed.

Fixes #624

I have not tested this locally as I don't have the time to setup a local results build, and I am not sure how to test it with unit tests. 
