### PR TITLE
fix subgrouping not working in CEL filters

### DIFF
--- a/pkg/api/server/cel2sql/interpreter.go
+++ b/pkg/api/server/cel2sql/interpreter.go
@@ -290,9 +290,11 @@ func (i *interpreter) interpretUnaryCallExpr(expr *exprpb.Expr_Call) error {
 	sqlOperator := unaryOperators[expr.GetFunction()]
 	i.query.WriteString(sqlOperator)
 	i.query.WriteString(space)
+	i.query.WriteString("(")
 	if err := i.interpretExpr(expr.Args[0]); err != nil {
 		return err
 	}
+	i.query.WriteString(")")
 	return nil
 }
 
@@ -316,8 +318,10 @@ func (i *interpreter) interpretBinaryCallExpr(expr *exprpb.Expr) error {
 
 	sqlOperator := binaryOperators[function]
 	if (i.isString(arg1) || i.isString(arg2)) && isAddOperator(function) {
-		sqlOperator = posgresqlConcatOperator
+		sqlOperator = postgresqlConcatOperator
 	}
+
+	i.query.WriteString("(")
 
 	if err := i.interpretExpr(arg1); err != nil {
 		return err
@@ -344,6 +348,7 @@ func (i *interpreter) interpretBinaryCallExpr(expr *exprpb.Expr) error {
 			return err
 		}
 	}
+	i.query.WriteString(")")
 
 	return nil
 }

--- a/pkg/api/server/cel2sql/operators.go
+++ b/pkg/api/server/cel2sql/operators.go
@@ -39,7 +39,7 @@ var (
 		operators.Modulo:        "%",
 		operators.In:            "IN",
 	}
-	posgresqlConcatOperator = "||"
+	postgresqlConcatOperator = "||"
 )
 
 // isUnaryOperator returns true if the symbol in question is a CEL unary

--- a/pkg/api/server/v1alpha2/lister/filter_test.go
+++ b/pkg/api/server/v1alpha2/lister/filter_test.go
@@ -119,7 +119,7 @@ func TestFilterBuild(t *testing.T) {
 
 		testDB.Statement.Build("WHERE")
 
-		want := "WHERE recordsummary_status = 1"
+		want := "WHERE (recordsummary_status = 1)"
 		if got := testDB.Statement.SQL.String(); want != got {
 			t.Errorf("Want %q, but got %q", want, got)
 		}
@@ -142,7 +142,7 @@ func TestFilterBuild(t *testing.T) {
 
 		testDB.Statement.Build("WHERE")
 
-		want := "WHERE parent = ? AND id = ? AND recordsummary_status <> 1"
+		want := "WHERE parent = ? AND id = ? AND (recordsummary_status <> 1)"
 		if got := testDB.Statement.SQL.String(); want != got {
 			t.Errorf("Want %q, but got %q", want, got)
 		}

--- a/pkg/api/server/v1alpha2/lister/lister_test.go
+++ b/pkg/api/server/v1alpha2/lister/lister_test.go
@@ -89,7 +89,7 @@ func TestBuildQuery(t *testing.T) {
 
 		testDB.Statement.Build("WHERE", "ORDER BY", "LIMIT")
 
-		want := "WHERE (created_time, id) < (?, ?) AND parent = ? AND recordsummary_status = 1 ORDER BY created_time DESC,id DESC LIMIT 16"
+		want := "WHERE (created_time, id) < (?, ?) AND parent = ? AND (recordsummary_status = 1) ORDER BY created_time DESC,id DESC LIMIT 16"
 		if got := testDB.Statement.SQL.String(); want != got {
 			t.Errorf("Want %q, but got %q", want, got)
 		}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- CEL to SQL interpreter was not respecting subgroups given in CEL
  expression
- this commit fixes the subgrouping by containing unary and binary
  operators in parentheses
- fixes #620

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
fix subgroups not working in CEL filtering
```
