### PR TITLE
Update PostgreSQL image used in local-db deployment

### DIFF
--- a/config/components/local-db/201-sql-deployment.yaml
+++ b/config/components/local-db/201-sql-deployment.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: bitnami/postgresql@sha256:23b9a21460fefdd83accd0f864e734c88bebc67c86ee752a97b77dd4843907f0  # 13.3.0
+        image: bitnami/postgresql@sha256:35c57c2abb3775004d4a247b1119b2e436b0ef620c9236c64aebce373b58ff9a # 13.12.0
         envFrom:
           - configMapRef:
               name: tekton-results-postgres


### PR DESCRIPTION
# Changes

The 13.3.0 image in use was 2+ years old. Sticking to the same major version set to be supported until Nov '25. This also updates the base image from the older debian-10 to recent debian-11 one.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
