### PR TITLE
Use best practices for namespaces in kustomization

### DIFF
--- a/config/base/100-api-serviceaccount.yaml
+++ b/config/base/100-api-serviceaccount.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: api
-  namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39,7 +38,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: api
-    namespace: tekton-pipelines
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/base/100-watcher-serviceaccount.yaml
+++ b/config/base/100-watcher-serviceaccount.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: watcher
-  namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -55,7 +54,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: watcher
-    namespace: tekton-pipelines
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/base/api.yaml
+++ b/config/base/api.yaml
@@ -16,7 +16,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-api
 spec:
@@ -100,7 +99,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-service
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-api
 spec:

--- a/config/base/config-info.yaml
+++ b/config/base/config-info.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: info
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-info
 data:
@@ -31,7 +30,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: info
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-info
 rules:
@@ -48,7 +46,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: info
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-info
 subjects:

--- a/config/base/config-leader-election.yaml
+++ b/config/base/config-leader-election.yaml
@@ -15,7 +15,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-leader-election
 data:

--- a/config/base/config-logging.yaml
+++ b/config/base/config-logging.yaml
@@ -15,7 +15,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-logging
 data:

--- a/config/base/config-observability.yaml
+++ b/config/base/config-observability.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-observability
 data:

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -25,7 +25,6 @@ resources:
 configMapGenerator:
   # Create a ConfigMap containing the API configs.
   - name: api-config
-    namespace: tekton-pipelines
     files:
       - env/config
     options:

--- a/config/base/watcher.yaml
+++ b/config/base/watcher.yaml
@@ -16,7 +16,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: watcher
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-watcher
 spec:
@@ -83,7 +82,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: watcher
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-watcher
 spec:

--- a/config/components/local-db/201-sql-deployment.yaml
+++ b/config/components/local-db/201-sql-deployment.yaml
@@ -16,7 +16,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: postgres
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-postgres
 data:
@@ -26,7 +25,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: postgres
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-postgres
 spec:
@@ -77,7 +75,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres-service
-  namespace: tekton-pipelines
   labels:
     app.kubernetes.io/name: tekton-results-postgres
 spec:

--- a/config/components/local-db/api.yaml
+++ b/config/components/local-db/api.yaml
@@ -16,7 +16,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api
-  namespace: tekton-pipelines
 spec:
   template:
     spec:

--- a/config/components/local-db/kustomization.yaml
+++ b/config/components/local-db/kustomization.yaml
@@ -26,5 +26,4 @@ patches:
 - target:
     kind: Deployment
     name: api
-    namespace: tekton-pipelines
   path: api.yaml

--- a/config/components/logs-file/api.yaml
+++ b/config/components/logs-file/api.yaml
@@ -15,7 +15,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api
-  namespace: tekton-pipelines
 spec:
   template:
     spec:

--- a/config/components/logs-file/kustomization.yaml
+++ b/config/components/logs-file/kustomization.yaml
@@ -25,4 +25,3 @@ patches:
     target:
       kind: Deployment
       name: api
-      namespace: tekton-pipelines

--- a/config/components/logs-file/pvc.yaml
+++ b/config/components/logs-file/pvc.yaml
@@ -15,7 +15,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: logs
-  namespace: tekton-pipelines
 spec:
   resources:
     requests:

--- a/config/overlays/base-only/kustomization.yaml
+++ b/config/overlays/base-only/kustomization.yaml
@@ -17,6 +17,7 @@
 # Creates a Kustomization that deploys Results with no database or logs storage.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: tekton-pipelines
 resources:
   - ../../base
 components:

--- a/config/overlays/default-local-db/kustomization.yaml
+++ b/config/overlays/default-local-db/kustomization.yaml
@@ -17,6 +17,7 @@
 # Creates a Kustomization that deploys Results with a local PostGres database.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: tekton-pipelines
 resources:
   - ../../base
 components:

--- a/config/overlays/logs-local-db/kustomization.yaml
+++ b/config/overlays/logs-local-db/kustomization.yaml
@@ -18,6 +18,7 @@
 # and log storage backed by a PersistentVolumeClaim
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: tekton-pipelines
 resources:
   - ../../base
 components:

--- a/release/kustomization.yaml
+++ b/release/kustomization.yaml
@@ -2,6 +2,7 @@
   # the release process to label all resources with the proper version.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: tekton-pipelines
 resources:
 - ../config/overlays/default-local-db
 labels:

--- a/test/e2e/kustomize/kustomization.yaml
+++ b/test/e2e/kustomize/kustomization.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 resources:
 - ../../../config/overlays/default-local-db
 - rbac.yaml
@@ -22,11 +21,9 @@ patches:
     version: v1
     kind: Deployment
     name: tekton-results-watcher
-    namespace: tekton-pipelines
   path: watcher.yaml
 - target:
     version: v1
     kind: Service
     name: tekton-results-api-service
-    namespace: tekton-pipelines
   path: api-service.yaml


### PR DESCRIPTION
# Changes

This change will allow users that reference these kustomizations to more easily run this in any namespace of their choosing. Whenever namespaces are included in base resources, any patches also require the original namespace to be referenced in said patch.

In regards to ClusterRoles/ClusterRoleBindings, kustomize will automatically add the namespace where it is required automatically.

To allow the release artifacts to continue to set the tekton-pipelines namespace in it's output, the namespace has been set specifically for the release kustomziation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
