### PR TITLE
Drop NET_BIND_SERVICE cap as it isn't necessary

### DIFF
--- a/config/base/api.yaml
+++ b/config/base/api.yaml
@@ -86,8 +86,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                - NET_BIND_SERVICE
       volumes:
         - name: config
           configMap:

--- a/config/base/watcher.yaml
+++ b/config/base/watcher.yaml
@@ -72,8 +72,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                - NET_BIND_SERVICE
       volumes:
         - name: tls
           secret:


### PR DESCRIPTION
# Changes

NET_BIND_SERVICE is only necessary for applications the require access to privileged ports, eg. ports under 1024. Since we are using ports that any user may listen on, this is unnecessary

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Drop NET_BIND_SERVICE capability from results deployments.
```

