### PR TITLE
Add owner references check optional in watcher

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -66,6 +66,7 @@ var (
 	labelSelector           = flag.String("label_selector", "", "Selector (label query) to filter objects to be deleted. Matching objects must satisfy all labels requirements to be eligible for deletion")
 	requeueInterval         = flag.Duration("requeue_interval", 10*time.Minute, "How long the Watcher waits to reprocess keys on certain events (e.g. an object doesn't match the provided selectors)")
 	namespace               = flag.String("namespace", corev1.NamespaceAll, "Should the Watcher only watch a single namespace, then this value needs to be set to the namespace name otherwise leave it empty.")
+	checkOwner              = flag.Bool("check_owner", true, "If enabled, owner references will be checked while deleting objects")
 )
 
 func main() {
@@ -97,6 +98,7 @@ func main() {
 		DisableAnnotationUpdate:      *disableCRDUpdate,
 		CompletedResourceGracePeriod: *completedRunGracePeriod,
 		RequeueInterval:              *requeueInterval,
+		CheckOwner:                   *checkOwner,
 	}
 
 	if selector := *labelSelector; selector != "" {

--- a/docs/watcher/README.md
+++ b/docs/watcher/README.md
@@ -57,3 +57,9 @@ metadata:
     results.tekton.dev/recordSummaryAnnotations: |-
       {"foo": "bar"}
 ```
+
+## Resource Deletion
+
+When the command line flag is `completed_run_grace_period` is set to any value other than `0`, resources will be deleted after the specified duration in the flag, calculated from the time of completion. If the value is < `0`, Runs will be deleted immediately after completion or failure.
+
+The flag `check_owner` allows additional check before deleting a resource. If set `true`, resources with any owner references set will not be deleted. When the flag is `false`, owner references will be not be checked before deletion. 

--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// How long the controller waits to reprocess keys on certain events
 	// (e.g. an object doesn't match the provided label selectors).
 	RequeueInterval time.Duration
+
+	// Check owner reference when deleting objects. By default, objects having owner references set won't be deleted.
+	CheckOwner bool
 }
 
 // GetDisableAnnotationUpdate returns whether annotation updates should be

--- a/pkg/watcher/reconciler/dynamic/dynamic.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic.go
@@ -182,7 +182,7 @@ func (r *Reconciler) deleteUponCompletion(ctx context.Context, o results.Object)
 		return nil
 	}
 
-	if ownerReferences := o.GetOwnerReferences(); len(ownerReferences) > 0 {
+	if ownerReferences := o.GetOwnerReferences(); r.cfg.CheckOwner && len(ownerReferences) > 0 {
 		logger.Debugw("Resource is owned by another object, deferring deletion to parent resource(s)", zap.Any("results.tekton.dev/ownerReferences", ownerReferences))
 		return nil
 	}


### PR DESCRIPTION
As per discussion in #648 

# Changes
This PR makes the owner reference check in watcher optional.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
"check_owner" command line flag allows the Owner References check to be optional while deleting resources.
```
