### PR TITLE
updated deprecated field in docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -581,16 +581,16 @@ To request a list of objects with a specific order, include a `order_by` query
 parameter in your request. Pass it the name of the field to be ordered on.
 Multiple fields can be specified with a comma-separated list. Examples:
 
-- `created_time`
-- `updated_time asc`
-- `created_time desc, updated_time asc`
+- `create_time`
+- `update_time asc`
+- `create_time desc, update_time asc`
 
 Fields supported in `order_by`:
 
 | Field Name     |
 | -------------- |
-| `created_time` |
-| `updated_time` |
+| `create_time` |
+| `update_time` |
 
 ## Pagination
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updating documentation for sorting query results. Documentation was still referring to deprecated field names `created_at` and `updated_at`.

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
