### PR TITLE
handle all terminal states when processing logs

### DIFF
--- a/pkg/watcher/reconciler/dynamic/dynamic.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic.go
@@ -285,7 +285,7 @@ func (r *Reconciler) sendLog(ctx context.Context, o results.Object) error {
 		(GVK.Kind == "TaskRun" || GVK.Kind == "PipelineRun") &&
 		condition != nil &&
 		condition.Type == "Succeeded" &&
-		(condition.Reason == "Succeeded" || condition.Reason == "Completed" || condition.Reason == "Failed") {
+		!condition.IsUnknown() {
 
 		rec, err := r.resultsClient.GetLogRecord(ctx, o)
 		if err != nil {


### PR DESCRIPTION
# Changes

Fixes https://github.com/tektoncd/results/issues/698

/kind bug

The prior check for whether the results Object had completed did not account for objects which had been cancelled.  Rather then check every conceivable terminal state, this commit instead makes sure it is not in the Unknown state, which means it has not terminated.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ /] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ /] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [/ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ /] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ /] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ n/a] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
Tekton results will now store logs when the supported runs in question are cancelled
```


