### PR TITLE
fix: prevent panic when a record Summary is not a valid object

### DIFF
--- a/pkg/watcher/results/results.go
+++ b/pkg/watcher/results/results.go
@@ -146,7 +146,7 @@ func (c *Client) ensureResult(ctx context.Context, o Object, opts ...grpc.CallOp
 				return nil, err
 			}
 			var annotations map[string]string
-			if curr != nil && len(curr.Summary.Annotations) != 0 {
+			if curr != nil && curr.Summary != nil && len(curr.Summary.Annotations) != 0 {
 				copyKeys(recordSummaryAnnotations, curr.Summary.Annotations)
 				annotations = curr.Summary.Annotations
 			} else {


### PR DESCRIPTION
# Changes

There were occurrences of runtime panic due to a nil pointer dereference prior to the code modification suggested in this PR.
It specifically occurs because the code does not currently handle cases where curr.Summary could be nil, leading to a crash if it tries to access the Annotations field on a nil object.
Here's a panic instance:
```
{"severity":"debug","timestamp":"2024-02-02T11:35:16.921+0530","logger":"watcher","caller":"results/results.go:305","message":"Record doesn't exist yet - creating","commit":"e1f8cbc-dirty","knative.dev/traceid":"0135a529-2d00-46b0-bf29-4527b54cddb6","knative.dev/key":"test/hello-dcz2q-hello","results.tekton.dev/kind":"TaskRun","results.tekton.dev/record":"test/results/502876c1-6aa0-4371-85ab-cfa2ae89696b/records/8340355b-ec4d-4aab-88f6-f79f9b0a008b"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4129095]

goroutine 77 [running]:
github.com/tektoncd/results/pkg/watcher/results.(*Client).ensureResult(0xc00052e900, {0x4cb6780, 0xc000d04f90}, {0x4cd7af0, 0xc0004aec80}, {0x0, 0x0, 0x0})
	/home/ramesses/Work/redhat/results/pkg/watcher/results/results.go:150 +0xff5
github.com/tektoncd/results/pkg/watcher/results.(*Client).Put(0xc00052e900, {0x4cb6780, 0xc000d04f90}, {0x4cd7af0, 0xc0004aec80}, {0x0, 0x0, 0x0})
	/home/ramesses/Work/redhat/results/pkg/watcher/results/results.go:81 +0xcf
github.com/tektoncd/results/pkg/watcher/reconciler/dynamic.(*Reconciler).Reconcile(0xc000d04f60, {0x4cb6780, 0xc000d04f90}, {0x4cd7af0, 0xc0004aec80})
	/home/ramesses/Work/redhat/results/pkg/watcher/reconciler/dynamic/dynamic.go:110 +0x56a
github.com/tektoncd/results/pkg/watcher/reconciler/pipelinerun.(*Reconciler).Reconcile(0xc000b3c1e0, {0x4cb6780, 0xc000d04f00}, {0xc000e00080, 0x10})
	/home/ramesses/Work/redhat/results/pkg/watcher/reconciler/pipelinerun/reconciler.go:100 +0xadf
knative.dev/pkg/controller.(*Impl).processNextWorkItem(0xc000b187e0)
	/home/ramesses/Work/redhat/results/vendor/knative.dev/pkg/controller/controller.go:542 +0x7b8
knative.dev/pkg/controller.(*Impl).RunContext.func3()
	/home/ramesses/Work/redhat/results/vendor/knative.dev/pkg/controller/controller.go:491 +0xab
created by knative.dev/pkg/controller.(*Impl).RunContext in goroutine 206
	/home/ramesses/Work/redhat/results/vendor/knative.dev/pkg/controller/controller.go:489 +0x5c5
```

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
