### PR TITLE
fix: add stored status explicitly for logs

### DIFF
--- a/pkg/api/server/v1alpha2/log/file.go
+++ b/pkg/api/server/v1alpha2/log/file.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tektoncd/results/pkg/api/server/config"
 
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 )
 
 type fileStream struct {
@@ -20,7 +20,7 @@ type fileStream struct {
 }
 
 // NewFileStream returns a LogStreamer that streams directly from a log file on local disk.
-func NewFileStream(ctx context.Context, log *v1alpha2.Log, config *config.Config) (Stream, error) {
+func NewFileStream(ctx context.Context, log *v1alpha3.Log, config *config.Config) (Stream, error) {
 	if log.Status.Path == "" {
 		filePath, err := FilePath(log)
 		if err != nil {
@@ -42,7 +42,7 @@ func NewFileStream(ctx context.Context, log *v1alpha2.Log, config *config.Config
 }
 
 func (*fileStream) Type() string {
-	return string(v1alpha2.FileLogType)
+	return string(v1alpha3.FileLogType)
 }
 
 // WriteTo reads the contents of the TaskRun log file and writes them to the provided writer, such

--- a/pkg/api/server/v1alpha2/log/gcs.go
+++ b/pkg/api/server/v1alpha2/log/gcs.go
@@ -27,7 +27,7 @@ import (
 	"os"
 
 	server "github.com/tektoncd/results/pkg/api/server/config"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 
 	"gocloud.dev/blob/gcsblob"
 	"gocloud.dev/gcp"
@@ -41,7 +41,7 @@ type gcsStream struct {
 }
 
 // NewGCSStream returns a log streamer for the GCS storage type.
-func NewGCSStream(ctx context.Context, log *v1alpha2.Log, config *server.Config) (Stream, error) {
+func NewGCSStream(ctx context.Context, log *v1alpha3.Log, config *server.Config) (Stream, error) {
 	if log.Status.Path == "" {
 		filePath, err := FilePath(log)
 		if err != nil {
@@ -89,7 +89,7 @@ func getGCSClient(ctx context.Context, cfg *server.Config) (*gcp.HTTPClient, err
 }
 
 func (*gcsStream) Type() string {
-	return string(v1alpha2.GCSLogType)
+	return string(v1alpha3.GCSLogType)
 }
 
 func (gcs *gcsStream) WriteTo(w io.Writer) (int64, error) {

--- a/pkg/api/server/v1alpha2/log/log.go
+++ b/pkg/api/server/v1alpha2/log/log.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tektoncd/results/pkg/api/server/config"
 	"github.com/tektoncd/results/pkg/api/server/db"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -64,13 +64,13 @@ type Stream interface {
 //
 // NewStream may mutate the Log object's status, to provide implementation information
 // for reading and writing files.
-func NewStream(ctx context.Context, log *v1alpha2.Log, config *config.Config) (Stream, error) {
+func NewStream(ctx context.Context, log *v1alpha3.Log, config *config.Config) (Stream, error) {
 	switch log.Spec.Type {
-	case v1alpha2.FileLogType:
+	case v1alpha3.FileLogType:
 		return NewFileStream(ctx, log, config)
-	case v1alpha2.S3LogType:
+	case v1alpha3.S3LogType:
 		return NewS3Stream(ctx, log, config)
-	case v1alpha2.GCSLogType:
+	case v1alpha3.GCSLogType:
 		return NewGCSStream(ctx, log, config)
 	}
 	return nil, fmt.Errorf("log streamer type %s is not supported", log.Spec.Type)
@@ -78,7 +78,7 @@ func NewStream(ctx context.Context, log *v1alpha2.Log, config *config.Config) (S
 
 // ToStorage converts log record to marshaled json bytes
 func ToStorage(record *pb.Record, config *config.Config) ([]byte, error) {
-	log := &v1alpha2.Log{}
+	log := &v1alpha3.Log{}
 	if len(record.GetData().Value) > 0 {
 		err := json.Unmarshal(record.GetData().Value, log)
 		if err != nil {
@@ -88,7 +88,7 @@ func ToStorage(record *pb.Record, config *config.Config) ([]byte, error) {
 	log.Default()
 
 	if log.Spec.Type == "" {
-		log.Spec.Type = v1alpha2.LogType(config.LOGS_TYPE)
+		log.Spec.Type = v1alpha3.LogType(config.LOGS_TYPE)
 		if len(log.Spec.Type) == 0 {
 			return nil, fmt.Errorf("failed to set up log storage type to spec")
 		}
@@ -100,11 +100,11 @@ func ToStorage(record *pb.Record, config *config.Config) ([]byte, error) {
 // First one is a new log streamer created by log record.
 // Second one is log API resource retrieved from log record.
 // Third argument is an error.
-func ToStream(ctx context.Context, record *db.Record, config *config.Config) (Stream, *v1alpha2.Log, error) {
-	if record.Type != v1alpha2.LogRecordType {
+func ToStream(ctx context.Context, record *db.Record, config *config.Config) (Stream, *v1alpha3.Log, error) {
+	if record.Type != v1alpha3.LogRecordType {
 		return nil, nil, fmt.Errorf("record type %s cannot stream logs", record.Type)
 	}
-	log := &v1alpha2.Log{}
+	log := &v1alpha3.Log{}
 	err := json.Unmarshal(record.Data, log)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not decode Log record: %w", err)
@@ -115,7 +115,7 @@ func ToStream(ctx context.Context, record *db.Record, config *config.Config) (St
 
 // FilePath returns file path to store log. This file path can be
 // path in the real file system or virtual value depending on storage type.
-func FilePath(log *v1alpha2.Log) (string, error) {
+func FilePath(log *v1alpha3.Log) (string, error) {
 	filePath := filepath.Join(log.GetNamespace(), string(log.GetUID()), log.Name)
 	if filePath == "" {
 		return "", fmt.Errorf("invalid file path")

--- a/pkg/api/server/v1alpha2/log/log_test.go
+++ b/pkg/api/server/v1alpha2/log/log_test.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/tektoncd/results/pkg/api/server/config"
 	"github.com/tektoncd/results/pkg/api/server/db"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 	"github.com/tektoncd/results/pkg/internal/jsonutil"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFilePath(t *testing.T) {
-	log := &v1alpha2.Log{
+	log := &v1alpha3.Log{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "test-log",
 			Namespace: "test",
@@ -112,13 +112,13 @@ func TestParseName(t *testing.T) {
 }
 
 func TestToStorage(t *testing.T) {
-	log := &v1alpha2.Log{
+	log := &v1alpha3.Log{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "test-taskrun-log",
 		},
-		Spec: v1alpha2.LogSpec{
-			Type: v1alpha2.FileLogType,
-			Resource: v1alpha2.Resource{
+		Spec: v1alpha3.LogSpec{
+			Type: v1alpha3.FileLogType,
+			Resource: v1alpha3.Resource{
 				Name: "test-taskrun",
 			},
 		},
@@ -133,7 +133,7 @@ func TestToStorage(t *testing.T) {
 	rec := &pb.Record{
 		Name: "test-log",
 		Data: &pb.Any{
-			Type:  v1alpha2.LogRecordType,
+			Type:  v1alpha3.LogRecordType,
 			Value: want,
 		},
 	}
@@ -183,16 +183,16 @@ func TestToStream(t *testing.T) {
 				ResultName: "push-main",
 				Name:       "taskrun-compile-log",
 				ID:         "a",
-				Type:       v1alpha2.LogRecordType,
-				Data: jsonutil.AnyBytes(t, &v1alpha2.Log{
+				Type:       v1alpha3.LogRecordType,
+				Data: jsonutil.AnyBytes(t, &v1alpha3.Log{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "test-log",
 						Namespace: "test",
 						UID:       "test-uid",
 					},
-					Spec: v1alpha2.LogSpec{
-						Type: v1alpha2.FileLogType,
-						Resource: v1alpha2.Resource{
+					Spec: v1alpha3.LogSpec{
+						Type: v1alpha3.FileLogType,
+						Resource: v1alpha3.Resource{
 							Namespace: "app",
 							Name:      "taskrun-compile",
 						},
@@ -200,7 +200,7 @@ func TestToStream(t *testing.T) {
 				}),
 			},
 			want: &mockStream{
-				streamType: string(v1alpha2.FileLogType),
+				streamType: string(v1alpha3.FileLogType),
 			},
 		},
 		{

--- a/pkg/api/server/v1alpha2/log/s3.go
+++ b/pkg/api/server/v1alpha2/log/s3.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	server "github.com/tektoncd/results/pkg/api/server/config"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 )
 
 const (
@@ -49,7 +49,7 @@ type s3Stream struct {
 }
 
 // NewS3Stream returns a log streamer for the S3 log storage type.
-func NewS3Stream(ctx context.Context, log *v1alpha2.Log, config *server.Config) (Stream, error) {
+func NewS3Stream(ctx context.Context, log *v1alpha3.Log, config *server.Config) (Stream, error) {
 	if log.Status.Path == "" {
 		filePath, err := FilePath(log)
 		if err != nil {
@@ -130,7 +130,7 @@ func initConfig(ctx context.Context, cfg *server.Config) (*s3.Client, error) {
 }
 
 func (*s3Stream) Type() string {
-	return string(v1alpha2.S3LogType)
+	return string(v1alpha3.S3LogType)
 }
 
 func (s3s *s3Stream) WriteTo(w io.Writer) (n int64, err error) {

--- a/pkg/api/server/v1alpha2/logs_test.go
+++ b/pkg/api/server/v1alpha2/logs_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/log"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 	"github.com/tektoncd/results/pkg/internal/jsonutil"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/grpc/codes"
@@ -128,19 +128,20 @@ func TestGetLog(t *testing.T) {
 		Record: &pb.Record{
 			Name: record.FormatName(res.GetName(), "baz"),
 			Data: &pb.Any{
-				Type: v1alpha2.LogRecordType,
-				Value: jsonutil.AnyBytes(t, &v1alpha2.Log{
-					Spec: v1alpha2.LogSpec{
-						Resource: v1alpha2.Resource{
+				Type: v1alpha3.LogRecordType,
+				Value: jsonutil.AnyBytes(t, &v1alpha3.Log{
+					Spec: v1alpha3.LogSpec{
+						Resource: v1alpha3.Resource{
 							Namespace: "foo",
 							Name:      "baz",
 						},
-						Type: v1alpha2.FileLogType,
+						Type: v1alpha3.FileLogType,
 					},
 					// To avoid defaulting behavior, explicitly set the file path in status
-					Status: v1alpha2.LogStatus{
-						Path: logFile.Name(),
-						Size: 1024,
+					Status: v1alpha3.LogStatus{
+						Path:     logFile.Name(),
+						Size:     1024,
+						IsStored: true,
 					},
 				}),
 			},
@@ -197,21 +198,21 @@ func TestUpdateLog(t *testing.T) {
 		Record: &pb.Record{
 			Name: recordName,
 			Data: &pb.Any{
-				Type: v1alpha2.LogRecordType,
-				Value: jsonutil.AnyBytes(t, &v1alpha2.Log{
+				Type: v1alpha3.LogRecordType,
+				Value: jsonutil.AnyBytes(t, &v1alpha3.Log{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-name",
 						UID:  "test-uid",
 					},
-					Spec: v1alpha2.LogSpec{
-						Resource: v1alpha2.Resource{
+					Spec: v1alpha3.LogSpec{
+						Resource: v1alpha3.Resource{
 							Namespace: "foo",
 							Name:      "baz",
 						},
-						Type: v1alpha2.FileLogType,
+						Type: v1alpha3.FileLogType,
 					},
 					// To avoid defaulting behavior, explicitly set the file path in status
-					Status: v1alpha2.LogStatus{
+					Status: v1alpha3.LogStatus{
 						Path: path,
 					},
 				}),
@@ -276,8 +277,8 @@ func TestListLogs(t *testing.T) {
 			Record: &pb.Record{
 				Name: fmt.Sprintf("%s/records/%d", res.GetName(), i),
 				Data: &pb.Any{
-					Type: v1alpha2.LogRecordType,
-					Value: jsonutil.AnyBytes(t, &v1alpha2.Log{
+					Type: v1alpha3.LogRecordType,
+					Value: jsonutil.AnyBytes(t, &v1alpha3.Log{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: fmt.Sprintf("%d", i),
 						},
@@ -374,12 +375,12 @@ func TestListLogs(t *testing.T) {
 			name: "filter and page size",
 			req: &pb.ListRecordsRequest{
 				Parent:   res.GetName(),
-				Filter:   `data_type == "results.tekton.dev/v1alpha2.Log"`,
+				Filter:   `data_type == "results.tekton.dev/v1alpha3.Log"`,
 				PageSize: 1,
 			},
 			want: &pb.ListRecordsResponse{
 				Records:       records[:1],
-				NextPageToken: pagetoken(t, records[1].GetUid(), `data_type == "results.tekton.dev/v1alpha2.Log"`),
+				NextPageToken: pagetoken(t, records[1].GetUid(), `data_type == "results.tekton.dev/v1alpha3.Log"`),
 			},
 		},
 		{
@@ -533,8 +534,8 @@ func TestListLogs_multiresult(t *testing.T) {
 					Record: &pb.Record{
 						Name: record.FormatName(res.GetName(), strconv.Itoa(k)),
 						Data: &pb.Any{
-							Type: v1alpha2.LogRecordType,
-							Value: jsonutil.AnyBytes(t, &v1alpha2.Log{
+							Type: v1alpha3.LogRecordType,
+							Value: jsonutil.AnyBytes(t, &v1alpha3.Log{
 								ObjectMeta: metav1.ObjectMeta{
 									Name: fmt.Sprintf("%d", k),
 								},
@@ -609,17 +610,17 @@ func TestDeleteLog(t *testing.T) {
 		Record: &pb.Record{
 			Name: record.FormatName(res.GetName(), "baz"),
 			Data: &pb.Any{
-				Type: v1alpha2.LogRecordType,
-				Value: jsonutil.AnyBytes(t, &v1alpha2.Log{
-					Spec: v1alpha2.LogSpec{
-						Resource: v1alpha2.Resource{
+				Type: v1alpha3.LogRecordType,
+				Value: jsonutil.AnyBytes(t, &v1alpha3.Log{
+					Spec: v1alpha3.LogSpec{
+						Resource: v1alpha3.Resource{
 							Namespace: "foo",
 							Name:      "baz",
 						},
-						Type: v1alpha2.FileLogType,
+						Type: v1alpha3.FileLogType,
 					},
 					// To avoid defaulting behavior, explicitly set the file path in status
-					Status: v1alpha2.LogStatus{
+					Status: v1alpha3.LogStatus{
 						Path: logFile.Name(),
 						Size: 1024,
 					},

--- a/pkg/api/server/v1alpha2/record/record.go
+++ b/pkg/api/server/v1alpha2/record/record.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/tektoncd/results/pkg/api/server/config"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/log"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 
 	"github.com/google/cel-go/cel"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -98,7 +98,7 @@ func ToStorage(parent, resultName, resultID, name string, r *pb.Record, config *
 	if r.UpdateTime.IsValid() {
 		dbr.UpdatedTime = r.UpdateTime.AsTime()
 	}
-	if dbr.Type == v1alpha2.LogRecordType {
+	if dbr.Type == v1alpha3.LogRecordType {
 		data, err := log.ToStorage(r, config)
 		if err != nil {
 			return nil, err
@@ -184,8 +184,8 @@ func validateData(m *pb.Any) error {
 		return json.Unmarshal(m.GetValue(), &v1beta1.TaskRun{})
 	case "pipeline.tekton.dev/PipelineRun":
 		return json.Unmarshal(m.GetValue(), &v1beta1.PipelineRun{})
-	case "results.tekton.dev/v1alpha2.Log":
-		return json.Unmarshal(m.GetValue(), &v1alpha2.Log{})
+	case "results.tekton.dev/v1alpha3.Log":
+		return json.Unmarshal(m.GetValue(), &v1alpha3.Log{})
 	default:
 		// If it's not a well known type, just check that the message is a valid JSON document.
 		return json.Unmarshal(m.GetValue(), &json.RawMessage{})

--- a/pkg/apis/v1alpha3/types.go
+++ b/pkg/apis/v1alpha3/types.go
@@ -1,4 +1,4 @@
-package v1alpha2
+package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -6,7 +6,7 @@ import (
 )
 
 // LogRecordType represents the API resource type for Tekton log records.
-const LogRecordType = "results.tekton.dev/v1alpha2.Log"
+const LogRecordType = "results.tekton.dev/v1alpha3.Log"
 
 // Log represents the API resource for Tekton results Log.
 type Log struct {
@@ -49,12 +49,13 @@ const (
 
 // LogStatus defines the current status of the log resource.
 type LogStatus struct {
-	Path string `json:"path,omitempty"`
-	Size int64  `json:"size"`
+	Path     string `json:"path,omitempty"`
+	Size     int64  `json:"size"`
+	IsStored bool   `json:"isStored"`
 }
 
 // Default sets up default values for Log TypeMeta, such as API version and kind.
 func (t *Log) Default() {
 	t.TypeMeta.Kind = "Log"
-	t.TypeMeta.APIVersion = "results.tekton.dev/v1alpha2"
+	t.TypeMeta.APIVersion = "results.tekton.dev/v1alpha3"
 }

--- a/pkg/watcher/convert/convert.go
+++ b/pkg/watcher/convert/convert.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -62,14 +62,14 @@ func ToLogProto(in metav1.Object, kind, name string) (*rpb.Any, error) {
 	if err != nil {
 		return nil, err
 	}
-	log := &v1alpha2.Log{
+	log := &v1alpha3.Log{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: in.GetNamespace(),
 			Name:      fmt.Sprintf("%s-log", in.GetName()),
 			UID:       types.UID(uid),
 		},
-		Spec: v1alpha2.LogSpec{
-			Resource: v1alpha2.Resource{
+		Spec: v1alpha3.LogSpec{
+			Resource: v1alpha3.Resource{
 				Kind:      kind,
 				Namespace: in.GetNamespace(),
 				Name:      in.GetName(),
@@ -83,7 +83,7 @@ func ToLogProto(in metav1.Object, kind, name string) (*rpb.Any, error) {
 		return nil, err
 	}
 	return &rpb.Any{
-		Type:  v1alpha2.LogRecordType,
+		Type:  v1alpha3.LogRecordType,
 		Value: b,
 	}, nil
 }

--- a/pkg/watcher/convert/convert_test.go
+++ b/pkg/watcher/convert/convert_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tektoncd/results/pkg/apis/v1alpha2"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/google/go-cmp/cmp"
@@ -320,7 +320,7 @@ func toJSON(v any) []byte {
 }
 
 func TestToLogProto(t *testing.T) {
-	wantType := "results.tekton.dev/v1alpha2.Log"
+	wantType := "results.tekton.dev/v1alpha3.Log"
 	recordName := "foo/results/bar/records/baz"
 	for _, tc := range []struct {
 		in   metav1.Object
@@ -336,14 +336,14 @@ func TestToLogProto(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%s Log", tc.kind), func(t *testing.T) {
-			log := &v1alpha2.Log{
+			log := &v1alpha3.Log{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: tc.in.GetNamespace(),
 					Name:      fmt.Sprintf("%s-log", tc.in.GetName()),
 					UID:       types.UID("baz"),
 				},
-				Spec: v1alpha2.LogSpec{
-					Resource: v1alpha2.Resource{
+				Spec: v1alpha3.LogSpec{
+					Resource: v1alpha3.Resource{
 						Kind:      tc.kind,
 						Namespace: tc.in.GetNamespace(),
 						Name:      tc.in.GetName(),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any-Ideally you can get that description straight from
your descriptive commit message(s)! -->

- added IsStored to LogStatus
- update the API Version to v1alpha3
- v1alpha2 will be removed later
- this will serve as a clear indication of if the logs have been stored, partially stored or not stored at all.
- this can be used to mitigate the race condition between pruning of runs and log storage.

Signed-off-by: Avinal Kumar <avinal@redhat.com>
<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: - the log status contains an extra field called `is_stored` to denote if the logs have been correctly stored or not
- Breaking Change: API Version is updated to v1alpha3 from v1alpha2 
```


