### PR TITLE
fix syntax error with tekton results data model diagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,9 +77,6 @@ sequenceDiagram
 ## Data Model
 
 ```mermaid
----
-title: Tekton Results Data Model 
----
 graph BT
   B(TaskRun) --> |Record| A[Result]
   C(Log) --> |Record| A


### PR DESCRIPTION
# Changes

Mermaid does not support titles for `graph`. If we want to have a title we would need to proceed with:
```
graph BT
  title[Tekton Results Data Model]
  B(TaskRun) --> |Record| A[Result]
  C(Log) --> |Record| A
  D(PipelineRun) --> |Record| A
```
which would produce:
<img width="645" alt="image" src="https://github.com/tektoncd/results/assets/104373159/7796f559-650c-45e6-84cd-f3619c321c01">

However, there is a header just above the diagram so the title is redundant.

I propose that we remove the title completely.

/kind docs

# Release Notes

```release-note
docs: Fix mermaid.js diagram for the Results data model
```