### PR TITLE
[WIP] Logs API apporach to fix race condition due to pruning in results watcher

### DIFF
--- a/pkg/api/server/v1alpha2/logs_test.go
+++ b/pkg/api/server/v1alpha2/logs_test.go
@@ -139,8 +139,9 @@ func TestGetLog(t *testing.T) {
 					},
 					// To avoid defaulting behavior, explicitly set the file path in status
 					Status: v1alpha2.LogStatus{
-						Path: logFile.Name(),
-						Size: 1024,
+						Path:     logFile.Name(),
+						Size:     1024,
+						IsStored: true,
 					},
 				}),
 			},

--- a/pkg/apis/v1alpha2/types.go
+++ b/pkg/apis/v1alpha2/types.go
@@ -49,8 +49,9 @@ const (
 
 // LogStatus defines the current status of the log resource.
 type LogStatus struct {
-	Path string `json:"path,omitempty"`
-	Size int64  `json:"size"`
+	Path     string `json:"path,omitempty"`
+	Size     int64  `json:"size"`
+	IsStored bool   `json:"isStored"`
 }
 
 // Default sets up default values for Log TypeMeta, such as API version and kind.

--- a/pkg/watcher/reconciler/dynamic/dynamic_test.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic_test.go
@@ -207,6 +207,16 @@ func TestReconcile_TaskRun(t *testing.T) {
 	})
 
 	t.Run("delete object once grace period elapses", func(t *testing.T) {
+		// Recreate the object to retest the deletion
+		if err := trclient.Delete(ctx, taskrun.GetName(), metav1.DeleteOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := trclient.Create(ctx, taskrun, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		// disable logs client so that requeuing due to missing logs
+		// won't interfere with this test
+		r.resultsClient.LogsClient = nil
 		// Enable object deletion, re-reconcile
 		cfg.CompletedResourceGracePeriod = 1 * time.Second
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #514
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Free up resources (PipelineRun/TaskRun) potentially without any race conditions in pruning w.r.t to streaming logs even with no Grace Period. 
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
