### PR TITLE
add timeout to dynamic Reconcile; switch from CloseSend to CloseRecv in streamLogs; add goroutine dump on timeouts/deadlocks

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -67,6 +67,7 @@ var (
 	requeueInterval         = flag.Duration("requeue_interval", 10*time.Minute, "How long the Watcher waits to reprocess keys on certain events (e.g. an object doesn't match the provided selectors)")
 	namespace               = flag.String("namespace", corev1.NamespaceAll, "Should the Watcher only watch a single namespace, then this value needs to be set to the namespace name otherwise leave it empty.")
 	checkOwner              = flag.Bool("check_owner", true, "If enabled, owner references will be checked while deleting objects")
+	updateLogTimeout        = flag.Duration("update_log_timeout", 30*time.Second, "How log the Watcher waits for the UpdateLog operation for storing logs to complete before it aborts.")
 )
 
 func main() {
@@ -99,6 +100,7 @@ func main() {
 		CompletedResourceGracePeriod: *completedRunGracePeriod,
 		RequeueInterval:              *requeueInterval,
 		CheckOwner:                   *checkOwner,
+		UpdateLogTimeout:             updateLogTimeout,
 	}
 
 	if selector := *labelSelector; selector != "" {

--- a/pkg/api/server/v1alpha2/logs.go
+++ b/pkg/api/server/v1alpha2/logs.go
@@ -105,6 +105,14 @@ func (s *Server) UpdateLog(srv pb.Logs_UpdateLogServer) error {
 		}
 	}()
 	for {
+		// the underlying grpc stream RecvMsg method blocks until this receives a message or it is done,
+		// with the client now setting a context deadline, if a timeout occurs, that should make this done/canceled; let's check to confirm
+		deadline, ok := srv.Context().Deadline()
+		if !ok {
+			s.logger.Warnf("UpdateLog called with no deadline: %#v", srv)
+		} else {
+			s.logger.Infof("UpdateLog called with deadline: %s for %#v", deadline.String(), srv)
+		}
 		recv, err := srv.Recv()
 		// If we reach the end of the srv, we receive an io.EOF error
 		if err != nil {

--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -41,6 +41,9 @@ type Config struct {
 
 	// Check owner reference when deleting objects. By default, objects having owner references set won't be deleted.
 	CheckOwner bool
+
+	// UpdateLogTimeout is the time we provide for storing logs before aborting
+	UpdateLogTimeout *time.Duration
 }
 
 // GetDisableAnnotationUpdate returns whether annotation updates should be


### PR DESCRIPTION
# Changes

So we ran with the change from #712 in our production system, and while we confirmed the results logging memory leak was addresed, after about 12 to 13 hours, our reconciler threads systematically became deadlocked, and our watcher quit processing events.
    
We as of yet have not been able to get a goroutine dump with stack traces when this problem occurs, so we are unclear
whether the #712 fixes have had a direct cause to the deadlock, or if another issue was encountered.  Among other things our api server container restarted during the watcher deadlock, where the previous pod logs gave no clear indicationas to why.
    
This change pulls a couple of potentially helpful bits to help either diagnose or work around the deadlock:
    1) we have added a timeout to the context used in the dynamic Reconcile method, in case a blockage in any RPC call using a context somehow was causing the problem
    2) we also employ the combination of cancelling the context on method exit, to again unblock things, as well as the switch to
    CloseAndRecv instead of CloseSend to confirm the UpdateLog finished, so that our canceling of the streamLog context does not
    intermittenly cancel an UpdateLog call that would have otherwise succeeded.
    3) we are analyzing how a context is released, and if it is from a timeout and not cancel, we initiate a goroutine dump with stack traces
   4) using of a context with timeout that is canceled on exit from the reconcile method require no longer running 'sendLogs' on a separate goroutine, otherwise we re-introduced intermitent cancelling of 'UpdateLog' processing before it could complete.
   5) we now log the dealines for UpdateLog on the api server side 


rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [n/a ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ y] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [y ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ y] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [y ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ y] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
Address deadlocked reconciler threads potentially hung while streaming logs
```


