### PR TITLE
Add ability to set DB connection pool limits

### DIFF
--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -11,6 +11,8 @@
 | DB_SSLMODE               | Database SSL mode                                                                                                                 | verify-full                                  |
 | DB_SSLROOTCERT           | Path to CA cert used to validate Database cert                                                                                    | /etc/tls/db/ca.crt                           |
 | DB_ENABLE_AUTO_MIGRATION | Auto-migrate the database on startup (create/update schemas). For further details, refer to <https://gorm.io/docs/migration.html> | true (default)                               |
+| DB_MAX_IDLE_CONNECTIONS  | The number of idle database connections to keep open                                                                              | 10                                           |
+| DB_MAX_OPEN_CONNECTIONS  | The maximum number of database connections, for best performance it should equal DB_MAX_IDLE_CONNECTIONS                          | 10                                           |
 | SERVER_PORT              | gRPC and REST Server Port                                                                                                         | 8080  (default)                              |
 | PROMETHEUS_PORT          | Prometheus Port                                                                                                                   | 9090  (default)                              |
 | PROMETHEUS_HISTOGRAM     | Enable Prometheus histogram metrics to measure latency distributions of RPCs                                                      | false  (default)                             |

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -65,6 +65,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// The default number of connections to use
+const defaultDatabaseConnections = 10
+
 func main() {
 	serverConfig := config.Get()
 
@@ -116,6 +119,20 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to connect to database: %v", err)
 	}
+
+	sqlDB, err := db.DB()
+
+	// Set DB connection limits
+	maxIdle := serverConfig.DB_MAX_IDLE_CONNECTIONS
+	maxOpen := serverConfig.DB_MAX_OPEN_CONNECTIONS
+	if maxOpen < 1 {
+		maxOpen = defaultDatabaseConnections
+	}
+	if maxIdle < 1 {
+		maxIdle = defaultDatabaseConnections
+	}
+	sqlDB.SetMaxIdleConns(maxIdle)
+	sqlDB.SetMaxOpenConns(maxOpen)
 
 	// Create the authorization authCheck
 	var authCheck auth.Checker

--- a/pkg/api/server/config/config.go
+++ b/pkg/api/server/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	DB_SSLMODE               string `mapstructure:"DB_SSLMODE"`
 	DB_SSLROOTCERT           string `mapstructure:"DB_SSLROOTCERT"`
 	DB_ENABLE_AUTO_MIGRATION bool   `mapstructure:"DB_ENABLE_AUTO_MIGRATION"`
+	DB_MAX_IDLE_CONNECTIONS  int    `mapstructure:"DB_MAX_IDLE_CONNECTIONS"`
+	DB_MAX_OPEN_CONNECTIONS  int    `mapstructure:"DB_MAX_OPEN_CONNECTIONS"`
 	SERVER_PORT              string `mapstructure:"SERVER_PORT"`
 	PROMETHEUS_PORT          string `mapstructure:"PROMETHEUS_PORT"`
 	PROMETHEUS_HISTOGRAM     bool   `mapstructure:"PROMETHEUS_HISTOGRAM"`


### PR DESCRIPTION
## Changes

Add environment variables to configure the DB connection pool

## Release Note

```release-note
The number of idle and max database connections can be now configured using environment variables.
```