### PR TITLE
Enable storing of Run Events as Record

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -72,6 +72,7 @@ var (
 	checkOwner              = flag.Bool("check_owner", true, "If enabled, owner references will be checked while deleting objects")
 	updateLogTimeout        = flag.Duration("update_log_timeout", 300*time.Second, "How log the Watcher waits for the UpdateLog operation for storing logs to complete before it aborts.")
 	dynamicReconcileTimeout = flag.Duration("dynamic_reconcile_timeout", 30*time.Second, "How long the Watcher waits for the dynamic reconciler to complete before it aborts.")
+	storeEvent              = flag.Bool("store_event", false, "If enabled, events related to runs will also be stored")
 )
 
 func main() {
@@ -106,6 +107,7 @@ func main() {
 		CheckOwner:                   *checkOwner,
 		UpdateLogTimeout:             updateLogTimeout,
 		DynamicReconcileTimeout:      dynamicReconcileTimeout,
+		StoreEvent:                   *storeEvent,
 	}
 	log.Printf("dynamic reconcile timeout %s and update log timeout is %s", cfg.DynamicReconcileTimeout.String(), cfg.UpdateLogTimeout.String())
 

--- a/config/base/100-watcher-serviceaccount.yaml
+++ b/config/base/100-watcher-serviceaccount.yaml
@@ -33,7 +33,7 @@ rules:
   # Watcher currently get config from APISever, so will
   # fail to start if it does not have this permission.
   - apiGroups: [""]
-    resources: ["configmaps", "pods"]
+    resources: ["configmaps", "pods", "events"]
     verbs: ["get", "list", "watch"]
   # Required to read logs, when logs API is enabled
   - apiGroups: [""]

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -225,6 +225,8 @@ Possible values for `data_type` and `summary.type` (for Result) are:
 - `tekton.dev/v1beta1.TaskRun` or `TASK_RUN`
 - `tekton.dev/v1beta1.PipelineRun` or `PIPELINE_RUN`
 - `results.tekton.dev/v1alpha2.Log`
+- `results.tekton.dev/v1alpha3.Log`
+- `results.tekton.dev/v1.EventList`
 
 #### The `data` field in Record
 

--- a/pkg/apis/v1alpha3/types.go
+++ b/pkg/apis/v1alpha3/types.go
@@ -5,6 +5,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// EventListRecordType represents the API resource type for EventSet records.
+const EventListRecordType = "results.tekton.dev/v1.EventList"
+
 // LogRecordType represents the API resource type for Tekton log records.
 const LogRecordType = "results.tekton.dev/v1alpha3.Log"
 

--- a/pkg/watcher/reconciler/annotation/annotation.go
+++ b/pkg/watcher/reconciler/annotation/annotation.go
@@ -31,6 +31,9 @@ const (
 	// Log identifier.
 	Log = "results.tekton.dev/log"
 
+	// EventList identifier.
+	EventList = "results.tekton.dev/eventlist"
+
 	// ResultAnnotations is an annotation that integrators should add to objects in order to store
 	// arbitrary keys/values into the Result.Annotations field.
 	ResultAnnotations = "results.tekton.dev/resultAnnotations"

--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -47,6 +47,8 @@ type Config struct {
 
 	// DynamicReconcileTimeout is the time we provide for the dynamic reconciler to process an event
 	DynamicReconcileTimeout *time.Duration
+	// Whether to Store Events related to Taskrun and Pipelineruns
+	StoreEvent bool
 }
 
 // GetDisableAnnotationUpdate returns whether annotation updates should be

--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/reconciler/leaderelection"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 )
@@ -48,6 +49,7 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 
 	c := &Reconciler{
 		LeaderAwareFuncs:  leaderelection.NewLeaderAwareFuncs(pipelineRunLister.List),
+		kubeClientSet:     kubeclient.Get(ctx),
 		resultsClient:     resultsClient,
 		logsClient:        logs.Get(ctx),
 		pipelineRunLister: pipelineRunLister,

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/reconciler/leaderelection"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 )
@@ -47,6 +48,7 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 
 	c := &Reconciler{
 		LeaderAwareFuncs: leaderelection.NewLeaderAwareFuncs(lister.List),
+		kubeClientSet:    kubeclient.Get(ctx),
 		resultsClient:    resultsClient,
 		logsClient:       logs.Get(ctx),
 		lister:           lister,

--- a/pkg/watcher/results/eventlist.go
+++ b/pkg/watcher/results/eventlist.go
@@ -1,0 +1,89 @@
+package results
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
+	"github.com/tektoncd/results/pkg/apis/v1alpha3"
+	"github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// PutEventList adds the given Object to the Results API.
+// If the parent result is missing or the object is not yet associated with a
+// result, one is created automatically.
+func (c *Client) PutEventList(ctx context.Context, o Object, eventList []byte, opts ...grpc.CallOption) (*pb.Record, error) {
+	res, err := c.ensureResult(ctx, o, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return c.createEventListRecord(ctx, res, o, eventList, opts...)
+}
+
+// createEventListRecord creates a record for eventlist.
+func (c *Client) createEventListRecord(ctx context.Context, result *pb.Result, o Object, eventList []byte, opts ...grpc.CallOption) (*pb.Record, error) {
+	name, err := getEventListRecordName(result, o)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := c.GetRecord(ctx, &pb.GetRecordRequest{Name: name}, opts...)
+	if err != nil && status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+	if rec != nil {
+		return rec, nil
+	}
+	return c.CreateRecord(ctx, &pb.CreateRecordRequest{
+		Parent: result.GetName(),
+		Record: &pb.Record{
+			Name: name,
+			Data: &pb.Any{
+				Type:  v1alpha3.EventListRecordType,
+				Value: eventList,
+			},
+		},
+	})
+}
+
+// getEventListRecordName gets the eventlist name to use for the given object.
+// The name is derived from a known Tekton annotation if available, else
+// the object's UID is used to create MD5 UUID.
+func getEventListRecordName(result *pb.Result, o Object) (string, error) {
+	name, ok := o.GetAnnotations()[annotation.EventList]
+	if ok {
+		return name, nil
+	}
+	uid, err := uuid.Parse(result.GetUid())
+	if err != nil {
+		return "", nil
+	}
+	return FormatEventListName(result.GetName(), uid, o), nil
+}
+
+// FormatEventListName generates record name for EventList given resultName,
+// result UUID and object - taskrun/pipelinerun.
+func FormatEventListName(resultName string, resultUID uuid.UUID, o Object) string {
+	return record.FormatName(resultName,
+		uuid.NewMD5(resultUID, []byte(o.GetUID()+"eventlist")).String())
+}
+
+// GetEventListRecord returns eventlist record using gRPC clients.
+func (c *Client) GetEventListRecord(ctx context.Context, o Object) (*pb.Record, error) {
+	res, err := c.ensureResult(ctx, o)
+	if err != nil {
+		return nil, err
+	}
+	name, err := getEventListRecordName(res, o)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := c.GetRecord(ctx, &pb.GetRecordRequest{Name: name})
+	if err != nil && status.Code(err) == codes.NotFound {
+		return nil, nil
+	}
+	return rec, err
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -138,7 +138,7 @@ func TestTaskRun(t *testing.T) {
 
 	gc, _ := resultsClient(t, allNamespacesReadAccessTokenFile, nil)
 
-	var resName, recName string
+	var resName, recName, eventName string
 
 	// Wait for Result ID to show up.
 	t.Run("check annotations", func(t *testing.T) {
@@ -147,10 +147,11 @@ func TestTaskRun(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error getting TaskRun: %v", err)
 			}
-			var resAnnotation, recAnnotation bool
+			var resAnnotation, recAnnotation, eventAnnotation bool
 			resName, resAnnotation = tr.GetAnnotations()["results.tekton.dev/result"]
 			recName, recAnnotation = tr.GetAnnotations()["results.tekton.dev/record"]
-			if resAnnotation && recAnnotation {
+			eventName, eventAnnotation = tr.GetAnnotations()["results.tekton.dev/eventlist"]
+			if resAnnotation && recAnnotation && eventAnnotation {
 				return true, nil
 			}
 			return false, nil
@@ -194,6 +195,16 @@ func TestTaskRun(t *testing.T) {
 			t.Errorf("Error getting Record: %v", err)
 		}
 	})
+
+	t.Run("check event record", func(t *testing.T) {
+		if eventName == "" {
+			t.Skip("Event Record name not found")
+		}
+		_, err = gc.GetRecord(context.Background(), &resultsv1alpha2.GetRecordRequest{Name: eventName})
+		if err != nil {
+			t.Errorf("Error getting Event Record: %v", err)
+		}
+	})
 }
 
 func TestPipelineRun(t *testing.T) {
@@ -218,7 +229,7 @@ func TestPipelineRun(t *testing.T) {
 
 	gc, _ := resultsClient(t, allNamespacesReadAccessTokenFile, nil)
 
-	var resName, recName string
+	var resName, recName, eventName string
 
 	t.Run("check annotations", func(t *testing.T) {
 		// Wait for Result ID to show up.
@@ -227,10 +238,11 @@ func TestPipelineRun(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error getting PipelineRun: %v", err)
 			}
-			var resAnnotation, recAnnotation bool
+			var resAnnotation, recAnnotation, eventAnnotation bool
 			resName, resAnnotation = pr.GetAnnotations()["results.tekton.dev/result"]
 			recName, recAnnotation = pr.GetAnnotations()["results.tekton.dev/record"]
-			if resAnnotation && recAnnotation {
+			eventName, eventAnnotation = pr.GetAnnotations()["results.tekton.dev/eventlist"]
+			if resAnnotation && recAnnotation && eventAnnotation {
 				return true, nil
 			}
 			return false, nil
@@ -272,6 +284,16 @@ func TestPipelineRun(t *testing.T) {
 		_, err = gc.GetRecord(context.Background(), &resultsv1alpha2.GetRecordRequest{Name: recName})
 		if err != nil {
 			t.Errorf("Error getting Record: %v", err)
+		}
+	})
+
+	t.Run("check event record", func(t *testing.T) {
+		if eventName == "" {
+			t.Skip("Event Record name not found")
+		}
+		_, err = gc.GetRecord(context.Background(), &resultsv1alpha2.GetRecordRequest{Name: eventName})
+		if err != nil {
+			t.Errorf("Error getting Event Record: %v", err)
 		}
 	})
 

--- a/test/e2e/kustomize/watcher.yaml
+++ b/test/e2e/kustomize/watcher.yaml
@@ -18,3 +18,9 @@
 - op: add
   path: "/spec/template/spec/containers/0/args/-"
   value: "15s"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-store_event"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "true"


### PR DESCRIPTION
All Events related to taskrun or PipelineRun are stored when we are done with Runs and in a single List.
This can be controlled by a flag passed to the watcher: "store-event". Setting it to false 
disables the storing of Events. 
The record Name of EventList is stored as `results.tekton.dev/eventlist` in TaskRun and PipelineRun.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
All Events related to taskrun or PipelineRun are stored when we are done with Runs and in a single List.
This can be controlled by a flag passed to the watcher: "store-event". Setting it to false 
disables the storing of Events. 
The record Name of EventList is stored as `results.tekton.dev/eventlist` in TaskRun and PipelineRun.
```

