### PR TITLE
Use latest Kind k8s version, fixes e2e tests

### DIFF
--- a/test/e2e/kind-cluster.yaml
+++ b/test/e2e/kind-cluster.yaml
@@ -18,8 +18,8 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - &node
   role: control-plane
-  # Set a fixed Kubernetes version.
-  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+  # Set a fixed Kubernetes version: https://github.com/kubernetes-sigs/kind/releases
+  image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
 
 # Merge the same definition as the control-plane to reuse the same Kindest image
 # in the data-plane. We'll set specific values of the data-plane afterwards.


### PR DESCRIPTION
The latest pipelines version requires k8s version 1.28+. This was breaking the e2e tests.
As per our policy to always use the latest k8s version, switched the local deployment to using k8s 1.30.

Fixes: #765 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
