### PR TITLE
Pass Record name to the v1alpha3 API in tkn-results cli

### DIFF
--- a/pkg/cli/cmd/logs/get.go
+++ b/pkg/cli/cmd/logs/get.go
@@ -17,11 +17,15 @@ package logs
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	httpbody "google.golang.org/genproto/googleapis/api/httpbody"
 	grpc "google.golang.org/grpc"
 
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/log"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
 	"github.com/tektoncd/results/pkg/cli/config"
 	"github.com/tektoncd/results/pkg/cli/flags"
 	"github.com/tektoncd/results/pkg/cli/format"
@@ -47,8 +51,19 @@ func GetLogCommand(params *flags.Params) *cobra.Command {
 					Name: args[0],
 				})
 			} else {
+				var name, parent, res, rec string
+				parent, res, rec, err = record.ParseName(args[0])
+				if err != nil {
+					if !strings.Contains(args[0], "logs") {
+						return err
+					}
+					fmt.Printf("GetLog you can also pass in the format <namespace>/results/<parent-run-uuid>/records/<child-run-uuid>\n")
+					name = args[0]
+				} else {
+					name = log.FormatName(result.FormatName(parent, res), rec)
+				}
 				resp, err = params.PluginLogsClient.GetLog(cmd.Context(), &pb3.GetLogRequest{
-					Name: args[0],
+					Name: name,
 				})
 			}
 			if err != nil {


### PR DESCRIPTION
Now user can pass the record name in the below format to v1alpha3 GetLog :
`<namespace>/results/<parent-run-uuid>/records/<child-run-uuid>`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes



```release-note
User can pass the record name in the below format to v1alpha3 GetLog :
<namespace>/results/<parent-run-uuid>/records/<child-run-uuid>
```

