### PR TITLE
Storing PipelineRun and TaskRun deletion metadata

### DIFF
--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -130,6 +130,9 @@ func isMarkedAsReadyForDeletion(taskRun *pipelinev1.TaskRun) bool {
 // that we see flowing through the system.  If we don't add a finalizer, it could
 // get cleaned up before we see the final state and store it.
 func (r *Reconciler) FinalizeKind(ctx context.Context, pr *pipelinev1.PipelineRun) knativereconciler.Event {
+	// Reconcile the pipelinerun to ensure that it is stored in the database
+	rerr := r.ReconcileKind(ctx, pr)
+
 	// If logsClient isn't nil, it means we have logging storage enabled
 	// and we can't use finalizers to coordinate deletion.
 	if r.logsClient != nil {
@@ -179,7 +182,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *pipelinev1.PipelineRu
 			pr.Namespace, pr.Name, now.String(), storeDeadline.String(), requeueAfter.String())
 		return controller.NewRequeueAfter(requeueAfter)
 	}
-	if stored != "true" {
+	if rerr != nil || stored != "true" {
 		logging.FromContext(ctx).Debugf("stored annotation is not true on pipelinerun %s/%s, now: %s, storeDeadline: %s, requeueAfter: %s",
 			pr.Namespace, pr.Name, now.String(), storeDeadline.String(), requeueAfter.String())
 		return controller.NewRequeueAfter(requeueAfter)


### PR DESCRIPTION
Earlier, data coming during deletion like timestamp weren't stored. This PR fixes that.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
