### PR TITLE
Fix Panic in the API server

### DIFF
--- a/pkg/api/server/v1alpha2/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin_logs.go
@@ -169,8 +169,8 @@ func (s *LogPluginServer) getLokiLogs(writer *logs.BufferedLog, parent string, r
 	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
 	resp, err := s.client.Do(req)
 	if err != nil {
-		dump, err := httputil.DumpRequest(req, true)
-		if err == nil {
+		dump, derr := httputil.DumpRequest(req, true)
+		if derr == nil {
 			s.logger.Debugf("Request Dump***:\n %q\n", dump)
 		}
 		s.logger.Errorf("request to loki failed, err: %s, req: %v", err.Error(), req)


### PR DESCRIPTION
API server gets panic under certain negative scenarios. We fixed that by creating a new variable for error.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
