### PR TITLE
Provide configurations to store labels and Annotations in summary

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -70,6 +70,8 @@ var (
 	labelSelector           = flag.String("label_selector", "", "Selector (label query) to filter objects to be deleted. Matching objects must satisfy all labels requirements to be eligible for deletion")
 	requeueInterval         = flag.Duration("requeue_interval", 10*time.Minute, "How long the Watcher waits to reprocess keys on certain events (e.g. an object doesn't match the provided selectors)")
 	namespace               = flag.String("namespace", corev1.NamespaceAll, "Should the Watcher only watch a single namespace, then this value needs to be set to the namespace name otherwise leave it empty.")
+	summaryLabels           = flag.String("summary_labels", "tekton.dev/pipeline", "List of Labels keys separated by comma which should be part of the summary of the result")
+	summaryAnnotations      = flag.String("summary_annotations", "", "List of Annotations keys separated by comma which should be part of the summary of the result")
 	checkOwner              = flag.Bool("check_owner", true, "If enabled, owner references will be checked while deleting objects")
 	updateLogTimeout        = flag.Duration("update_log_timeout", 300*time.Second, "How log the Watcher waits for the UpdateLog operation for storing logs to complete before it aborts.")
 	dynamicReconcileTimeout = flag.Duration("dynamic_reconcile_timeout", 30*time.Second, "How long the Watcher waits for the dynamic reconciler to complete before it aborts.")
@@ -116,6 +118,8 @@ func main() {
 		StoreDeadline:                storeDeadline,
 		ForwardBuffer:                forwardBuffer,
 		LogsTimestamps:               *logsTimestamps,
+		SummaryLabels:                *summaryLabels,
+		SummaryAnnotations:           *summaryAnnotations,
 	}
 
 	log.Printf("dynamic reconcile timeout %s and update log timeout is %s", cfg.DynamicReconcileTimeout.String(), cfg.UpdateLogTimeout.String())

--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -62,6 +62,12 @@ type Config struct {
 
 	// Collect logs with timestamps
 	LogsTimestamps bool
+
+	// SummaryLabels are labels which should be part of the summary of the result
+	SummaryLabels string
+
+	// SummaryAnnotations are annotations which should be part of the summary of the result
+	SummaryAnnotations string
 }
 
 // GetDisableAnnotationUpdate returns whether annotation updates should be

--- a/pkg/watcher/reconciler/dynamic/dynamic.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic.go
@@ -87,7 +87,7 @@ type AfterDeletion func(ctx context.Context, object results.Object) error
 // NewDynamicReconciler creates a new dynamic Reconciler.
 func NewDynamicReconciler(kubeClientSet kubernetes.Interface, rc pb.ResultsClient, lc pb.LogsClient, oc ObjectClient, cfg *reconciler.Config) *Reconciler {
 	return &Reconciler{
-		resultsClient: results.NewClient(rc, lc),
+		resultsClient: results.NewClient(rc, lc, cfg),
 		KubeClientSet: kubeClientSet,
 		objectClient:  oc,
 		cfg:           cfg,

--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -242,7 +242,7 @@ func TestEnsureResult(t *testing.T) {
 				Kind:       "TaskRun",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "taskrun",
+				Name:      "foo",
 				Namespace: "test",
 				UID:       "taskrun-id",
 			},
@@ -253,7 +253,7 @@ func TestEnsureResult(t *testing.T) {
 				Kind:       "PipelineRun",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pipelinerun",
+				Name:      "foo",
 				Namespace: "test",
 				UID:       "pipelinerun-id",
 			},
@@ -280,6 +280,7 @@ func TestEnsureResult(t *testing.T) {
 					Record: recordName(name, o),
 					Type:   convert.TypeName(o),
 				},
+				Annotations: map[string]string{"object.metadata.name": "foo"},
 			}
 			if diff := cmp.Diff(want, create, protocmp.Transform(), protoutil.IgnoreResultOutputOnly()); diff != "" {
 				t.Errorf("Create Result diff (-want, +got):\n%s", diff)
@@ -305,6 +306,7 @@ func TestEnsureResult_RecordSummaryUpdate(t *testing.T) {
 
 	pr := &pipelinev1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
 			Namespace: "default",
 			UID:       "1",
 		},
@@ -339,6 +341,7 @@ func TestEnsureResult_RecordSummaryUpdate(t *testing.T) {
 			Record: recordName(resultName(pr), pr),
 			Type:   convert.TypeName(pr),
 		},
+		Annotations: map[string]string{"object.metadata.name": "foo"},
 	}
 	if diff := cmp.Diff(got, want, protocmp.Transform(), protoutil.IgnoreResultOutputOnly()); diff != "" {
 		t.Fatal(diff)
@@ -351,6 +354,7 @@ func TestAnnotations(t *testing.T) {
 
 	pipelineRun := &pipelinev1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
 			Namespace: "default",
 			Annotations: map[string]string{
 				annotation.ResultAnnotations:        `{"x": "y", "i": 7}`,
@@ -366,7 +370,7 @@ func TestAnnotations(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(map[string]string{
-		"x": "y", "i": "7",
+		"x": "y", "object.metadata.name": "foo", "i": "7",
 	}, result.Annotations); diff != "" {
 		t.Errorf("Result.Annotations: mismatch (-want +got):\n%s", diff)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -308,8 +308,10 @@ func TestPipelineRun(t *testing.T) {
 
 		t.Run("Result and RecordSummary Annotations were set accordingly", func(t *testing.T) {
 			if diff := cmp.Diff(map[string]string{
-				"repo":   "tektoncd/results",
-				"commit": "1a6b908",
+				"repo":                 "tektoncd/results",
+				"object.metadata.name": "hello",
+				"commit":               "1a6b908",
+				"tekton.dev/pipeline":  "hello",
 			}, result.Annotations); diff != "" {
 				t.Errorf("Result.Annotations: mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
This helps by enabling making query to Results Table which have less rows.
Also, we can avoid toast query if PipelineRuns are too large. Also, we can create index on these.
You can provide args to watcher `summary_labels` and `summary_annotations` to store these labels/annotations to Result.Annotation field.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
You can provide args to watcher `summary_labels` and `summary_annotations` to store these labels/annotations to Result.Annotation field.
Top Level Resource name is always saved as object.metadata.name in annotation.  

```
