### PR TITLE
Enable Finalizer for Pruner - Grace Period Config

### DIFF
--- a/pkg/watcher/reconciler/dynamic/dynamic.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic.go
@@ -722,10 +722,6 @@ func (r *Reconciler) addStoredAnnotations(ctx context.Context, o results.Object)
 		return nil
 	}
 
-	if r.cfg.GetCompletedResourceGracePeriod() != 0*time.Second {
-		logger.Debugf("Skipping CRD annotation patch: CompletedResourceGracePeriod is disabled ObjectName: %s", o.GetName())
-		return nil
-	}
 	if r.cfg.GetDisableAnnotationUpdate() { //nolint:gocritic
 		logger.Debug("Skipping CRD annotation patch: annotation update is disabled")
 		return nil

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -144,12 +144,6 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *pipelinev1.PipelineRu
 		return nil
 	}
 
-	// If the completed resource grace period isn't 0, we can't use finalizers
-	// to coordinate deletion because a results pruner is running.
-	if r.cfg.GetCompletedResourceGracePeriod() != 0*time.Second {
-		return nil
-	}
-
 	// Check to make sure the PipelineRun is finished.
 	if !pr.IsDone() {
 		logging.FromContext(ctx).Debugf("pipelinerun %s/%s is still running", pr.Namespace, pr.Name)

--- a/pkg/watcher/reconciler/taskrun/reconciler.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler.go
@@ -78,12 +78,6 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *pipelinev1.TaskRun) k
 		return nil
 	}
 
-	// If the completed resource grace period isn't 0, we can't use finalizers
-	// to coordinate deletion because a results pruner is running.
-	if r.cfg.GetCompletedResourceGracePeriod() != 0*time.Second {
-		return nil
-	}
-
 	// Check the TaskRun has finished.
 	if !tr.IsDone() {
 		logging.FromContext(ctx).Debugf("taskrun %s/%s is still running", tr.Namespace, tr.Name)

--- a/test/e2e/kustomize/watcher.yaml
+++ b/test/e2e/kustomize/watcher.yaml
@@ -20,6 +20,18 @@
   value: "15s"
 - op: add
   path: "/spec/template/spec/containers/0/args/-"
+  value: "-store_deadline"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "20s"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-forward_buffer"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "17s"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
   value: "-store_event=true"
 - op: add
   path: "/spec/template/spec/containers/0/args/-"


### PR DESCRIPTION
Finalizer was disabled earlier for pruner setting, this enables it.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
Enable Finalizer for Pruner - Grace Period Config
```

