### PR TITLE
Enable Impersonation of user in Rest API for Logging

### DIFF
--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -407,17 +407,17 @@ func (s *LogServer) LogMux() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO: Create a new log handler
 		ctx := r.Context()
-		md := metadata.New(map[string]string{"authorization": r.Header.Get("Authorization")})
+		md := metadata.MD(r.Header)
 		ctx = metadata.NewIncomingContext(ctx, md)
 		parent := r.PathValue("parent")
+		recID := r.PathValue("recordID")
+		res := r.PathValue("resultID")
+		s.logger.Debugf("recordID: %s resultID: %s name: %s md: %+v", recID, res, parent, r.Header)
 		if err := s.auth.Check(ctx, parent, auth.ResourceLogs, auth.PermissionGet); err != nil {
 			s.logger.Error(err)
 			http.Error(w, "Not Authorized", http.StatusUnauthorized)
 			return
 		}
-		recID := r.PathValue("recordID")
-		res := r.PathValue("resultID")
-		s.logger.Infof("recordID: %s resultID: %s name: %s", recID, res, parent)
 		rec, err := getRecord(s.db, parent, res, recID)
 		if err != nil {
 			s.logger.Error(err)


### PR DESCRIPTION
This adds all header pass to incoming context.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
NONE
```