### PR TITLE
feat: tkn-results add pipelinerun list and result describe command

### DIFF
--- a/pkg/api/server/v1alpha2/lister/proto/pagetoken_go_proto/page_token.pb.go
+++ b/pkg/api/server/v1alpha2/lister/proto/pagetoken_go_proto/page_token.pb.go
@@ -21,11 +21,12 @@
 package pagetoken_go_proto
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -424,6 +424,7 @@ func (s *LogServer) setLogPlugin() bool {
 		s.IsLogPluginEnabled = true
 		s.getLog = getBlobLogs
 	default:
+		// TODO(xinnjie) when s.config.LOGS_TYPE is File also show this error log
 		s.IsLogPluginEnabled = false
 		s.logger.Warnf("Plugin Logs API Disable: unsupported type of logs given for plugin, " +
 			"legacy logging system might work")

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -1,0 +1,127 @@
+package pipelinerun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/formatted"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/results/pkg/cli/flags"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+)
+
+const listTemplate = `{{- $size := len .PipelineRuns -}}{{- if eq $size 0 -}}
+No PipelineRuns found
+{{ else -}}
+NAMESPACE	UID	STARTED	DURATION	STATUS
+{{- range $_, $pr := .PipelineRuns }}
+{{ $pr.ObjectMeta.Namespace }}	{{ $pr.ObjectMeta.Name }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
+{{- end -}}
+{{- end -}}`
+
+type listOptions struct {
+	Namespace string
+	Limit     int
+}
+
+// listCommand initializes a cobra command to list PipelineRuns
+func listCommand(params *flags.Params) *cobra.Command {
+	opts := &listOptions{Limit: 0, Namespace: "default"}
+
+	eg := `List all PipelineRuns in a namespace 'foo':
+    tkn-results pipelinerun list -n foo
+
+List all PipelineRuns in 'default' namespace:
+    tkn-results pipelinerun list -n default
+`
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List PipelineRuns in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.Limit < 0 {
+				return fmt.Errorf("limit was %d, but must be greater than 0", opts.Limit)
+			}
+
+			resp, err := params.ResultsClient.ListRecords(cmd.Context(), &pb.ListRecordsRequest{
+				Parent:   fmt.Sprintf("%s/results/-", opts.Namespace),
+				PageSize: int32(opts.Limit),
+				Filter:   `data_type==PIPELINE_RUN`,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list PipelineRuns from namespace %s: %v", opts.Namespace, err)
+			}
+			return printFormatted(cmd.OutOrStdout(), resp.Records, params.Clock)
+		},
+	}
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "default", "Namespace to list PipelineRuns in")
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 0, "Limit the number of PipelineRuns to return")
+	return cmd
+}
+
+func pipelineRunFromRecord(record *pb.Record) (*pipelinev1.PipelineRun, error) {
+	if record.Data == nil {
+		return nil, fmt.Errorf("record data is nil")
+	}
+	pr := &pipelinev1.PipelineRun{}
+	switch record.Data.GetType() {
+	case "tekton.dev/v1beta1.PipelineRun":
+		//nolint:staticcheck
+		prV1beta1 := &pipelinev1beta1.PipelineRun{}
+		if err := json.Unmarshal(record.Data.Value, prV1beta1); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal PipelineRun data: %v", err)
+		}
+		if err := pr.ConvertFrom(context.TODO(), prV1beta1); err != nil {
+			return nil, fmt.Errorf("failed to convert v1beta1 PipelineRun to v1: %v", err)
+		}
+	case "tekton.dev/v1.PipelineRun":
+		if err := json.Unmarshal(record.Data.Value, pr); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal PipelineRun data: %v", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported PipelineRun type: %s", record.Data.GetType())
+	}
+	return pr, nil
+}
+
+func printFormatted(out io.Writer, records []*pb.Record, c clockwork.Clock) error {
+	var data = struct {
+		PipelineRuns []*pipelinev1.PipelineRun
+		Time         clockwork.Clock
+	}{
+		PipelineRuns: []*pipelinev1.PipelineRun{},
+		Time:         c,
+	}
+
+	for _, record := range records {
+		if pr, err := pipelineRunFromRecord(record); err == nil {
+			data.PipelineRuns = append(data.PipelineRuns, pr)
+		}
+	}
+
+	funcMap := template.FuncMap{
+		"formatAge":       formatted.Age,
+		"formatDuration":  formatted.Duration,
+		"formatCondition": formatted.Condition,
+	}
+
+	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	t := template.Must(template.New("List TaskRuns").Funcs(funcMap).Parse(listTemplate))
+
+	err := t.Execute(w, data)
+	if err != nil {
+		return err
+	}
+	return w.Flush()
+}

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -28,7 +28,7 @@ NAMESPACE	UID	STARTED	DURATION	STATUS
 
 type listOptions struct {
 	Namespace string
-	Limit     int
+	Limit     int32
 }
 
 // listCommand initializes a cobra command to list PipelineRuns
@@ -56,7 +56,7 @@ List all PipelineRuns in 'default' namespace:
 
 			resp, err := params.ResultsClient.ListRecords(cmd.Context(), &pb.ListRecordsRequest{
 				Parent:   fmt.Sprintf("%s/results/-", opts.Namespace),
-				PageSize: int32(opts.Limit),
+				PageSize: opts.Limit,
 				Filter:   `data_type==PIPELINE_RUN`,
 			})
 			if err != nil {
@@ -66,7 +66,7 @@ List all PipelineRuns in 'default' namespace:
 		},
 	}
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "default", "Namespace to list PipelineRuns in")
-	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 0, "Limit the number of PipelineRuns to return")
+	cmd.Flags().Int32VarP(&opts.Limit, "limit", "l", 0, "Limit the number of PipelineRuns to return")
 	return cmd
 }
 

--- a/pkg/cli/cmd/pipelinerun/list_test.go
+++ b/pkg/cli/cmd/pipelinerun/list_test.go
@@ -1,0 +1,146 @@
+package pipelinerun
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/results/pkg/test"
+
+	"github.com/tektoncd/results/pkg/cli/flags"
+	"github.com/tektoncd/results/pkg/test/fake"
+
+	"github.com/jonboulle/clockwork"
+
+	"github.com/spf13/cobra"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestListPipelineRuns_empty(t *testing.T) {
+	records := []*pb.Record{}
+	now := time.Now()
+	cmd := command(records, now)
+
+	output, err := test.ExecuteCommand(cmd, "list")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	test.AssertOutput(t, "No PipelineRuns found\n", output)
+}
+
+func TestListPipelineRuns(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	createTime := clock.Now().Add(time.Duration(-3) * time.Minute)
+	updateTime := clock.Now().Add(time.Duration(-2) * time.Minute)
+	startTime := clock.Now().Add(time.Duration(-3) * time.Minute)
+	endTime := clock.Now().Add(time.Duration(-1) * time.Minute)
+	records := testDataSuccessfulPipelineRun(t, createTime, updateTime, startTime, endTime)
+	cmd := command(records, clock.Now())
+	output, err := test.ExecuteCommand(cmd, "list")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	test.AssertOutput(t, `NAMESPACE   UID                       STARTED         DURATION   STATUS
+default     hello-goodbye-run-xgkf8   3 minutes ago   2m0s       Succeeded`, output)
+}
+
+func command(records []*pb.Record, now time.Time) *cobra.Command {
+	clock := clockwork.NewFakeClockAt(now)
+
+	param := &flags.Params{
+		ResultsClient:    fake.NewResultsClient(nil, records),
+		LogsClient:       nil,
+		PluginLogsClient: nil,
+		Clock:            clock,
+	}
+	cmd := Command(param)
+	return cmd
+}
+
+func testDataSuccessfulPipelineRun(t *testing.T, createTime, updateTime, startTime, endTime time.Time) []*pb.Record {
+	pipelineRun := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "hello-goodbye-run-xgkf8",
+			Namespace:       "default",
+			UID:             "d2c19786-5fb7-4577-84a4-10d43c157c5c",
+			ResourceVersion: "4320960",
+			Generation:      1,
+			Labels: map[string]string{
+				"tekton.dev/pipeline": "hello-goodbye",
+			},
+			Annotations: map[string]string{
+				"results.tekton.dev/log":    "default/results/d2c19786-5fb7-4577-84a4-10d43c157c5c/logs/d05a16ce-f7a4-3370-8c3a-88c30067680a",
+				"results.tekton.dev/record": "default/results/d2c19786-5fb7-4577-84a4-10d43c157c5c/records/d2c19786-5fb7-4577-84a4-10d43c157c5c",
+				"results.tekton.dev/result": "default/results/d2c19786-5fb7-4577-84a4-10d43c157c5c",
+			},
+			Finalizers: []string{"results.tekton.dev/pipelinerun"},
+		},
+		Spec: pipelinev1.PipelineRunSpec{
+			PipelineRef: &pipelinev1.PipelineRef{
+				Name: "hello-goodbye",
+			},
+			Params: []pipelinev1.Param{
+				{
+					Name: "username",
+					Value: pipelinev1.ParamValue{
+						Type:      pipelinev1.ParamTypeString,
+						StringVal: "Tekton",
+					},
+				},
+			},
+			Timeouts: &pipelinev1.TimeoutFields{
+				Pipeline: &metav1.Duration{Duration: time.Hour},
+			},
+		},
+		Status: pipelinev1.PipelineRunStatus{
+			PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+				StartTime:      &metav1.Time{Time: startTime},
+				CompletionTime: &metav1.Time{Time: endTime},
+				ChildReferences: []pipelinev1.ChildStatusReference{
+					{
+						Name:             "hello-goodbye-run-xgkf8-hello",
+						PipelineTaskName: "hello",
+					},
+					{
+						Name:             "hello-goodbye-run-xgkf8-goodbye",
+						PipelineTaskName: "goodbye",
+					},
+				},
+			},
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{
+					{
+						Type:               apis.ConditionSucceeded,
+						Status:             corev1.ConditionTrue,
+						Reason:             "Succeeded",
+						Message:            "Tasks Completed: 2 (Failed: 0, Cancelled 0), Skipped: 0",
+						LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: updateTime}},
+					},
+				},
+			},
+		},
+	}
+	prBytes, err := json.Marshal(pipelineRun)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	records := []*pb.Record{
+		{
+			Name: "default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7/records/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7",
+			Uid:  "095a449f-691a-4be7-9bcb-3a52bba3bc6d",
+			Data: &pb.Any{
+				Type:  "tekton.dev/v1.PipelineRun",
+				Value: prBytes,
+			},
+			CreateTime: timestamppb.New(createTime),
+			UpdateTime: timestamppb.New(updateTime),
+		},
+	}
+	return records
+}

--- a/pkg/cli/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cli/cmd/pipelinerun/pipelinerun.go
@@ -1,0 +1,22 @@
+package pipelinerun
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/results/pkg/cli/flags"
+)
+
+// Command initializes a cobra command for `pipelinerun` sub commands
+func Command(params *flags.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "pipelinerun",
+		Aliases: []string{"pr", "pipelineruns"},
+		Short:   "Query PipelineRuns",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+
+	cmd.AddCommand(listCommand(params))
+
+	return cmd
+}

--- a/pkg/cli/cmd/records/get.go
+++ b/pkg/cli/cmd/records/get.go
@@ -15,14 +15,31 @@
 package records
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"os"
+	"io"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/results/pkg/cli/format"
 
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/results/pkg/cli/flags"
-	"github.com/tektoncd/results/pkg/cli/format"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 )
+
+const tmpl = `Name:              {{.Record.Name}}
+UID:               {{.Record.Uid}}
+Status:
+Created:	{{ formatAge .Record.CreateTime .Time }}	Duration:	{{formatDuration .Record.CreateTime .Record.UpdateTime}}
+{{- if .Record.Data }}
+Type:         {{.Record.Data.Type}}
+Data:
+{{formatJSON .Record.Data.Value}}
+{{ end -}}
+`
 
 // GetRecordCommand returns a cobra sub command that will fetch a record by name
 func GetRecordCommand(params *flags.Params) *cobra.Command {
@@ -33,14 +50,14 @@ func GetRecordCommand(params *flags.Params) *cobra.Command {
 		Short: "Get Record by <record-name>",
 		Long:  "Get Record by <record-name>. <record-name> is typically of format <namespace>/results/<parent-run-uuid>/records/<child-run-uuid>",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resp, err := params.ResultsClient.GetRecord(cmd.Context(), &pb.GetRecordRequest{
+			record, err := params.ResultsClient.GetRecord(cmd.Context(), &pb.GetRecordRequest{
 				Name: args[0],
 			})
 			if err != nil {
 				fmt.Printf("GetRecord: %v\n", err)
 				return err
 			}
-			return format.PrintProto(os.Stdout, resp, opts.Format)
+			return formatRecord(cmd.OutOrStdout(), record, params.Clock)
 		},
 		Args: cobra.ExactArgs(1),
 		Annotations: map[string]string{
@@ -64,4 +81,32 @@ func GetRecordCommand(params *flags.Params) *cobra.Command {
 	flags.AddGetFlags(opts, cmd)
 
 	return cmd
+}
+
+func formatRecord(out io.Writer, record *pb.Record, c clockwork.Clock) error {
+	data := struct {
+		Record *pb.Record
+		Time   clockwork.Clock
+	}{
+		Record: record,
+		Time:   c,
+	}
+
+	funcMap := template.FuncMap{
+		"formatAge":      format.Age,
+		"formatDuration": format.Duration,
+		"formatJSON": func(data []byte) string {
+			if len(data) == 0 {
+				return "No data"
+			}
+			var prettyJSON bytes.Buffer
+			if err := json.Indent(&prettyJSON, data, "       ", "  "); err != nil {
+				return fmt.Sprintf("Error formatting JSON: %v", err)
+			}
+			return prettyJSON.String()
+		},
+	}
+	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	t := template.Must(template.New("record").Funcs(funcMap).Parse(tmpl))
+	return t.Execute(w, data)
 }

--- a/pkg/cli/cmd/result/describe.go
+++ b/pkg/cli/cmd/result/describe.go
@@ -1,0 +1,116 @@
+package result
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/results/pkg/cli/flags"
+	"github.com/tektoncd/results/pkg/cli/format"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+)
+
+const resultDescTmpl = `Name:	{{.Result.Name}}
+UID:	{{.Result.Uid}}
+{{- if .Result.Annotations}}
+Annotations:
+{{- range $key, $value := .Result.Annotations}}
+	{{$key}}={{$value}}
+{{- end}}
+{{- end}}
+Status:
+	Created:	{{formatAge .Result.CreateTime .Time}}	DURATION: {{formatDuration .Result.CreateTime .Result.UpdateTime}}
+{{- if .Result.Summary}}
+Summary:
+	Type:	{{.Result.Summary.Type}}
+	Status:
+	STARTED	DURATION	STATUS
+	{{formatAge .Result.Summary.StartTime .Time}}	{{formatDuration .Result.Summary.StartTime .Result.Summary.EndTime}}	{{.Result.Summary.Status}}
+	{{- if .Result.Summary.Annotations}}
+	Annotations:
+		{{- range $key, $value := .Result.Summary.Annotations}}
+			{{$key}}={{$value}}
+		{{- end}}
+	{{- end}}
+{{- end}}
+`
+
+type describeOptions struct {
+	Parent string
+	UID    string
+}
+
+func describeCommand(params *flags.Params) *cobra.Command {
+	opts := &describeOptions{}
+	eg := `Query by name:
+tkn-result result describe default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7
+
+Query by parent and uid:
+tkn-result result desc --parent default --uid 949eebd9-1cf7-478f-a547-9ee313035f10
+`
+	cmd := &cobra.Command{
+		Use:     "describe [-p parent -u uid] [name]",
+		Aliases: []string{"desc"},
+		Short:   "Describes a Result",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				name := args[0]
+				result, err := params.ResultsClient.GetResult(cmd.Context(), &pb.GetResultRequest{
+					Name: name,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to get result of name %s: %v", name, err)
+				}
+				return printResultDescription(cmd.OutOrStdout(), result, params.Clock)
+			}
+
+			if opts.Parent != "" && opts.UID != "" {
+				resp, err := params.ResultsClient.ListResults(cmd.Context(), &pb.ListResultsRequest{
+					Parent: opts.Parent,
+					Filter: fmt.Sprintf(`uid=="%s"`, opts.UID),
+				})
+				if err != nil {
+					return fmt.Errorf("failed to get result of parent %s and uid %s: %v", opts.Parent, opts.UID, err)
+				}
+				if len(resp.Results) == 0 {
+					return fmt.Errorf("no result found with parent %s and uid %s", opts.Parent, opts.UID)
+				}
+				return printResultDescription(cmd.OutOrStdout(), resp.Results[0], params.Clock)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Parent, "parent", "p", "", "parent of the result")
+	cmd.Flags().StringVarP(&opts.UID, "uid", "u", "", "uid of the result")
+	return cmd
+}
+
+func printResultDescription(out io.Writer, result *pb.Result, c clockwork.Clock) error {
+	data := struct {
+		Result *pb.Result
+		Time   clockwork.Clock
+	}{
+		Result: result,
+		Time:   c,
+	}
+	funcMap := template.FuncMap{
+		"formatAge":      format.Age,
+		"formatDuration": format.Duration,
+		"formatStatus":   format.Status,
+	}
+	w := tabwriter.NewWriter(out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	t := template.Must(template.New("Describe A Result").Funcs(funcMap).Parse(resultDescTmpl))
+	err := t.Execute(w, data)
+	if err != nil {
+		return err
+	}
+	return w.Flush()
+}

--- a/pkg/cli/cmd/result/describe_test.go
+++ b/pkg/cli/cmd/result/describe_test.go
@@ -1,0 +1,65 @@
+package result
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/tektoncd/results/pkg/cli/flags"
+	"github.com/tektoncd/results/pkg/test"
+	"github.com/tektoncd/results/pkg/test/fake"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestDescribeResult(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	createTime := clock.Now().Add(time.Duration(-3) * time.Minute)
+	updateTime := clock.Now().Add(time.Duration(-2) * time.Minute)
+	startTime := clock.Now().Add(time.Duration(-3) * time.Minute)
+	endTime := clock.Now().Add(time.Duration(-1) * time.Minute)
+	results := []*pb.Result{
+		{
+			Name:       "default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7",
+			Uid:        "949eebd9-1cf7-478f-a547-9ee313035f10",
+			CreateTime: timestamppb.New(createTime),
+			UpdateTime: timestamppb.New(updateTime),
+			Annotations: map[string]string{
+				"object.metadata.name": "hello-goodbye-run-vfsxn",
+				"tekton.dev/pipeline":  "hello-goodbye",
+			},
+			Summary: &pb.RecordSummary{
+				Record:    "default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7/records/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7",
+				Type:      "tekton.dev/v1.PipelineRun",
+				StartTime: timestamppb.New(startTime),
+				EndTime:   timestamppb.New(endTime),
+				Status:    pb.RecordSummary_SUCCESS,
+			},
+		}}
+
+	param := &flags.Params{
+		ResultsClient:    fake.NewResultsClient(results, nil),
+		LogsClient:       nil,
+		PluginLogsClient: nil,
+		Clock:            clock,
+	}
+	cmd := Command(param)
+
+	output, err := test.ExecuteCommand(cmd, "describe", "default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	test.AssertOutput(t, `Name:   default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7
+UID:    949eebd9-1cf7-478f-a547-9ee313035f10
+Annotations:
+	object.metadata.name=hello-goodbye-run-vfsxn
+	tekton.dev/pipeline=hello-goodbye
+Status:
+	Created:   3 minutes ago   DURATION: 1m0s
+Summary:
+	Type:   tekton.dev/v1.PipelineRun
+	Status:
+	STARTED         DURATION   STATUS
+	3 minutes ago   2m0s       SUCCESS
+`, output)
+}

--- a/pkg/cli/cmd/result/list.go
+++ b/pkg/cli/cmd/result/list.go
@@ -1,4 +1,4 @@
-package cmd
+package result
 
 import (
 	"fmt"
@@ -20,9 +20,9 @@ func ListCommand(params *flags.Params) *cobra.Command {
   <parent>: Parent name to query. This is typically corresponds to a namespace, but may vary depending on the API Server. "-" may be used to query all parents.`,
 		Short: "List Results",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
+			parent := args[0]
 			resp, err := params.ResultsClient.ListResults(cmd.Context(), &pb.ListResultsRequest{
-				Parent:    args[0],
+				Parent:    parent,
 				Filter:    opts.Filter,
 				PageSize:  opts.Limit,
 				PageToken: opts.PageToken,

--- a/pkg/cli/cmd/result/result.go
+++ b/pkg/cli/cmd/result/result.go
@@ -1,0 +1,25 @@
+package result
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/results/pkg/cli/flags"
+)
+
+// Command initializes a cobra command for `pipelinerun` sub commands
+func Command(params *flags.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "result",
+		Aliases: []string{"r", "results"},
+		Short:   "Query Results",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+
+	cmd.AddCommand(
+		ListCommand(params),
+		describeCommand(params),
+	)
+
+	return cmd
+}

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -5,12 +5,15 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/cmd/logs"
+	"github.com/tektoncd/results/pkg/cli/cmd/pipelinerun"
 	"github.com/tektoncd/results/pkg/cli/cmd/records"
+	"github.com/tektoncd/results/pkg/cli/cmd/result"
 	"github.com/tektoncd/results/pkg/cli/config"
 	"github.com/tektoncd/results/pkg/cli/flags"
 	"github.com/tektoncd/results/pkg/cli/portforward"
@@ -77,6 +80,8 @@ func Root() *cobra.Command {
 
 			params.PluginLogsClient = pluginLogsClient
 
+			params.Clock = clockwork.NewRealClock()
+
 			return nil
 		},
 		PersistentPostRun: func(_ *cobra.Command, _ []string) {
@@ -97,7 +102,11 @@ func Root() *cobra.Command {
 	cmd.PersistentFlags().Bool("insecure", false, "determines whether to run insecure GRPC tls request")
 	cmd.PersistentFlags().Bool("v1alpha2", false, "use v1alpha2 API for get log command")
 
-	cmd.AddCommand(ListCommand(params), records.Command(params), logs.Command(params))
+	cmd.AddCommand(result.Command(params),
+		records.Command(params),
+		logs.Command(params),
+		pipelinerun.Command(params),
+	)
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	pb3 "github.com/tektoncd/results/proto/v1alpha3/results_go_proto"
@@ -11,6 +12,8 @@ type Params struct {
 	ResultsClient    pb.ResultsClient
 	LogsClient       pb.LogsClient
 	PluginLogsClient pb3.LogsClient
+
+	Clock clockwork.Clock
 }
 
 // ListOptions is used on commands that list Results, Records or Logs

--- a/pkg/cli/format/format.go
+++ b/pkg/cli/format/format.go
@@ -7,10 +7,13 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/hako/durafmt"
+	"github.com/jonboulle/clockwork"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // PrintProto prints the given proto message to the given writer in the given format.
@@ -67,4 +70,51 @@ func PrintProto(w io.Writer, m proto.Message, format string) error {
 		return fmt.Errorf("unknown output format %q", format)
 	}
 	return nil
+}
+
+// Age returns the age of the given timestamp in a human-readable format.
+func Age(timestamp *timestamppb.Timestamp, c clockwork.Clock) string {
+	if timestamp == nil {
+		return "---"
+	}
+	t := timestamp.AsTime()
+	if t.IsZero() {
+		return "---"
+	}
+	duration := c.Since(t)
+	return durafmt.ParseShort(duration).String() + " ago"
+}
+
+// Duration returns the duration between two timestamps in a human-readable format.
+func Duration(timestamp1, timestamp2 *timestamppb.Timestamp) string {
+	if timestamp1 == nil || timestamp2 == nil {
+		return "---"
+	}
+	t1 := timestamp1.AsTime()
+	t2 := timestamp2.AsTime()
+	if t1.IsZero() || t2.IsZero() {
+		return "---"
+	}
+	duration := t2.Sub(t1)
+	return duration.String()
+}
+
+// Status returns the status of the given record summary in a human-readable format.
+func Status(status pb.RecordSummary_Status) string {
+	switch status {
+	case pb.RecordSummary_SUCCESS:
+		return "Succeeded"
+	case pb.RecordSummary_FAILURE:
+		return "Failed"
+	case pb.RecordSummary_TIMEOUT:
+		return "Timed Out"
+	case pb.RecordSummary_CANCELLED:
+		return "Cancelled"
+	}
+	return "Unknown"
+}
+
+// Namespace returns the namespace of the given result name.
+func Namespace(resultName string) string {
+	return strings.Split(resultName, "/")[0]
 }

--- a/pkg/test/cobra.go
+++ b/pkg/test/cobra.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"bytes"
+
+	"github.com/spf13/cobra"
+)
+
+// ExecuteCommand executes the root command passing the args and returns
+// the output as a string and error
+func ExecuteCommand(c *cobra.Command, args ...string) (string, error) {
+	buf := new(bytes.Buffer)
+	c.SetOut(buf)
+	c.SetErr(buf)
+	c.SetArgs(args)
+	c.SilenceUsage = true
+
+	_, err := c.ExecuteC()
+
+	return buf.String(), err
+}

--- a/pkg/test/expect.go
+++ b/pkg/test/expect.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// AssertOutput is a helper function to assert that the actual output matches the expected output.
+func AssertOutput(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	diff := cmp.Diff(actual, expected)
+	if diff == "" {
+		return
+	}
+
+	t.Errorf(`
+Unexpected output:
+%s
+
+Expected
+%s
+
+Actual
+%s
+`, diff, expected, actual)
+}

--- a/pkg/test/fake/results.go
+++ b/pkg/test/fake/results.go
@@ -1,0 +1,110 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// ResultsClient is a fake implementation of the ResultsClient interface
+type ResultsClient struct {
+	// Map of result name to Result for GetResult and ListResults
+	results map[string]*pb.Result
+
+	// Map of record name to Record for GetRecord and ListRecords
+	records map[string]*pb.Record
+}
+
+// NewResultsClient creates a new fake ResultsClient
+func NewResultsClient(testResults []*pb.Result, testRecords []*pb.Record) *ResultsClient {
+	r := &ResultsClient{
+		results: make(map[string]*pb.Result),
+		records: make(map[string]*pb.Record),
+	}
+	for _, result := range testResults {
+		r.results[result.Name] = result
+	}
+	for _, record := range testRecords {
+		r.records[record.Name] = record
+	}
+	return r
+}
+
+// GetResult implements ResultsClient.GetResult
+func (c *ResultsClient) GetResult(_ context.Context, in *pb.GetResultRequest, _ ...grpc.CallOption) (*pb.Result, error) {
+	result, exists := c.results[in.Name]
+	if !exists {
+		return nil, fmt.Errorf("result not found: %s", in.Name)
+	}
+	return result, nil
+}
+
+// ListResults implements ResultsClient.ListResults
+func (c *ResultsClient) ListResults(_ context.Context, _ *pb.ListResultsRequest, _ ...grpc.CallOption) (*pb.ListResultsResponse, error) {
+	results := make([]*pb.Result, 0, len(c.results))
+	for _, result := range c.results {
+		results = append(results, result)
+	}
+
+	return &pb.ListResultsResponse{
+		Results: results,
+	}, nil
+}
+
+// CreateResult is unimplemented
+func (c *ResultsClient) CreateResult(_ context.Context, _ *pb.CreateResultRequest, _ ...grpc.CallOption) (*pb.Result, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// UpdateResult is unimplemented
+func (c *ResultsClient) UpdateResult(_ context.Context, _ *pb.UpdateResultRequest, _ ...grpc.CallOption) (*pb.Result, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// DeleteResult is unimplemented
+func (c *ResultsClient) DeleteResult(_ context.Context, _ *pb.DeleteResultRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// CreateRecord is unimplemented
+func (c *ResultsClient) CreateRecord(_ context.Context, _ *pb.CreateRecordRequest, _ ...grpc.CallOption) (*pb.Record, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// UpdateRecord is unimplemented
+func (c *ResultsClient) UpdateRecord(_ context.Context, _ *pb.UpdateRecordRequest, _ ...grpc.CallOption) (*pb.Record, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// GetRecord is unimplemented
+func (c *ResultsClient) GetRecord(_ context.Context, in *pb.GetRecordRequest, _ ...grpc.CallOption) (*pb.Record, error) {
+	record, exists := c.records[in.Name]
+	if !exists {
+		return nil, fmt.Errorf("record not found: %s", in.Name)
+	}
+	return record, nil
+}
+
+// ListRecords is unimplemented
+func (c *ResultsClient) ListRecords(_ context.Context, _ *pb.ListRecordsRequest, _ ...grpc.CallOption) (*pb.ListRecordsResponse, error) {
+	records := make([]*pb.Record, 0, len(c.records))
+	for _, record := range c.records {
+		records = append(records, record)
+	}
+	return &pb.ListRecordsResponse{
+		Records: records,
+	}, nil
+}
+
+// DeleteRecord is unimplemented
+func (c *ResultsClient) DeleteRecord(_ context.Context, _ *pb.DeleteRecordRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// GetRecordListSummary is unimplemented
+func (c *ResultsClient) GetRecordListSummary(_ context.Context, _ *pb.RecordListSummaryRequest, _ ...grpc.CallOption) (*pb.RecordListSummary, error) {
+	return nil, fmt.Errorf("unimplemented")
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`tkn-results` introduces commands for listing pipelineruns and describing results, improving user experience and assisting contributors in comprehending the Results API. Ideally, the `tkn-results` experience should mirror that of `tkn`(mybe in far future).

To list PipelineRuns in the `default` namespace, use: `tkn-results pipelinerun list`

For details on a specific result, run: `tkn-results result describe <result-name>` or `tkn-results result describe  -n <namespace> --uid <result-uid>` 

Currently, PipelineRuns listing does not utilize paging.

Related to https://github.com/tektoncd/results/issues/587, More commands like `tkn results taskrun list/describe/logs` are expected to be added in an upcoming PR(Try best I can).

# Breaking Changes
`tkn-results list` is moved to `tkn-results result list` for clarity.

# Examples
`records get`:
```
(base) ➜  results git:(feat-tkn-results-cli-ux) ✗ bin/tkn-results records get default/results/6dbeca0d-7029-4b7e-a535-e3c9259923e2/records/fcf2c228-9808-32a8-8c7e-8d9ec536ad3e
Name:              default/results/6dbeca0d-7029-4b7e-a535-e3c9259923e2/records/fcf2c228-9808-32a8-8c7e-8d9ec536ad3e
UID:               1680bf31-c78d-4168-bd0b-051c64e3225c
Status:
Created:   4 days ago   Duration:   6.798992s
Type:         results.tekton.dev/v1alpha3.Log
Data:
{
         "kind": "Log",
         "spec": {
           "type": "File",
           "resource": {
             "uid": "6dbeca0d-7029-4b7e-a535-e3c9259923e2",
             "kind": "TaskRun",
             "name": "hello-task-runctshh",
             "namespace": "default"
           }
         },
         "status": {
           "path": "default/fcf2c228-9808-32a8-8c7e-8d9ec536ad3e/hello-task-runctshh-log",
           "size": 268,
           "isStored": true,
           "isRetryableErr": false,
           "errorOnStoreMsg": ""
         },
         "metadata": {
           "uid": "fcf2c228-9808-32a8-8c7e-8d9ec536ad3e",
           "name": "hello-task-runctshh-log",
           "namespace": "default",
           "creationTimestamp": null
         },
         "apiVersion": "results.tekton.dev/v1alpha3"
       }
```

`pipelinerun list`:
```
(base) ➜  results git:(feat-tkn-results-cli-ux) ✗ bin/tkn-results pipelinerun list
NAMESPACE   UID                       STARTED      DURATION   STATUS
default     hello-goodbye-run-vfsxn   4 days ago   1m10s      Succeeded
default     hello-goodbye-run-xtw2j   4 days ago   0s         Failed(CouldntGetTask)
```

And `result describe` below.
# Known issues: 
```
(base) ➜  results git:(feat-tkn-results-cli-ux) ✗ bin/tkn-results result describe default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7       
Name:   default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7
UID:    949eebd9-1cf7-478f-a547-9ee313035f10
Annotations:
        object.metadata.name=hello-goodbye-run-vfsxn
        tekton.dev/pipeline=hello-goodbye
Status:
        Created:   23 hours ago   DURATION: 1m9.582481s
Summary:
        Type:   tekton.dev/v1.PipelineRun
        Status:
        STARTED   DURATION   STATUS
         ---       ---        SUCCESS
```
STARTED and DURATION are not displayed due to the absence of start/end times in the result summary.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
`tkn-results` introduces commands for listing and describing pipeline runs and results. The command `tkn-results list -` is now `tkn-results result list`.
```
