### PR TITLE
Fix Logs ordered from the Loki response

### DIFF
--- a/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
@@ -58,9 +58,21 @@ func TestLogPluginServer_GetLog(t *testing.T) {
 			"data": map[string]interface{}{
 				"result": []map[string]interface{}{
 					{
-						"stream": map[string]string{"message": "Foo Bar!"},
+						"stream": map[string]string{},
 						"values": [][]string{
-							{"1625081600000000000", "Hello World!"},
+							{"1625081600000000001", "Log Message 1"},
+						},
+					},
+					{
+						"stream": map[string]string{},
+						"values": [][]string{
+							{"1625081600000000003", "Log Message 3"},
+						},
+					},
+					{
+						"stream": map[string]string{},
+						"values": [][]string{
+							{"1625081600000000000", "Log Message 0"},
 						},
 					},
 				},
@@ -139,7 +151,7 @@ func TestLogPluginServer_GetLog(t *testing.T) {
 		Name: log.FormatName(res.GetName(), "baz"),
 	}
 
-	expectedData := "Foo Bar!"
+	expectedData := "Log Message 0\nLog Message 1\nLog Message 3"
 	// Call GetLog
 	err = srv.LogPluginServer.GetLog(req, mockServer)
 	if err != nil {


### PR DESCRIPTION
Before this logs weren't sorted. This fixes the logs order by utilizing the unixtime in the value field.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
This fixes the logs returned by loki.

```
