### PR TITLE
Add Container name to the logs being fetched from Loki

### DIFF
--- a/config/base/env/config
+++ b/config/base/env/config
@@ -41,6 +41,7 @@ LOGGING_PLUGIN_PROXY_PATH=/api/logs/v1/application
 LOGGING_PLUGIN_API_URL=
 LOGGING_PLUGIN_TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
 LOGGING_PLUGIN_NAMESPACE_KEY=kubernetes_namespace_name
+LOGGING_PLUGIN_CONTAINER_KEY=kubernetes.container_name
 LOGGING_PLUGIN_STATIC_LABELS='log_type=application'
 LOGGING_PLUGIN_CA_CERT=
 LOGGING_PLUGIN_QUERY_LIMIT=1700

--- a/docs/logging-support.md
+++ b/docs/logging-support.md
@@ -43,6 +43,7 @@ These are the common configuration options for all third party logging APIs.
 - `LOGGING_PLUGIN_API_URL`: The URL of the third party logging API.
 - `LOGGING_PLUGIN_TOKEN_PATH`: The path to the file containing the API token. (optional)
 - `LOGGING_PLUGIN_NAMESPACE_KEY`: The key to use for the namespace filtering.
+- `LOGGING_PLUGIN_CONTAINER_KEY`: The key to use for adding container name to the logs. (optional)
 - `LOGGING_PLUGIN_STATIC_LABELS`: The static labels to use for the logs.
 - `LOGGING_PLUGIN_PROXY_PATH`: The path to the proxy to use for the third party logging API. (optional)
 - `LOGGING_PLUGIN_CA_CERT`: The CA certificate to use for the third party logging API. This should ideally be passed as environment variable in the deployment spec of the results-api pod. (optional)

--- a/pkg/api/server/config/config.go
+++ b/pkg/api/server/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 
 	LOGGING_PLUGIN_API_URL                  string `mapstructure:"LOGGING_PLUGIN_API_URL"`
 	LOGGING_PLUGIN_NAMESPACE_KEY            string `mapstructure:"LOGGING_PLUGIN_NAMESPACE_KEY"`
+	LOGGING_PLUGIN_CONTAINER_KEY            string `mapstructure:"LOGGING_PLUGIN_CONTAINER_KEY"`
 	LOGGING_PLUGIN_STATIC_LABELS            string `mapstructure:"LOGGING_PLUGIN_STATIC_LABELS"`
 	LOGGING_PLUGIN_TOKEN_PATH               string `mapstructure:"LOGGING_PLUGIN_TOKEN_PATH"`
 	LOGGING_PLUGIN_PROXY_PATH               string `mapstructure:"LOGGING_PLUGIN_PROXY_PATH"`

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -170,7 +170,11 @@ func getLokiLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) 
 	for k, v := range s.queryParams {
 		parameters.Add(k, v)
 	}
-	parameters.Add("query", `{ `+s.staticLabels+s.config.LOGGING_PLUGIN_NAMESPACE_KEY+`="`+parent+`" }|json uid="`+uidKey+`", message="message" |uid="`+rec.Name+`"| line_format "{{.message}}"`)
+	query := `{ ` + s.staticLabels + s.config.LOGGING_PLUGIN_NAMESPACE_KEY + `="` + parent + `" }|json uid="` + uidKey + `", message="message" |uid="` + rec.Name + `"| line_format "{{.message}}"`
+	if s.config.LOGGING_PLUGIN_CONTAINER_KEY != "" {
+		query = `{ ` + s.staticLabels + s.config.LOGGING_PLUGIN_NAMESPACE_KEY + `="` + parent + `" }|json uid="` + uidKey + `", container="` + s.config.LOGGING_PLUGIN_CONTAINER_KEY + `", message="message" |uid="` + rec.Name + `"| line_format "container-{{.container}}: message={{.message}}"`
+	}
+	parameters.Add("query", query)
 	parameters.Add("end", endTime)
 	parameters.Add("start", startTime)
 	parameters.Add("limit", strconv.FormatUint(uint64(s.queryLimit), 10))

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
@@ -60,19 +60,19 @@ func TestLogPluginServer_GetLog(t *testing.T) {
 					{
 						"stream": map[string]string{},
 						"values": [][]string{
-							{"1625081600000000001", "Log Message 1"},
+							{"1625081600000000001", "container-step-foo: Log Message 1"},
 						},
 					},
 					{
 						"stream": map[string]string{},
 						"values": [][]string{
-							{"1625081600000000003", "Log Message 3"},
+							{"1625081600000000003", "container-step-foo: Log Message 3"},
 						},
 					},
 					{
 						"stream": map[string]string{},
 						"values": [][]string{
-							{"1625081600000000000", "Log Message 0"},
+							{"1625081600000000000", "container-step-foo: Log Message 0"},
 						},
 					},
 				},
@@ -99,6 +99,7 @@ func TestLogPluginServer_GetLog(t *testing.T) {
 		LOGGING_PLUGIN_TLS_VERIFICATION_DISABLE: true,
 		LOGGING_PLUGIN_STATIC_LABELS:            "namespace=\"foo\"",
 		LOGGING_PLUGIN_NAMESPACE_KEY:            "namespace",
+		LOGGING_PLUGIN_CONTAINER_KEY:            "kubernetes.container_name",
 		LOGGING_PLUGIN_QUERY_LIMIT:              1500,
 		LOGGING_PLUGIN_QUERY_PARAMS:             "direction=forward",
 	}, logger.Get("info"), test.NewDB(t))
@@ -151,7 +152,7 @@ func TestLogPluginServer_GetLog(t *testing.T) {
 		Name: log.FormatName(res.GetName(), "baz"),
 	}
 
-	expectedData := "Log Message 0\nLog Message 1\nLog Message 3"
+	expectedData := "container-step-foo: Log Message 0\ncontainer-step-foo: Log Message 1\ncontainer-step-foo: Log Message 3"
 	// Call GetLog
 	err = srv.LogPluginServer.GetLog(req, mockServer)
 	if err != nil {

--- a/test/e2e/loki_vector/loki-vector-api-config.yaml
+++ b/test/e2e/loki_vector/loki-vector-api-config.yaml
@@ -24,6 +24,7 @@ data:
     LOGGING_PLUIN_TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
     LOGGING_PLUGIN_PROXY_PATH=
     LOGGING_PLUGIN_NAMESPACE_KEY=kubernetes_namespace_name
+    LOGGING_PLUGIN_CONTAINER_KEY=kubernetes.container_name
     LOGGING_PLUGIN_API_URL=http://loki.logging.svc.cluster.local:3100/loki/api/v1/query_range
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Adding container name to help us figure out from which step a particular log is generated.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
Logs returned from Loki have container name.  This is confiurable by LOGGING_PLUGIN_CONTAINER_KEY. In case of loki + vector, it's  kubernetes.container_name.
```

