### PR TITLE
Fix Nil Pointer Panic in API server Get Log

### DIFF
--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -167,7 +167,7 @@ func getLokiLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) 
 		endTime = strconv.FormatInt(data.Status.CompletionTime.Add(s.forwarderDelayDuration).UTC().Unix(), 10)
 
 	default:
-		s.logger.Error("record type is invalid")
+		s.logger.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID:  %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID)
 		return errors.New("record type is invalid")
 	}
 
@@ -383,7 +383,7 @@ func getBlobLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) 
 		}
 		logPath[""] = filepath.Join(s.config.LOGS_PATH, log.Status.Path)
 	default:
-		s.logger.Errorf("record type is invalid %s", rec.Type)
+		s.logger.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID:  %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID)
 		return fmt.Errorf("record type is invalid %s", rec.Type)
 	}
 
@@ -451,17 +451,20 @@ func (s *LogServer) LogMux() http.Handler {
 		if err != nil {
 			s.logger.Error(err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		if rec == nil {
 			s.logger.Errorf("records not found: parent: %s, result: %s, recID: %s", parent, res, recID)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		err = s.getLog(s, w, parent, rec)
 		if err != nil {
 			s.logger.Error(err)
 			http.Error(w, "Failed to stream logs err: "+err.Error(), http.StatusInternalServerError)
+			return
 		}
 	})
 }


### PR DESCRIPTION
Add a nil pointer fix by adding a return statement after getting an error or nil record.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
Fix Nil Pointer Panic in API server Get Log for non existent record.
```
