### PR TITLE
[CLI enhancement] Add taskrun list command

### DIFF
--- a/docs/cli/tkn-results.md
+++ b/docs/cli/tkn-results.md
@@ -59,4 +59,5 @@ Example:
 * [tkn-results pipelinerun](tkn-results_pipelinerun.md)	 - Query PipelineRuns
 * [tkn-results records](tkn-results_records.md)	 - Command sub-group for querying Records
 * [tkn-results result](tkn-results_result.md)	 - Query Results
+* [tkn-results taskrun](tkn-results_taskrun.md)	 - Query TaskRuns
 

--- a/docs/cli/tkn-results_pipelinerun_list.md
+++ b/docs/cli/tkn-results_pipelinerun_list.md
@@ -12,9 +12,6 @@ tkn-results pipelinerun list [pipeline-name]
 List all PipelineRuns in a namespace 'foo':
     tkn-results pipelinerun list -n foo
 
-List all PipelineRuns in 'default' namespace:
-    tkn-results pipelinerun list -n default
-
 List PipelineRuns with a specific label:
     tkn-results pipelinerun list -L app=myapp
 

--- a/docs/cli/tkn-results_taskrun.md
+++ b/docs/cli/tkn-results_taskrun.md
@@ -1,33 +1,33 @@
-## tkn-results pipelinerun
+## tkn-results taskrun
 
-Query PipelineRuns
+Query TaskRuns
 
 ### Synopsis
 
-Query PipelineRuns stored in Tekton Results.
+Query TaskRuns stored in Tekton Results.
 
-This command allows you to list PipelineRuns stored in Tekton Results.
+This command allows you to list TaskRuns stored in Tekton Results.
 You can filter results by namespace, labels and other criteria.
 
 Examples:
-  # List PipelineRuns in a namespace
-  tkn-results pipelinerun list -n default
+  # List TaskRuns in a namespace
+  tkn-results taskrun list -n default
 
-  # List PipelineRuns with a specific label
-  tkn-results pipelinerun list -L app=myapp
+  # List TaskRuns with a specific label
+  tkn-results taskrun list -L app=myapp
 
-  # List PipelineRuns from all namespaces
-  tkn-results pipelinerun list -A
+  # List TaskRuns from all namespaces
+  tkn-results taskrun list -A
 
-  # List PipelineRuns with limit
-  tkn-results pipelinerun list --limit=20
+  # List TaskRuns with limit
+  tkn-results taskrun list --limit=20
 
 ### Options
 
 ```
       --api-path string            api path to use (default: value provided in config set command)
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
-  -h, --help                       help for pipelinerun
+  -h, --help                       help for taskrun
       --host string                host to use (default: value provided in config set command)
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
@@ -50,5 +50,5 @@ Examples:
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI
-* [tkn-results pipelinerun list](tkn-results_pipelinerun_list.md)	 - List PipelineRuns in a namespace
+* [tkn-results taskrun list](tkn-results_taskrun_list.md)	 - List TaskRuns in a namespace
 

--- a/docs/cli/tkn-results_taskrun_list.md
+++ b/docs/cli/tkn-results_taskrun_list.md
@@ -33,16 +33,20 @@ List TaskRuns for a specific task:
 List TaskRuns with partial task name match:
     tkn-results taskrun list build -n namespace
 
+List TaskRuns for a specific PipelineRun:
+    tkn-results taskrun list --pipelinerun my-pipeline-run -n namespace
+
 ```
 
 ### Options
 
 ```
-  -A, --all-namespaces   List TaskRuns from all namespaces
-  -h, --help             help for list
-  -L, --label string     Filter by label (format: key=value[,key=value...])
-      --limit int32      Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50) (default 50)
-      --single-page      Return only a single page of results (default true)
+  -A, --all-namespaces       List TaskRuns from all namespaces
+  -h, --help                 help for list
+  -L, --label string         Filter by label (format: key=value[,key=value...])
+      --limit int32          Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50) (default 50)
+      --pipelinerun string   Filter TaskRuns by PipelineRun name. Note that multiple PipelineRuns can have the same name, so this will return TaskRuns from all PipelineRuns with the matching name.
+      --single-page          Return only a single page of results (default true)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/tkn-results_taskrun_list.md
+++ b/docs/cli/tkn-results_taskrun_list.md
@@ -1,47 +1,47 @@
-## tkn-results pipelinerun list
+## tkn-results taskrun list
 
-List PipelineRuns in a namespace
+List TaskRuns in a namespace
 
 ```
-tkn-results pipelinerun list [pipeline-name]
+tkn-results taskrun list [task-name]
 ```
 
 ### Examples
 
 ```
-List all PipelineRuns in a namespace 'foo':
-    tkn-results pipelinerun list -n foo
+List all TaskRuns in a namespace 'foo':
+    tkn-results taskrun list -n foo
 
-List all PipelineRuns in 'default' namespace:
-    tkn-results pipelinerun list -n default
+List all TaskRuns in 'default' namespace:
+    tkn-results taskrun list -n default
 
-List PipelineRuns with a specific label:
-    tkn-results pipelinerun list -L app=myapp
+List TaskRuns with a specific label:
+    tkn-results taskrun list -L app=myapp
 
-List PipelineRuns with multiple label selectors:
-    tkn-results pipelinerun list -L app=myapp,env=prod
+List TaskRuns with multiple labels:
+    tkn-results taskrun list --label app=myapp,env=prod
 
-List PipelineRuns from all namespaces:
-    tkn-results pipelinerun list -A
+List TaskRuns from all namespaces:
+    tkn-results taskrun list -A
 
-List PipelineRuns with limit of 20 per page:
-    tkn-results pipelinerun list --limit=20
+List TaskRuns with limit of 20 per page:
+    tkn-results taskrun list --limit=20
 
-List PipelineRuns for a specific pipeline:
-    tkn-results pipelinerun list foo -n namespace
+List TaskRuns for a specific task:
+    tkn-results taskrun list foo -n namespace
 
-List PipelineRuns with partial pipeline name match:
-    tkn-results pipelinerun list build -n namespace
+List TaskRuns with partial task name match:
+    tkn-results taskrun list build -n namespace
 
 ```
 
 ### Options
 
 ```
-  -A, --all-namespaces   List PipelineRuns from all namespaces
+  -A, --all-namespaces   List TaskRuns from all namespaces
   -h, --help             help for list
-  -L, --label string     Filter by label (format: key=value,key2=value2)
-      --limit int32      Maximum number of PipelineRuns to return (must be between 5 and 1000 and defaults to 50) (default 50)
+  -L, --label string     Filter by label (format: key=value[,key=value...])
+      --limit int32      Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50) (default 50)
       --single-page      Return only a single page of results (default true)
 ```
 
@@ -66,5 +66,5 @@ List PipelineRuns with partial pipeline name match:
 
 ### SEE ALSO
 
-* [tkn-results pipelinerun](tkn-results_pipelinerun.md)	 - Query PipelineRuns
+* [tkn-results taskrun](tkn-results_taskrun.md)	 - Query TaskRuns
 

--- a/docs/cli/tkn-results_taskrun_list.md
+++ b/docs/cli/tkn-results_taskrun_list.md
@@ -12,9 +12,6 @@ tkn-results taskrun list [task-name]
 List all TaskRuns in a namespace 'foo':
     tkn-results taskrun list -n foo
 
-List all TaskRuns in 'default' namespace:
-    tkn-results taskrun list -n default
-
 List TaskRuns with a specific label:
     tkn-results taskrun list -L app=myapp
 

--- a/docs/man/man1/tkn-results-pipelinerun-list.1
+++ b/docs/man/man1/tkn-results-pipelinerun-list.1
@@ -101,9 +101,6 @@ List PipelineRuns in a namespace
 List all PipelineRuns in a namespace 'foo':
     tkn-results pipelinerun list -n foo
 
-List all PipelineRuns in 'default' namespace:
-    tkn-results pipelinerun list -n default
-
 List PipelineRuns with a specific label:
     tkn-results pipelinerun list -L app=myapp
 

--- a/docs/man/man1/tkn-results-taskrun-list.1
+++ b/docs/man/man1/tkn-results-taskrun-list.1
@@ -105,9 +105,6 @@ List TaskRuns in a namespace
 List all TaskRuns in a namespace 'foo':
     tkn-results taskrun list -n foo
 
-List all TaskRuns in 'default' namespace:
-    tkn-results taskrun list -n default
-
 List TaskRuns with a specific label:
     tkn-results taskrun list -L app=myapp
 

--- a/docs/man/man1/tkn-results-taskrun-list.1
+++ b/docs/man/man1/tkn-results-taskrun-list.1
@@ -34,6 +34,10 @@ List TaskRuns in a namespace
 	Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50)
 
 .PP
+\fB--pipelinerun\fP=""
+	Filter TaskRuns by PipelineRun name. Note that multiple PipelineRuns can have the same name, so this will return TaskRuns from all PipelineRuns with the matching name.
+
+.PP
 \fB--single-page\fP[=true]
 	Return only a single page of results
 
@@ -121,6 +125,9 @@ List TaskRuns for a specific task:
 
 List TaskRuns with partial task name match:
     tkn-results taskrun list build -n namespace
+
+List TaskRuns for a specific PipelineRun:
+    tkn-results taskrun list --pipelinerun my-pipeline-run -n namespace
 
 .EE
 

--- a/docs/man/man1/tkn-results-taskrun-list.1
+++ b/docs/man/man1/tkn-results-taskrun-list.1
@@ -3,23 +3,23 @@
 
 .SH NAME
 .PP
-tkn-results-pipelinerun-list - List PipelineRuns in a namespace
+tkn-results-taskrun-list - List TaskRuns in a namespace
 
 
 .SH SYNOPSIS
 .PP
-\fBtkn-results pipelinerun list [pipeline-name]\fP
+\fBtkn-results taskrun list [task-name]\fP
 
 
 .SH DESCRIPTION
 .PP
-List PipelineRuns in a namespace
+List TaskRuns in a namespace
 
 
 .SH OPTIONS
 .PP
 \fB-A\fP, \fB--all-namespaces\fP[=false]
-	List PipelineRuns from all namespaces
+	List TaskRuns from all namespaces
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]
@@ -27,11 +27,11 @@ List PipelineRuns in a namespace
 
 .PP
 \fB-L\fP, \fB--label\fP=""
-	Filter by label (format: key=value,key2=value2)
+	Filter by label (format: key=value[,key=value...])
 
 .PP
 \fB--limit\fP=50
-	Maximum number of PipelineRuns to return (must be between 5 and 1000 and defaults to 50)
+	Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50)
 
 .PP
 \fB--single-page\fP[=true]
@@ -98,33 +98,33 @@ List PipelineRuns in a namespace
 
 .SH EXAMPLE
 .EX
-List all PipelineRuns in a namespace 'foo':
-    tkn-results pipelinerun list -n foo
+List all TaskRuns in a namespace 'foo':
+    tkn-results taskrun list -n foo
 
-List all PipelineRuns in 'default' namespace:
-    tkn-results pipelinerun list -n default
+List all TaskRuns in 'default' namespace:
+    tkn-results taskrun list -n default
 
-List PipelineRuns with a specific label:
-    tkn-results pipelinerun list -L app=myapp
+List TaskRuns with a specific label:
+    tkn-results taskrun list -L app=myapp
 
-List PipelineRuns with multiple label selectors:
-    tkn-results pipelinerun list -L app=myapp,env=prod
+List TaskRuns with multiple labels:
+    tkn-results taskrun list --label app=myapp,env=prod
 
-List PipelineRuns from all namespaces:
-    tkn-results pipelinerun list -A
+List TaskRuns from all namespaces:
+    tkn-results taskrun list -A
 
-List PipelineRuns with limit of 20 per page:
-    tkn-results pipelinerun list --limit=20
+List TaskRuns with limit of 20 per page:
+    tkn-results taskrun list --limit=20
 
-List PipelineRuns for a specific pipeline:
-    tkn-results pipelinerun list foo -n namespace
+List TaskRuns for a specific task:
+    tkn-results taskrun list foo -n namespace
 
-List PipelineRuns with partial pipeline name match:
-    tkn-results pipelinerun list build -n namespace
+List TaskRuns with partial task name match:
+    tkn-results taskrun list build -n namespace
 
 .EE
 
 
 .SH SEE ALSO
 .PP
-\fBtkn-results-pipelinerun(1)\fP
+\fBtkn-results-taskrun(1)\fP

--- a/docs/man/man1/tkn-results-taskrun.1
+++ b/docs/man/man1/tkn-results-taskrun.1
@@ -3,38 +3,38 @@
 
 .SH NAME
 .PP
-tkn-results-pipelinerun - Query PipelineRuns
+tkn-results-taskrun - Query TaskRuns
 
 
 .SH SYNOPSIS
 .PP
-\fBtkn-results pipelinerun\fP
+\fBtkn-results taskrun\fP
 
 
 .SH DESCRIPTION
 .PP
-Query PipelineRuns stored in Tekton Results.
+Query TaskRuns stored in Tekton Results.
 
 .PP
-This command allows you to list PipelineRuns stored in Tekton Results.
+This command allows you to list TaskRuns stored in Tekton Results.
 You can filter results by namespace, labels and other criteria.
 
 .PP
 Examples:
-  # List PipelineRuns in a namespace
-  tkn-results pipelinerun list -n default
+  # List TaskRuns in a namespace
+  tkn-results taskrun list -n default
 
 .PP
-# List PipelineRuns with a specific label
-  tkn-results pipelinerun list -L app=myapp
+# List TaskRuns with a specific label
+  tkn-results taskrun list -L app=myapp
 
 .PP
-# List PipelineRuns from all namespaces
-  tkn-results pipelinerun list -A
+# List TaskRuns from all namespaces
+  tkn-results taskrun list -A
 
 .PP
-# List PipelineRuns with limit
-  tkn-results pipelinerun list --limit=20
+# List TaskRuns with limit
+  tkn-results taskrun list --limit=20
 
 
 .SH OPTIONS
@@ -48,7 +48,7 @@ Examples:
 
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for pipelinerun
+	help for taskrun
 
 .PP
 \fB--host\fP=""
@@ -103,4 +103,4 @@ Examples:
 
 .SH SEE ALSO
 .PP
-\fBtkn-results(1)\fP, \fBtkn-results-pipelinerun-list(1)\fP
+\fBtkn-results(1)\fP, \fBtkn-results-taskrun-list(1)\fP

--- a/docs/man/man1/tkn-results.1
+++ b/docs/man/man1/tkn-results.1
@@ -89,4 +89,4 @@ portforward: false
 
 .SH SEE ALSO
 .PP
-\fBtkn-results-config(1)\fP, \fBtkn-results-logs(1)\fP, \fBtkn-results-pipelinerun(1)\fP, \fBtkn-results-records(1)\fP, \fBtkn-results-result(1)\fP
+\fBtkn-results-config(1)\fP, \fBtkn-results-logs(1)\fP, \fBtkn-results-pipelinerun(1)\fP, \fBtkn-results-records(1)\fP, \fBtkn-results-result(1)\fP, \fBtkn-results-taskrun(1)\fP

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -228,7 +228,7 @@ func printFormattedPr(s *cli.Stream, prs *v1.PipelineRunList, c clockwork.Clock,
 	}
 
 	funcMap := template.FuncMap{
-		"formatAge":       formatted.Age,
+		"formatAge":       common.FormatAge,
 		"formatDuration":  formatted.Duration,
 		"formatCondition": formatted.Condition,
 	}

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -53,9 +53,6 @@ func listCommand(p common.Params) *cobra.Command {
 	eg := `List all PipelineRuns in a namespace 'foo':
     tkn-results pipelinerun list -n foo
 
-List all PipelineRuns in 'default' namespace:
-    tkn-results pipelinerun list -n default
-
 List PipelineRuns with a specific label:
     tkn-results pipelinerun list -L app=myapp
 
@@ -155,13 +152,9 @@ List PipelineRuns with partial pipeline name match:
 					return err
 				}
 
-				// If single page is requested, break after first iteration
-				if opts.SinglePage {
-					break
-				}
-
-				// If there's no next page token, we're done
-				if resp.NextPageToken == "" {
+				// If single page is requested or if there's no next page token,
+				// we're done break after first iteration
+				if opts.SinglePage || resp.NextPageToken == "" {
 					break
 				}
 

--- a/pkg/cli/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cli/cmd/pipelinerun/pipelinerun.go
@@ -23,12 +23,12 @@ Examples:
   tkn-results pipelinerun list -n default
 
   # List PipelineRuns with a specific label
-  tkn-results pipelinerun list -l app=myapp
+  tkn-results pipelinerun list -L app=myapp
 
   # List PipelineRuns from all namespaces
   tkn-results pipelinerun list -A
 
-  # List PipelineRuns without pagination
+  # List PipelineRuns with limit
   tkn-results pipelinerun list --limit=20`,
 		PersistentPreRunE: prerun.PersistentPreRunE(p),
 		Annotations: map[string]string{

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/tektoncd/results/pkg/cli/cmd/taskrun"
+
 	"github.com/tektoncd/results/pkg/cli/cmd/pipelinerun"
 
 	"github.com/tektoncd/results/pkg/cli/cmd/config"
@@ -68,6 +70,7 @@ func Root(p common.Params) *cobra.Command {
 		// new commands
 		config.Command(p),
 		pipelinerun.Command(p),
+		taskrun.Command(p),
 	)
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -74,6 +74,9 @@ List TaskRuns for a specific task:
 
 List TaskRuns with partial task name match:
     tkn-results taskrun list build -n namespace
+
+List TaskRuns for a specific PipelineRun:
+    tkn-results taskrun list --pipelinerun my-pipeline-run -n namespace
 `
 	cmd := &cobra.Command{
 		Use:     "list [task-name]",
@@ -115,6 +118,7 @@ List TaskRuns with partial task name match:
 	cmd.Flags().Int32VarP(&opts.Limit, "limit", "", 50, "Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50)")
 	cmd.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", false, "List TaskRuns from all namespaces")
 	cmd.Flags().StringVarP(&opts.Label, "label", "L", "", "Filter by label (format: key=value[,key=value...])")
+	cmd.Flags().StringVarP(&opts.PipelineRun, "pipelinerun", "", "", "Filter TaskRuns by PipelineRun name. Note that multiple PipelineRuns can have the same name, so this will return TaskRuns from all PipelineRuns with the matching name.")
 	cmd.Flags().BoolVar(&opts.SinglePage, "single-page", true, "Return only a single page of results")
 
 	return cmd

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -1,0 +1,263 @@
+package taskrun
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/tektoncd/results/pkg/cli/options"
+
+	"github.com/tektoncd/results/pkg/cli/client"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/formatted"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/results/pkg/cli/client/records"
+	"github.com/tektoncd/results/pkg/cli/common"
+	"github.com/tektoncd/results/pkg/cli/config"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+)
+
+const trListTemplate = `{{- $trl := len .TaskRuns.Items -}}{{- if eq $trl 0 -}}
+No TaskRuns found
+{{ else -}}
+{{- if not $.NoHeaders -}}
+{{- if $.AllNamespaces -}}
+NAMESPACE	NAME	UID	STARTED	DURATION	STATUS
+{{ else -}}
+NAME	UID	STARTED	DURATION	STATUS
+{{ end -}}
+{{- end -}}
+{{- range $_, $tr := .TaskRuns.Items }}{{- if $tr }}{{- if $.AllNamespaces -}}
+{{ $tr.Namespace }}	{{ $tr.Name }} {{ $tr.UID }}	{{ formatAge $tr.Status.StartTime $.Time }}	{{ formatDuration $tr.Status.StartTime $tr.Status.CompletionTime }}	{{ formatCondition $tr.Status.Conditions }}
+{{ else -}}
+{{ $tr.Name }}	{{ $tr.UID }}	{{ formatAge $tr.Status.StartTime $.Time }}	{{ formatDuration $tr.Status.StartTime $tr.Status.CompletionTime }}	{{ formatCondition $tr.Status.Conditions }}
+{{ end -}}{{- end -}}{{- end -}}
+{{- end -}}`
+
+// listCommand initializes a cobra command to list TaskRuns
+func listCommand(p common.Params) *cobra.Command {
+	opts := &options.ListOptions{
+		Limit:         50, // Default to 50
+		AllNamespaces: false,
+		SinglePage:    true, // Default to true
+	}
+
+	eg := `List all TaskRuns in a namespace 'foo':
+    tkn-results taskrun list -n foo
+
+List all TaskRuns in 'default' namespace:
+    tkn-results taskrun list -n default
+
+List TaskRuns with a specific label:
+    tkn-results taskrun list -L app=myapp
+
+List TaskRuns with multiple labels:
+    tkn-results taskrun list --label app=myapp,env=prod
+
+List TaskRuns from all namespaces:
+    tkn-results taskrun list -A
+
+List TaskRuns with limit of 20 per page:
+    tkn-results taskrun list --limit=20
+
+List TaskRuns for a specific task:
+    tkn-results taskrun list foo -n namespace
+
+List TaskRuns with partial task name match:
+    tkn-results taskrun list build -n namespace
+`
+	cmd := &cobra.Command{
+		Use:     "list [task-name]",
+		Aliases: []string{"ls"},
+		Short:   "List TaskRuns in a namespace",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			c, err := config.NewConfig(p)
+			if err != nil {
+				return err
+			}
+			opts.Client, err = client.NewRESTClient(c.Get())
+			if err != nil {
+				return err
+			}
+
+			if opts.Limit < 5 || opts.Limit > 1000 {
+				return errors.New("limit should be between 5 and 1000")
+			}
+
+			// Validate label format if provided
+			if opts.Label != "" {
+				return common.ValidateLabels(opts.Label)
+			}
+
+			if len(args) > 0 {
+				opts.ResourceName = args[0]
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return listTaskRuns(cmd.Context(), p, opts)
+		},
+	}
+
+	cmd.Flags().Int32VarP(&opts.Limit, "limit", "", 50, "Maximum number of TaskRuns to return (must be between 5 and 1000, default is 50)")
+	cmd.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", false, "List TaskRuns from all namespaces")
+	cmd.Flags().StringVarP(&opts.Label, "label", "L", "", "Filter by label (format: key=value[,key=value...])")
+	cmd.Flags().BoolVar(&opts.SinglePage, "single-page", true, "Return only a single page of results")
+
+	return cmd
+}
+
+func listTaskRuns(ctx context.Context, p common.Params, opts *options.ListOptions) error {
+	// Build filter string
+	filter := common.BuildFilterString(opts, "taskrun")
+
+	// Handle all namespaces
+	parent := fmt.Sprintf("%s/results/-", p.Namespace())
+	if opts.AllNamespaces {
+		parent = "*/results/-"
+	}
+
+	// Create initial request
+	req := &pb.ListRecordsRequest{
+		Parent:   parent,
+		Filter:   filter,
+		OrderBy:  "create_time desc",
+		PageSize: opts.Limit,
+	}
+
+	// Create record client
+	recordClient := records.NewClient(opts.Client)
+
+	// If single page is requested, just fetch and print
+	if opts.SinglePage {
+		resp, err := recordClient.ListRecords(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		stream := &cli.Stream{
+			Out: os.Stdout,
+			Err: os.Stderr,
+		}
+
+		// Parse records to TaskRuns before printing
+		trs, err := parseRecordsToTr(resp.Records)
+		if err != nil {
+			return err
+		}
+		return printFormattedTr(stream, trs, clockwork.NewRealClock(), opts.AllNamespaces, false)
+	}
+
+	// Interactive pagination
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		resp, err := recordClient.ListRecords(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		stream := &cli.Stream{
+			Out: os.Stdout,
+			Err: os.Stderr,
+		}
+
+		// Parse records to TaskRuns before printing
+		trs, err := parseRecordsToTr(resp.Records)
+		if err != nil {
+			return err
+		}
+		if err := printFormattedTr(stream, trs, clockwork.NewRealClock(), opts.AllNamespaces, false); err != nil {
+			return err
+		}
+
+		// If there's no next page token, we're done
+		if resp.NextPageToken == "" {
+			break
+		}
+
+		// Prompt for next page
+		if _, err := fmt.Fprintf(stream.Out, "\nPress 'n' for next page, 'q' to quit: "); err != nil {
+			return err
+		}
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+
+		// Trim whitespace and convert to lowercase
+		input = strings.TrimSpace(strings.ToLower(input))
+
+		// Handle user input
+		switch input {
+		case "n":
+			// Update request with next page token
+			req.PageToken = resp.NextPageToken
+		case "q":
+			return nil
+		default:
+			if _, err := fmt.Fprintf(stream.Out, "Invalid input. Exiting pagination.\n"); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func printFormattedTr(s *cli.Stream, trs *v1.TaskRunList, c clockwork.Clock, allnamespaces bool, noheaders bool) error {
+	var data = struct {
+		TaskRuns      *v1.TaskRunList
+		Time          clockwork.Clock
+		AllNamespaces bool
+		NoHeaders     bool
+	}{
+		TaskRuns:      trs,
+		Time:          c,
+		AllNamespaces: allnamespaces,
+		NoHeaders:     noheaders,
+	}
+
+	funcMap := template.FuncMap{
+		"formatAge":       formatted.Age,
+		"formatDuration":  formatted.Duration,
+		"formatCondition": formatted.Condition,
+	}
+
+	w := tabwriter.NewWriter(s.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	t := template.Must(template.New("List TaskRuns").Funcs(funcMap).Parse(trListTemplate))
+
+	err := t.Execute(w, data)
+	if err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+func parseRecordsToTr(records []*pb.Record) (*v1.TaskRunList, error) {
+	var taskRuns = new(v1.TaskRunList)
+
+	for _, record := range records {
+		var tr v1.TaskRun
+		if err := json.Unmarshal(record.Data.Value, &tr); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
+		}
+		taskRuns.Items = append(taskRuns.Items, tr)
+	}
+
+	return taskRuns, nil
+}

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -54,9 +54,6 @@ func listCommand(p common.Params) *cobra.Command {
 	eg := `List all TaskRuns in a namespace 'foo':
     tkn-results taskrun list -n foo
 
-List all TaskRuns in 'default' namespace:
-    tkn-results taskrun list -n default
-
 List TaskRuns with a specific label:
     tkn-results taskrun list -L app=myapp
 
@@ -172,13 +169,9 @@ func listTaskRuns(ctx context.Context, p common.Params, opts *options.ListOption
 			return err
 		}
 
-		// If single page is requested, break after first iteration
-		if opts.SinglePage {
-			break
-		}
-
-		// If there's no next page token, we're done
-		if resp.NextPageToken == "" {
+		// If single page is requested or if there's no next page token,
+		// we're done break after first iteration
+		if opts.SinglePage || resp.NextPageToken == "" {
 			break
 		}
 

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -232,7 +232,7 @@ func printFormattedTr(s *cli.Stream, trs *v1.TaskRunList, c clockwork.Clock, all
 	}
 
 	funcMap := template.FuncMap{
-		"formatAge":       formatted.Age,
+		"formatAge":       common.FormatAge,
 		"formatDuration":  formatted.Duration,
 		"formatCondition": formatted.Condition,
 	}

--- a/pkg/cli/cmd/taskrun/list_test.go
+++ b/pkg/cli/cmd/taskrun/list_test.go
@@ -1,0 +1,409 @@
+package taskrun
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"knative.dev/pkg/apis"
+
+	"github.com/tektoncd/results/pkg/cli/flags"
+	"github.com/tektoncd/results/pkg/cli/options"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/results/pkg/cli/client"
+	"github.com/tektoncd/results/pkg/cli/client/records"
+	"github.com/tektoncd/results/pkg/cli/common"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// testParams implements common.Params interface for testing
+type taskRunListTestParams struct {
+	common.ResultsParams
+	Client       *client.RESTClient
+	RecordClient records.RecordClient
+}
+
+type mockRecordClient struct {
+	records.RecordClient
+	listRecordsFunc func(ctx context.Context, req *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error)
+}
+
+func (m *mockRecordClient) ListRecords(ctx context.Context, req *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+	return m.listRecordsFunc(ctx, req)
+}
+
+// Mock implementation of GetRecordClient
+func (p *taskRunListTestParams) GetRecordClient(_ context.Context) (records.RecordClient, error) {
+	return p.RecordClient, nil
+}
+
+func TestListCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		listRecords    func(ctx context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error)
+		expectedOutput string
+		expectedError  bool
+	}{
+		{
+			name: "successful list with default options",
+			args: []string{"list"},
+			listRecords: func(_ context.Context, _ *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{
+						{
+							Name: "test-record",
+							Uid:  "test-uid",
+							Data: &pb.Any{
+								Value: []byte(`{"metadata":{"name":"taskrun-write-and-read-array-results-hjk57"},"status":{"conditions":[{"type":"Succeeded","status":"False"}]}}`),
+							},
+						},
+						{
+							Name: "test-record-2",
+							Uid:  "test-uid-2",
+							Data: &pb.Any{
+								Value: []byte(`{"metadata":{"name":"test-taskrun-5np8f"},"status":{"conditions":[{"type":"Succeeded","status":"True"}]}}`),
+							},
+						},
+					},
+				}, nil
+			},
+			expectedOutput: "taskrun-write-and-read-array-results-hjk57",
+			expectedError:  false,
+		},
+		{
+			name: "list with task name filter",
+			args: []string{"list", "test-task"},
+			listRecords: func(_ context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				expectedFilter := `(data_type=="tekton.dev/v1.TaskRun" || data_type=="tekton.dev/v1beta1.TaskRun") && data.metadata.name.contains("test-task")`
+				if in.Filter != expectedFilter {
+					t.Errorf("unexpected filter: got %v, want %v", in.Filter, expectedFilter)
+				}
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{
+						{
+							Name: "test-record",
+							Uid:  "test-uid",
+							Data: &pb.Any{
+								Value: []byte(`{"metadata":{"name":"test-task-run-1"},"status":{"conditions":[{"type":"Succeeded","status":"True"}]}}`),
+							},
+						},
+					},
+				}, nil
+			},
+			expectedOutput: "test-task-run-1",
+			expectedError:  false,
+		},
+		{
+			name: "list with single label filter",
+			args: []string{"list", "--label", "app=test"},
+			listRecords: func(_ context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				expectedFilter := `(data_type=="tekton.dev/v1.TaskRun" || data_type=="tekton.dev/v1beta1.TaskRun") && data.metadata.labels["app"]=="test"`
+				if in.Filter != expectedFilter {
+					t.Errorf("unexpected filter: got %v, want %v", in.Filter, expectedFilter)
+				}
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{
+						{
+							Name: "test-record",
+							Uid:  "test-uid",
+							Data: &pb.Any{
+								Value: []byte(`{"metadata":{"name":"test-taskrun","labels":{"app":"test"}},"status":{"conditions":[{"type":"Succeeded","status":"True"}]}}`),
+							},
+						},
+					},
+				}, nil
+			},
+			expectedOutput: "test-taskrun",
+			expectedError:  false,
+		},
+		{
+			name: "list with multiple label filters",
+			args: []string{"list", "--label", "app=test,env=prod"},
+			listRecords: func(_ context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				expectedFilter := `(data_type=="tekton.dev/v1.TaskRun" || data_type=="tekton.dev/v1beta1.TaskRun") && data.metadata.labels["app"]=="test" && data.metadata.labels["env"]=="prod"`
+				if in.Filter != expectedFilter {
+					t.Errorf("unexpected filter: got %v, want %v", in.Filter, expectedFilter)
+				}
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{
+						{
+							Name: "test-record",
+							Uid:  "test-uid",
+							Data: &pb.Any{
+								Value: []byte(`{"metadata":{"name":"test-taskrun","labels":{"app":"test","env":"prod"}},"status":{"conditions":[{"type":"Succeeded","status":"True"}]}}`),
+							},
+						},
+					},
+				}, nil
+			},
+			expectedOutput: "test-taskrun",
+			expectedError:  false,
+		},
+		{
+			name: "list with invalid label format",
+			args: []string{"list", "--label", "app=test,invalid"},
+			listRecords: func(_ context.Context, _ *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				return nil, nil
+			},
+			expectedOutput: "",
+			expectedError:  true,
+		},
+		{
+			name: "list with empty label value",
+			args: []string{"list", "--label", "app="},
+			listRecords: func(_ context.Context, _ *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				return nil, nil
+			},
+			expectedOutput: "",
+			expectedError:  true,
+		},
+		{
+			name: "list with empty label key",
+			args: []string{"list", "--label", "=test"},
+			listRecords: func(_ context.Context, _ *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				return nil, nil
+			},
+			expectedOutput: "",
+			expectedError:  true,
+		},
+		{
+			name: "list with task name and label filter",
+			args: []string{"list", "test-task", "--label", "app=test"},
+			listRecords: func(_ context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+				expectedFilter := `(data_type=="tekton.dev/v1.TaskRun" || data_type=="tekton.dev/v1beta1.TaskRun") && data.metadata.labels["app"]=="test" && data.metadata.name.contains("test-task")`
+				if in.Filter != expectedFilter {
+					t.Errorf("unexpected filter: got %v, want %v", in.Filter, expectedFilter)
+				}
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{
+						{
+							Name: "test-record",
+							Uid:  "test-uid",
+							Data: &pb.Any{
+								Value: []byte(`{"metadata":{"name":"test-task-run-1","labels":{"app":"test"}},"status":{"conditions":[{"type":"Succeeded","status":"True"}]}}`),
+							},
+						},
+					},
+				}, nil
+			},
+			expectedOutput: "test-task-run-1",
+			expectedError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock client
+			mockClient := &mockRecordClient{
+				listRecordsFunc: tt.listRecords,
+			}
+
+			// Create test params with mock client
+			params := &taskRunListTestParams{
+				ResultsParams: common.ResultsParams{},
+				RecordClient:  mockClient,
+			}
+			params.SetHost("http://localhost:8080")
+
+			// Create output and error buffers
+			var outBuf, errBuf bytes.Buffer
+
+			// Get the command
+			cmd := listCommand(params)
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&errBuf)
+			cmd.SetArgs(tt.args)
+
+			// Override PreRunE to bypass kubeconfig check
+			cmd.PreRunE = func(_ *cobra.Command, args []string) error {
+				if len(args) > 0 {
+					opts := &options.ListOptions{}
+					opts.ResourceName = args[0]
+				}
+				return nil
+			}
+
+			flags.AddResultsOptions(cmd)
+
+			// Override RunE to use mock client
+			cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+				opts := &options.ListOptions{
+					Limit:         10,
+					AllNamespaces: false,
+					SinglePage:    true,
+				}
+
+				if ns, nsErr := cmd.Flags().GetString("namespace"); nsErr == nil {
+					params.SetNamespace(ns)
+				}
+				if limit, limitErr := cmd.Flags().GetInt32("limit"); limitErr == nil {
+					opts.Limit = limit
+				}
+				if allNamespaces, allNsErr := cmd.Flags().GetBool("all-namespaces"); allNsErr == nil {
+					opts.AllNamespaces = allNamespaces
+				}
+				if singlePage, spErr := cmd.Flags().GetBool("single-page"); spErr == nil {
+					opts.SinglePage = singlePage
+				}
+				if label, labelErr := cmd.Flags().GetString("label"); labelErr == nil && label != "" {
+					opts.Label = label
+					// Validate label format only if label is provided
+					if err := common.ValidateLabels(label); err != nil {
+						return err
+					}
+				}
+				if len(tt.args) > 1 && tt.args[1] != "--label" {
+					opts.ResourceName = tt.args[1]
+				}
+
+				// Build filter string
+				filter := common.BuildFilterString(opts, "taskrun")
+
+				// Handle all namespaces
+				parent := fmt.Sprintf("%s/results/-", params.Namespace())
+				if opts.AllNamespaces {
+					parent = "*/results/-"
+				}
+
+				// Create initial request
+				req := &pb.ListRecordsRequest{
+					Parent:   parent,
+					Filter:   filter,
+					OrderBy:  "create_time desc",
+					PageSize: opts.Limit,
+				}
+
+				// Use the mock client directly
+				resp, listErr := mockClient.ListRecords(cmd.Context(), req)
+				if listErr != nil {
+					return listErr
+				}
+
+				stream := &cli.Stream{
+					Out: cmd.OutOrStdout(),
+					Err: cmd.OutOrStderr(),
+				}
+
+				// Parse records to TaskRuns before printing
+				trs, err := parseRecordsToTr(resp.Records)
+				if err != nil {
+					return err
+				}
+				return printFormattedTr(stream, trs, clockwork.NewRealClock(), opts.AllNamespaces, false)
+			}
+
+			// Execute the command
+			err := cmd.Execute()
+
+			// Check for expected error
+			if tt.expectedError {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check output
+			output := outBuf.String()
+			if !strings.Contains(output, tt.expectedOutput) {
+				t.Errorf("expected output to contain %q, got %q", tt.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func createMockTaskRunRecords(namespace string, count int) []*pb.Record {
+	records := make([]*pb.Record, count)
+	for i := 0; i < count; i++ {
+		tr := &v1.TaskRun{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "TaskRun",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("taskrun-%d", i),
+				Namespace: namespace,
+			},
+			Status: v1.TaskRunStatus{
+				Status: duckv1.Status{
+					Conditions: []apis.Condition{
+						{
+							Type:   "Succeeded",
+							Status: "True",
+						},
+					},
+				},
+				TaskRunStatusFields: v1.TaskRunStatusFields{
+					StartTime:      &metav1.Time{Time: time.Now()},
+					CompletionTime: &metav1.Time{Time: time.Now().Add(time.Hour)},
+				},
+			},
+		}
+		data, _ := json.Marshal(tr)
+		records[i] = &pb.Record{
+			Name: fmt.Sprintf("%s/results/-/records/taskrun-%d", namespace, i),
+			Data: &pb.Any{
+				Type:  "tekton.dev/v1.TaskRun",
+				Value: data,
+			},
+		}
+	}
+	return records
+}
+
+func TestParseRecordsToTr(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []*pb.Record
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "valid taskrun records",
+			records: createMockTaskRunRecords("default", 2),
+			want:    2,
+		},
+		{
+			name: "invalid taskrun data",
+			records: []*pb.Record{
+				{
+					Name: "test-record",
+					Data: &pb.Any{
+						Type:  "tekton.dev/v1.TaskRun",
+						Value: []byte("invalid json"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRecordsToTr(tt.records)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseRecordsToTr() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(got.Items) != tt.want {
+				t.Errorf("parseRecordsToTr() got %d items, want %d", len(got.Items), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/cmd/taskrun/taskrun.go
+++ b/pkg/cli/cmd/taskrun/taskrun.go
@@ -1,0 +1,45 @@
+package taskrun
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/results/pkg/cli/common"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
+	"github.com/tektoncd/results/pkg/cli/flags"
+)
+
+// Command returns a cobra command for `tkn-results taskrun` sub commands
+func Command(p common.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "taskrun",
+		Aliases: []string{"tr"},
+		Short:   "Query TaskRuns",
+		Long: `Query TaskRuns stored in Tekton Results.
+
+This command allows you to list TaskRuns stored in Tekton Results.
+You can filter results by namespace, labels and other criteria.
+
+Examples:
+  # List TaskRuns in a namespace
+  tkn-results taskrun list -n default
+
+  # List TaskRuns with a specific label
+  tkn-results taskrun list -L app=myapp
+
+  # List TaskRuns from all namespaces
+  tkn-results taskrun list -A
+
+  # List TaskRuns with limit
+  tkn-results taskrun list --limit=20`,
+		PersistentPreRunE: prerun.PersistentPreRunE(p),
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+
+	// Add flags to the taskrun command
+	flags.AddResultsOptions(cmd)
+
+	cmd.AddCommand(listCommand(p))
+
+	return cmd
+}

--- a/pkg/cli/cmd/taskrun/taskrun_test.go
+++ b/pkg/cli/cmd/taskrun/taskrun_test.go
@@ -1,0 +1,61 @@
+package taskrun
+
+import (
+	"testing"
+
+	"github.com/tektoncd/results/pkg/cli/common"
+)
+
+type testParams struct {
+	*common.ResultsParams
+}
+
+func (p *testParams) SetHost(host string) {
+	p.ResultsParams.SetHost(host)
+}
+
+func TestCommand(t *testing.T) {
+	// Create test params
+	params := &testParams{
+		ResultsParams: &common.ResultsParams{},
+	}
+	params.SetHost("http://localhost:8080")
+
+	// Get the command
+	cmd := Command(params)
+
+	// Test command configuration
+	t.Run("command configuration", func(t *testing.T) {
+		// Check command name and aliases
+		if cmd.Use != "taskrun" {
+			t.Errorf("unexpected command name: got %v, want %v", cmd.Use, "taskrun")
+		}
+		if len(cmd.Aliases) != 1 || cmd.Aliases[0] != "tr" {
+			t.Errorf("unexpected aliases: got %v, want [tr]", cmd.Aliases)
+		}
+
+		// Check command descriptions
+		if cmd.Short != "Query TaskRuns" {
+			t.Errorf("unexpected short description: got %v, want 'Query TaskRuns'", cmd.Short)
+		}
+		if cmd.PersistentPreRunE == nil {
+			t.Error("command should have PersistentPreRunE")
+		}
+
+		// Check command type annotation
+		if cmdType, ok := cmd.Annotations["commandType"]; !ok || cmdType != "main" {
+			t.Errorf("unexpected command type annotation: got %v, want 'main'", cmdType)
+		}
+	})
+
+	t.Run("subcommands", func(t *testing.T) {
+		// Check if list subcommand is registered
+		listCmd, _, err := cmd.Find([]string{"list"})
+		if err != nil {
+			t.Errorf("list subcommand not found: %v", err)
+		}
+		if listCmd.Name() != "list" {
+			t.Errorf("unexpected subcommand name: got %v, want 'list'", listCmd.Name())
+		}
+	})
+}

--- a/pkg/cli/common/format.go
+++ b/pkg/cli/common/format.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// FormatAge returns a human-readable string representation of how long ago a timestamp occurred.
+// The output format varies based on duration: seconds (<1m), minutes (<1h), hours (<24h), or days.
+func FormatAge(t *metav1.Time, c clockwork.Clock) string {
+	if t == nil {
+		return ""
+	}
+	age := c.Since(t.Time)
+	if age < time.Minute {
+		return fmt.Sprintf("%ds ago", int(age.Seconds()))
+	}
+	if age < time.Hour {
+		return fmt.Sprintf("%dm ago", int(age.Minutes()))
+	}
+	if age < 24*time.Hour {
+		return fmt.Sprintf("%dh ago", int(age.Hours()))
+	}
+	return fmt.Sprintf("%dd ago", int(age.Hours()/24))
+}

--- a/pkg/cli/options/list.go
+++ b/pkg/cli/options/list.go
@@ -1,0 +1,13 @@
+package options
+
+import "github.com/tektoncd/results/pkg/cli/client"
+
+// ListOptions holds the options for listing resources
+type ListOptions struct {
+	Client        *client.RESTClient
+	Limit         int32
+	AllNamespaces bool
+	Label         string
+	SinglePage    bool
+	ResourceName  string
+}

--- a/pkg/cli/options/list.go
+++ b/pkg/cli/options/list.go
@@ -8,6 +8,22 @@ type ListOptions struct {
 	Limit         int32
 	AllNamespaces bool
 	Label         string
+	PipelineRun   string
 	SinglePage    bool
 	ResourceName  string
+}
+
+// GetLabel implements FilterOptions interface
+func (o *ListOptions) GetLabel() string {
+	return o.Label
+}
+
+// GetResourceName implements FilterOptions interface
+func (o *ListOptions) GetResourceName() string {
+	return o.ResourceName
+}
+
+// GetPipelineRun implements FilterOptions interface
+func (o *ListOptions) GetPipelineRun() string {
+	return o.PipelineRun
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Follow-up PR towards the Results CLI enhancement [TEP](https://github.com/tektoncd/community/blob/main/teps/0160-enhance-results-cli.md)
Config command PR: https://github.com/tektoncd/results/pull/988
Pipelinerun list command PR: https://github.com/tektoncd/results/pull/995

This PR will add the command tkn-results taskrun list

Sample Run:

```
tkn-results tr ls -n tekton-ecosystem-tenant --limit 5                                                                                      
NAME                                                              UID                                    STARTED   DURATION   STATUS
openshift-pipelines-main-release-tests-zrgv6-e2e-test             10d6952f-b926-4e4b-a976-519867969ce7   16d ago   12m41s     Failed
openshift-pipelines-main-release-tests-zrgv6-deploy-operator      ab41b63b-16ec-4a32-8b95-f2678eb5c945   16d ago   22s        Succeeded
openshift-pipelines-main-release-tests-zrgv6-provision-cluster    b374df00-5132-4633-91df-3259670756b3   16d ago   12m30s     Succeeded
operator-main-index-4-18-on-pull-request-ml4ww-show-sbom          c5b77784-cd87-4be8-bc12-28957762f382   16d ago   16s        Succeeded
openshift-c4ae3a5a28e19ffc930e7c2aa758d85c-provision-eaas-space   22535d8e-d360-4143-9c0c-4bd0414a22b0   16d ago   17s        Succeeded
```

```
tkn-results tr ls tenant -n tekton-ecosystem-tenant                                                                                    
NAME                      UID                                    STARTED   DURATION   STATUS
tenant-8wrdv-create-tag   8b938c59-3311-44dc-a536-1fba8a829591   16d ago   20s        Succeeded
tenant-xx8sl-create-tag   78fea082-0806-4aac-9edf-12ee27d3bef0   16d ago   24s        Succeeded
tenant-brjmb-create-tag   fbbe7a36-eae5-458d-915d-505964ee76e0   16d ago   25s        Succeeded
tenant-t7zk6-create-tag   47c4b463-559f-44d7-bed9-dc72fd776cfc   17d ago   27s        Succeeded
tenant-58qft-create-tag   239d2082-31b4-4ee3-9ab0-51127db026f1   17d ago   37s        Succeeded
tenant-9lrfk-create-tag   80db1354-e2d5-40c4-a48e-158bf3341c78   17d ago   37s        Succeeded
tenant-76vgf-create-tag   da1a0a7d-f15a-4607-9386-bf45fa3da1cc   17d ago   45s        Succeeded
```
```
tkn-results tr ls --pipelinerun operator-main-index-4-18-on-pull-request-g95fk                                                             
NAME                                                              UID                                    STARTED   DURATION   STATUS
operator-main-index-4-18-on-pull-request-g95fk-show-sbom          5b405941-0d3e-4f8c-a68a-9ffcc481abf1   16d ago   13s        Succeeded
operator-main-index-4-18-on-pul2b222db723593a186d12f1b82f1a1fd9   89588ae7-aa36-4b62-97d1-5634ee201850   16d ago   36s        Succeeded
operator-fb80434867bc15d89fea82506058f664-fbc-fips-check-oci-ta   7598d44a-4370-459b-8ef0-ae4165c58ba5   16d ago   5m52s      Succeeded
operator-main-index-4-18-on-pull-request-g95fk-validate-fbc       fb80d962-807b-4b63-80cb-6a57d383755a   16d ago   1m26s      Succeeded
operator-main-index-4-18-on-pull-request-g95fk-apply-tags         8a34b46d-74a9-4f20-9e99-a285f7b258d6   16d ago   13s        Succeeded
```

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add taskrun list command to query TaskRuns stored in Tekton Results
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
