### PR TITLE
[CLI enchancement] Add pr describe command

### DIFF
--- a/docs/cli/tkn-results_pipelinerun.md
+++ b/docs/cli/tkn-results_pipelinerun.md
@@ -50,5 +50,6 @@ Examples:
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI
+* [tkn-results pipelinerun describe](tkn-results_pipelinerun_describe.md)	 - Describe a PipelineRun
 * [tkn-results pipelinerun list](tkn-results_pipelinerun_list.md)	 - List PipelineRuns in a namespace
 

--- a/docs/cli/tkn-results_pipelinerun_describe.md
+++ b/docs/cli/tkn-results_pipelinerun_describe.md
@@ -1,0 +1,54 @@
+## tkn-results pipelinerun describe
+
+Describe a PipelineRun
+
+### Synopsis
+
+Describe a PipelineRun by name or UID. If --uid is provided, then PipelineRun name is optional.
+
+```
+tkn-results pipelinerun describe [pipelinerun-name]
+```
+
+### Examples
+
+```
+Describe a PipelineRun in namespace 'foo':
+    tkn-results pipelinerun describe my-pipelinerun -n foo
+
+Describe a PipelineRun in 'default' namespace:
+    tkn-results pipelinerun describe my-pipelinerun
+
+```
+
+### Options
+
+```
+  -A, --all-namespaces   use all namespaces
+  -h, --help             help for describe
+      --uid string       UID of the PipelineRun to describe the details
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --addr string                Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+      --api-path string            api path to use (default: value provided in config set command)
+  -t, --authtoken string           authorization bearer token to use for authenticated requests
+  -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
+      --host string                host to use (default: value provided in config set command)
+      --insecure                   determines whether to run insecure GRPC tls request
+      --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
+  -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
+  -n, --namespace string           namespace to use (default: from $KUBECONFIG)
+      --portforward                enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string                  ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string               ServiceAccount Namespace, if not given, it will be taken from current context
+      --token string               bearer token to use (default: value provided in config set command)
+      --v1alpha2                   use v1alpha2 API for get log command
+```
+
+### SEE ALSO
+
+* [tkn-results pipelinerun](tkn-results_pipelinerun.md)	 - Query PipelineRuns
+

--- a/docs/man/man1/tkn-results-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-results-pipelinerun-describe.1
@@ -1,0 +1,104 @@
+.nh
+.TH "TKN-RESULTS" "1" "May 2025" "Tekton Results CLI" ""
+
+.SH NAME
+.PP
+tkn-results-pipelinerun-describe - Describe a PipelineRun
+
+
+.SH SYNOPSIS
+.PP
+\fBtkn-results pipelinerun describe [pipelinerun-name]\fP
+
+
+.SH DESCRIPTION
+.PP
+Describe a PipelineRun by name or UID. If --uid is provided, then PipelineRun name is optional.
+
+
+.SH OPTIONS
+.PP
+\fB-A\fP, \fB--all-namespaces\fP[=false]
+	use all namespaces
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for describe
+
+.PP
+\fB--uid\fP=""
+	UID of the PipelineRun to describe the details
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB-a\fP, \fB--addr\fP=""
+	Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+
+.PP
+\fB--api-path\fP=""
+	api path to use (default: value provided in config set command)
+
+.PP
+\fB-t\fP, \fB--authtoken\fP=""
+	authorization bearer token to use for authenticated requests
+
+.PP
+\fB-c\fP, \fB--context\fP=""
+	name of the kubeconfig context to use (default: kubectl config current-context)
+
+.PP
+\fB--host\fP=""
+	host to use (default: value provided in config set command)
+
+.PP
+\fB--insecure\fP[=false]
+	determines whether to run insecure GRPC tls request
+
+.PP
+\fB--insecure-skip-tls-verify\fP[=false]
+	skip server's certificate validation for requests (default: false)
+
+.PP
+\fB-k\fP, \fB--kubeconfig\fP=""
+	kubectl config file (default: $HOME/.kube/config)
+
+.PP
+\fB-n\fP, \fB--namespace\fP=""
+	namespace to use (default: from $KUBECONFIG)
+
+.PP
+\fB--portforward\fP[=true]
+	enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
+
+.PP
+\fB--sa\fP=""
+	ServiceAccount to use instead of token for authorization and authentication
+
+.PP
+\fB--sa-ns\fP=""
+	ServiceAccount Namespace, if not given, it will be taken from current context
+
+.PP
+\fB--token\fP=""
+	bearer token to use (default: value provided in config set command)
+
+.PP
+\fB--v1alpha2\fP[=false]
+	use v1alpha2 API for get log command
+
+
+.SH EXAMPLE
+.EX
+Describe a PipelineRun in namespace 'foo':
+    tkn-results pipelinerun describe my-pipelinerun -n foo
+
+Describe a PipelineRun in 'default' namespace:
+    tkn-results pipelinerun describe my-pipelinerun
+
+.EE
+
+
+.SH SEE ALSO
+.PP
+\fBtkn-results-pipelinerun(1)\fP

--- a/docs/man/man1/tkn-results-pipelinerun.1
+++ b/docs/man/man1/tkn-results-pipelinerun.1
@@ -103,4 +103,4 @@ Examples:
 
 .SH SEE ALSO
 .PP
-\fBtkn-results(1)\fP, \fBtkn-results-pipelinerun-list(1)\fP
+\fBtkn-results(1)\fP, \fBtkn-results-pipelinerun-describe(1)\fP, \fBtkn-results-pipelinerun-list(1)\fP

--- a/pkg/cli/client/records/records.go
+++ b/pkg/cli/client/records/records.go
@@ -12,7 +12,7 @@ import (
 
 // RecordClient defines the interface for record-related operations
 type RecordClient interface {
-	ListRecords(ctx context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error)
+	ListRecords(ctx context.Context, in *pb.ListRecordsRequest, fields string) (*pb.ListRecordsResponse, error)
 }
 
 // recordClient implements the RecordClient interface
@@ -26,7 +26,7 @@ func NewClient(rc *client.RESTClient) RecordClient {
 }
 
 // ListRecords makes request to get record list
-func (c *recordClient) ListRecords(ctx context.Context, in *pb.ListRecordsRequest) (*pb.ListRecordsResponse, error) {
+func (c *recordClient) ListRecords(ctx context.Context, in *pb.ListRecordsRequest, fields string) (*pb.ListRecordsResponse, error) {
 	out := &pb.ListRecordsResponse{}
 
 	// Add query parameters
@@ -45,7 +45,10 @@ func (c *recordClient) ListRecords(ctx context.Context, in *pb.ListRecordsReques
 	}
 
 	// Add fields parameter for partial response
-	params.Set("fields", "records.name,records.uid,records.create_time,records.update_time,records.data.value.metadata,records.data.value.status,next_page_token")
+	// (Only add fields parameter if provided)
+	if fields != "" {
+		params.Set("fields", fields)
+	}
 
 	// Construct the URL with parents prefix
 	buildURL := c.BuildURL(fmt.Sprintf("parents/%s/records", in.Parent), params)

--- a/pkg/cli/client/records/records_test.go
+++ b/pkg/cli/client/records/records_test.go
@@ -99,7 +99,7 @@ func TestListRecords(t *testing.T) {
 			}
 
 			recordClient := NewClient(restClient)
-			resp, err := recordClient.ListRecords(context.Background(), tt.req)
+			resp, err := recordClient.ListRecords(context.Background(), tt.req, "")
 
 			if (err != nil) != tt.expectedError {
 				t.Errorf("ListRecords() error = %v, wantErr %v", err, tt.expectedError)

--- a/pkg/cli/cmd/pipelinerun/describe.go
+++ b/pkg/cli/cmd/pipelinerun/describe.go
@@ -1,0 +1,248 @@
+package pipelinerun
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/tektoncd/results/pkg/cli/options"
+
+	"github.com/tektoncd/results/pkg/cli/client"
+	"github.com/tektoncd/results/pkg/cli/client/records"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/spf13/cobra"
+	"github.com/tektoncd/cli/pkg/cli"
+	"github.com/tektoncd/cli/pkg/formatted"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/results/pkg/cli/common"
+	"github.com/tektoncd/results/pkg/cli/config"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+)
+
+const describeTemplate = `{{decorate "bold" "Name"}}: {{ .PipelineRun.Name }}
+{{decorate "bold" "Namespace"}}: {{ .PipelineRun.Namespace }}
+{{- if .PipelineRun.Spec.PipelineRef }}
+{{- if ne .PipelineRun.Spec.PipelineRef.Name "" }}
+{{decorate "bold" "Pipeline Ref"}}: {{ .PipelineRun.Spec.PipelineRef.Name }}
+{{- end }}
+{{- end }}
+{{- if .PipelineRun.Spec.TaskRunTemplate.ServiceAccountName }}
+{{decorate "bold" "Service Account"}}: {{ .PipelineRun.Spec.TaskRunTemplate.ServiceAccountName }}
+{{- end }}
+{{- $l := len .PipelineRun.Labels }}{{ if eq $l 0 }}
+{{- else }}
+{{decorate "bold" "Labels"}}:
+{{- range $k, $v := .PipelineRun.Labels }}
+ {{ $k }}={{ $v }}
+{{- end }}
+{{- end }}
+{{- if .PipelineRun.Annotations }}
+{{decorate "bold" "Annotations"}}:
+{{- range $k, $v := .PipelineRun.Annotations }}
+ {{ $k }}={{ $v }}
+{{- end }}
+{{- end }}
+
+📌 {{decorate "underline bold" "Status"}}
+STARTED          DURATION         STATUS
+{{ formatAge .PipelineRun.Status.StartTime .Time | printf "%-16s" }} {{ formatDuration .PipelineRun.Status.StartTime .PipelineRun.Status.CompletionTime | printf "%-16s" }} {{ formatCondition .PipelineRun.Status.Conditions }}
+
+⏱ {{decorate "underline bold" "Timeouts"}}
+{{- if .PipelineRun.Spec.Timeouts }}
+{{- if .PipelineRun.Spec.Timeouts.Pipeline }}
+Pipeline:   {{ .PipelineRun.Spec.Timeouts.Pipeline.Duration.String }}
+{{- end }}
+{{- if .PipelineRun.Spec.Timeouts.Tasks }}
+Tasks:      {{ .PipelineRun.Spec.Timeouts.Tasks.Duration.String }}
+{{- end }}
+{{- if .PipelineRun.Spec.Timeouts.Finally }}
+Finally:    {{ .PipelineRun.Spec.Timeouts.Finally.Duration.String }}
+{{- end }}
+{{- end }}
+
+⚓ {{decorate "underline bold" "Params"}}
+{{- if ne (len .PipelineRun.Spec.Params) 0 }}
+  NAME                          VALUE
+{{- range $i, $p := .PipelineRun.Spec.Params }}
+  • {{ $p.Name | printf "% -28s" }}{{ if eq $p.Value.Type "string" }}{{ $p.Value.StringVal }}{{ else if eq $p.Value.Type "array" }}{{ $p.Value.ArrayVal }}{{ else }}{{ $p.Value.ObjectVal }}{{ end }}
+{{- end }}
+{{- end }}
+
+{{- if ne (len .PipelineRun.Status.Results) 0 }}
+📝 {{decorate "underline bold" "Results"}}
+  NAME                          VALUE
+{{- range $result := .PipelineRun.Status.Results }}
+  • {{ $result.Name | printf "% -28s" }}{{ if eq $result.Value.Type "string" }}{{ $result.Value.StringVal }}{{ else if eq $result.Value.Type "array" }}{{ $result.Value.ArrayVal }}{{ else }}{{ $result.Value.ObjectVal }}{{ end }}
+{{- end }}
+{{- end }}
+
+{{- if ne (len .PipelineRun.Spec.Workspaces) 0 }}
+
+🗂  {{decorate "underline bold" "Workspaces"}}
+  NAME                SUB PATH            WORKSPACE BINDING
+{{- range $workspace := .PipelineRun.Spec.Workspaces }}
+  • {{ $workspace.Name | printf "% -19s" }}{{ if not $workspace.SubPath }}{{ "---" | printf "% -19s" }}{{ else }}{{ $workspace.SubPath | printf "% -19s" }}{{ end }}{{ formatWorkspace $workspace }}
+{{- end }}
+{{- end }}
+
+{{- if ne (len .PipelineRun.Status.ChildReferences) 0 }}
+
+📦 {{decorate "underline bold" "Taskruns"}}
+  NAME                                                                         TASK NAME
+{{- range $taskrun := .PipelineRun.Status.ChildReferences }}
+  • {{ $taskrun.Name | printf "% -75s" }}{{ $taskrun.PipelineTaskName }}
+{{- end }}
+{{- end }}
+
+{{- if ne (len .PipelineRun.Status.SkippedTasks) 0 }}
+⏭️  {{decorate "underline bold" "Skipped Tasks"}}
+NAME
+{{- range $skippedTask := .PipelineRun.Status.SkippedTasks }}
+• {{ $skippedTask.Name }}
+{{- end }}
+{{- end }}
+`
+
+// describeCommand initializes a cobra command to describe a PipelineRun
+func describeCommand(p common.Params) *cobra.Command {
+	opts := &options.DescribeOptions{
+		ResourceType: common.ResourceTypePipelineRun,
+	}
+
+	eg := `Describe a PipelineRun in namespace 'foo':
+    tkn-results pipelinerun describe my-pipelinerun -n foo
+
+Describe a PipelineRun in the current namespace:
+    tkn-results pipelinerun describe my-pipelinerun
+`
+	cmd := &cobra.Command{
+		Use:     "describe [pipelinerun-name]",
+		Aliases: []string{"desc"},
+		Short:   "Describe a PipelineRun",
+		Long:    "Describe a PipelineRun by name or UID. If --uid is provided, then PipelineRun name is optional.",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		Example: eg,
+		Args: func(_ *cobra.Command, args []string) error {
+			// If UID is provided, no arguments are required
+			if opts.UID != "" {
+				return nil
+			}
+			// Otherwise, require exactly one argument
+			if len(args) != 1 {
+				return fmt.Errorf("requires exactly one argument when --uid is not provided")
+			}
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			allNs, _ := cmd.Flags().GetBool("all-namespaces")
+			nsSet := cmd.Flags().Changed("namespace")
+			if allNs && nsSet {
+				return errors.New("cannot use --all-namespaces/-A and --namespace/-n together")
+			}
+			c, err := config.NewConfig(p)
+			if err != nil {
+				return err
+			}
+			opts.Client, err = client.NewRESTClient(c.Get())
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if len(args) > 0 {
+				opts.ResourceName = args[0]
+			}
+
+			// Build filter string to find the PipelineRun
+			filter := common.BuildFilterString(opts)
+
+			// Handle namespace
+			parent := fmt.Sprintf("%s/results/-", p.Namespace())
+			if opts.AllNamespaces {
+				parent = "*/results/-"
+			}
+
+			// Create record client
+			recordClient := records.NewClient(opts.Client)
+
+			// Find the PipelineRun record
+			resp, err := recordClient.ListRecords(ctx, &pb.ListRecordsRequest{
+				Parent:   parent,
+				Filter:   filter,
+				PageSize: 25,
+			}, "")
+
+			if err != nil {
+				return fmt.Errorf("failed to find PipelineRun: %v", err)
+			}
+			if len(resp.Records) == 0 {
+				if opts.UID != "" && opts.ResourceName != "" {
+					return fmt.Errorf("no PipelineRun found with name %s and UID %s", opts.ResourceName, opts.UID)
+				} else if opts.UID != "" {
+					return fmt.Errorf("no PipelineRun found with UID %s", opts.UID)
+				}
+				return fmt.Errorf("no PipelineRun found with name %s", opts.ResourceName)
+			}
+
+			// If multiple PipelineRuns are found, return an error
+			if len(resp.Records) > 1 {
+				var uids []string
+				for _, record := range resp.Records {
+					uids = append(uids, record.Uid)
+				}
+				return fmt.Errorf("multiple PipelineRuns found. Use a more specific name or UID. Available UIDs: %s",
+					strings.Join(uids, ", "))
+			}
+
+			// Parse record to PipelineRun
+			var pr v1.PipelineRun
+			if err := json.Unmarshal(resp.Records[0].Data.Value, &pr); err != nil {
+				return fmt.Errorf("failed to unmarshal PipelineRun data: %v", err)
+			}
+
+			// Print formatted output
+			stream := &cli.Stream{
+				Out: cmd.OutOrStdout(),
+				Err: cmd.OutOrStderr(),
+			}
+
+			var data = struct {
+				PipelineRun *v1.PipelineRun
+				Time        clockwork.Clock
+			}{
+				PipelineRun: &pr,
+				Time:        clockwork.NewRealClock(),
+			}
+
+			funcMap := template.FuncMap{
+				"formatAge":       common.FormatAge,
+				"formatDuration":  formatted.Duration,
+				"formatCondition": formatted.Condition,
+				"formatWorkspace": formatted.Workspace,
+				"decorate":        formatted.DecorateAttr,
+			}
+
+			w := tabwriter.NewWriter(stream.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
+			t := template.Must(template.New("Describe PipelineRun").Funcs(funcMap).Parse(describeTemplate))
+
+			if err := t.Execute(w, data); err != nil {
+				return err
+			}
+
+			return w.Flush()
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.AllNamespaces, "all-namespaces", "A", false, "use all namespaces")
+	cmd.Flags().StringVar(&opts.UID, "uid", "", "UID of the PipelineRun to describe the details")
+
+	return cmd
+}

--- a/pkg/cli/cmd/pipelinerun/describe_test.go
+++ b/pkg/cli/cmd/pipelinerun/describe_test.go
@@ -1,0 +1,196 @@
+package pipelinerun
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/cobra"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/results/pkg/cli/common"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+)
+
+func TestDescribeCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		mockListFunc func(context.Context, *pb.ListRecordsRequest, string) (*pb.ListRecordsResponse, error)
+		wantErr      bool
+		wantOutput   string
+	}{
+		{
+			name: "success",
+			args: []string{"my-pipelinerun"},
+			mockListFunc: func(_ context.Context, _ *pb.ListRecordsRequest, _ string) (*pb.ListRecordsResponse, error) {
+				pr := v1.PipelineRun{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pipelinerun", Namespace: "default"},
+				}
+				prBytes, _ := json.Marshal(pr)
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{{
+						Name: "default/results/abc/records/def",
+						Uid:  "def",
+						Data: &pb.Any{Value: prBytes},
+					}},
+				}, nil
+			},
+			wantErr:    false,
+			wantOutput: "Name: my-pipelinerun",
+		},
+		{
+			name: "not found",
+			args: []string{"notfound"},
+			mockListFunc: func(_ context.Context, _ *pb.ListRecordsRequest, _ string) (*pb.ListRecordsResponse, error) {
+				return &pb.ListRecordsResponse{Records: []*pb.Record{}}, nil
+			},
+			wantErr:    true,
+			wantOutput: "no PipelineRun found with name notfound",
+		},
+		{
+			name: "multiple found",
+			args: []string{"foo"},
+			mockListFunc: func(_ context.Context, _ *pb.ListRecordsRequest, _ string) (*pb.ListRecordsResponse, error) {
+				pr := v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+				prBytes, _ := json.Marshal(pr)
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{
+						{Uid: "a", Data: &pb.Any{Value: prBytes}},
+						{Uid: "b", Data: &pb.Any{Value: prBytes}},
+					},
+				}, nil
+			},
+			wantErr:    true,
+			wantOutput: "multiple PipelineRuns found",
+		},
+		{
+			name: "error from client",
+			args: []string{"foo"},
+			mockListFunc: func(_ context.Context, _ *pb.ListRecordsRequest, _ string) (*pb.ListRecordsResponse, error) {
+				return nil, fmt.Errorf("test error")
+			},
+			wantErr:    true,
+			wantOutput: "failed to find PipelineRun: test error",
+		},
+		{
+			name:         "invalid arguments",
+			args:         []string{},
+			mockListFunc: nil,
+			wantErr:      true,
+			wantOutput:   "requires exactly one argument",
+		},
+		{
+			name: "UID lookup",
+			args: []string{"my-pipelinerun", "--uid", "my-uid"},
+			mockListFunc: func(_ context.Context, _ *pb.ListRecordsRequest, _ string) (*pb.ListRecordsResponse, error) {
+				pr := v1.PipelineRun{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pipelinerun", Namespace: "default", UID: "my-uid"},
+				}
+				prBytes, _ := json.Marshal(pr)
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{{
+						Name: "default/results/abc/records/def",
+						Uid:  "my-uid",
+						Data: &pb.Any{Value: prBytes},
+					}},
+				}, nil
+			},
+			wantErr:    false,
+			wantOutput: "my-uid",
+		},
+		{
+			name: "complex output",
+			args: []string{"complex-pipelinerun"},
+			mockListFunc: func(_ context.Context, _ *pb.ListRecordsRequest, _ string) (*pb.ListRecordsResponse, error) {
+				pr := v1.PipelineRun{
+					TypeMeta: metav1.TypeMeta{APIVersion: "tekton.dev/v1", Kind: "PipelineRun"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "complex-pipelinerun",
+						Namespace:   "default",
+						Labels:      map[string]string{"foo": "bar"},
+						Annotations: map[string]string{"anno": "val"},
+					},
+				}
+				prBytes, _ := json.Marshal(pr)
+				return &pb.ListRecordsResponse{
+					Records: []*pb.Record{{
+						Name: "default/results/abc/records/def",
+						Uid:  "def",
+						Data: &pb.Any{Value: prBytes},
+					}},
+				}, nil
+			},
+			wantErr:    false,
+			wantOutput: "complex-pipelinerun",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := describeCommand(&common.ResultsParams{})
+			buf := new(bytes.Buffer)
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetArgs(tt.args)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.PreRunE = func(_ *cobra.Command, _ []string) error { return nil }
+			cmd.RunE = func(_ *cobra.Command, args []string) error {
+				if tt.mockListFunc == nil {
+					if len(args) != 1 {
+						return fmt.Errorf("requires exactly one argument when --uid is not provided")
+					}
+					return nil
+				}
+				ctx := context.Background()
+				resp, err := tt.mockListFunc(ctx, nil, "")
+				if err != nil {
+					return fmt.Errorf("failed to find PipelineRun: %v", err)
+				}
+				if len(resp.Records) == 0 {
+					return fmt.Errorf("no PipelineRun found with name %s", args[0])
+				}
+				if len(resp.Records) > 1 {
+					return fmt.Errorf("multiple PipelineRuns found")
+				}
+				var pr v1.PipelineRun
+				if err := json.Unmarshal(resp.Records[0].Data.Value, &pr); err != nil {
+					return fmt.Errorf("failed to unmarshal PipelineRun data: %v", err)
+				}
+				// Output for UID/complex/normal
+				fmt.Fprintf(buf, "Name: %s\n", pr.Name)
+				if pr.UID != "" {
+					fmt.Fprintf(buf, "UID: %s\n", pr.UID)
+				}
+				if len(pr.Labels) > 0 {
+					fmt.Fprintf(buf, "Labels: %v\n", pr.Labels)
+				}
+				if len(pr.Annotations) > 0 {
+					fmt.Fprintf(buf, "Annotations: %v\n", pr.Annotations)
+				}
+				return nil
+			}
+			err := cmd.Execute()
+			output := buf.String()
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), tt.wantOutput) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantOutput, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(output, tt.wantOutput) {
+					t.Errorf("expected output to contain %q, got: %q", tt.wantOutput, output)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -134,7 +134,7 @@ List PipelineRuns with partial pipeline name match:
 			// Interactive pagination
 			reader := bufio.NewReader(os.Stdin)
 			for {
-				resp, err := recordClient.ListRecords(cmd.Context(), req)
+				resp, err := recordClient.ListRecords(cmd.Context(), req, common.ListFields)
 				if err != nil {
 					return err
 				}

--- a/pkg/cli/cmd/pipelinerun/pipelinerun.go
+++ b/pkg/cli/cmd/pipelinerun/pipelinerun.go
@@ -40,6 +40,7 @@ Examples:
 	flags.AddResultsOptions(cmd)
 
 	cmd.AddCommand(listCommand(p))
+	cmd.AddCommand(describeCommand(p))
 
 	return cmd
 }

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -151,7 +151,7 @@ func listTaskRuns(ctx context.Context, p common.Params, opts *options.ListOption
 	// Interactive pagination
 	reader := bufio.NewReader(os.Stdin)
 	for {
-		resp, err := recordClient.ListRecords(ctx, req)
+		resp, err := recordClient.ListRecords(ctx, req, common.ListFields)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/taskrun/logs.go
+++ b/pkg/cli/cmd/taskrun/logs.go
@@ -95,7 +95,7 @@ Get logs for a TaskRun from all namespaces:
 				Parent:   parent,
 				Filter:   filter,
 				PageSize: 25,
-			})
+			}, common.NameAndUIDField)
 			if err != nil {
 				return fmt.Errorf("failed to find TaskRun: %v", err)
 			}

--- a/pkg/cli/common/constants.go
+++ b/pkg/cli/common/constants.go
@@ -1,0 +1,14 @@
+package common
+
+const (
+	// ResourceTypeTaskRun is the string representation of a TaskRun resource
+	ResourceTypeTaskRun = "taskrun"
+	// ResourceTypePipelineRun is the string representation of a PipelineRun resource
+	ResourceTypePipelineRun = "pipelinerun"
+	// ListFields is the string used to fetch partial response
+	//  for the list command in the API calls
+	ListFields = "records.name,records.uid,records.create_time,records.update_time,records.data.value.metadata,records.data.value.status,next_page_token"
+	// NameAndUIDField is the string used to fetch only name and
+	// UID in an API call
+	NameAndUIDField = "records.name,records.uid"
+)

--- a/pkg/cli/common/resource_types.go
+++ b/pkg/cli/common/resource_types.go
@@ -1,8 +1,0 @@
-package common
-
-const (
-	// ResourceTypeTaskRun is the string representation of a TaskRun resource
-	ResourceTypeTaskRun = "taskrun"
-	// ResourceTypePipelineRun is the string representation of a PipelineRun resource
-	ResourceTypePipelineRun = "pipelinerun"
-)

--- a/pkg/cli/options/describe.go
+++ b/pkg/cli/options/describe.go
@@ -1,0 +1,37 @@
+package options
+
+import "github.com/tektoncd/results/pkg/cli/client"
+
+// DescribeOptions contains options for describing a resource.
+type DescribeOptions struct {
+	Client        *client.RESTClient
+	AllNamespaces bool
+	UID           string
+	ResourceType  string
+	ResourceName  string
+}
+
+// GetLabel implements FilterOptions interface
+func (o *DescribeOptions) GetLabel() string {
+	return "" // Label field is not relevant in the describe commands
+}
+
+// GetResourceName implements FilterOptions interface
+func (o *DescribeOptions) GetResourceName() string {
+	return o.ResourceName
+}
+
+// GetPipelineRun implements FilterOptions interface
+func (o *DescribeOptions) GetPipelineRun() string {
+	return "" // PipelineRun field is not relevant in the describe commands
+}
+
+// GetResourceType implements FilterOptions interface
+func (o *DescribeOptions) GetResourceType() string {
+	return o.ResourceType
+}
+
+// GetUID implements FilterOptions interface
+func (o *DescribeOptions) GetUID() string {
+	return o.UID
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Follow-up PR towards the Results CLI enhancement TEP
Config command PR: #988
Pipelinerun list command PR: #995
Taskrun list command PR: #998
Taskrun logs command PR: https://github.com/tektoncd/results/pull/1000

This PR will add the command `tkn-results pipelinerun describe` command

Sample Run:

```
> tkn-results pr desc operator-main-index-4-18-on-pull-request-7kssl                          
Name: operator-main-index-4-18-on-pull-request-7kssl
Namespace: tekton-ecosystem-tenant
Service Account: appstudio-pipeline
Labels:
 app.kubernetes.io/managed-by=pipelinesascode.tekton.dev
 app.kubernetes.io/version=v0.33.0
Annotations:
 appstudio.openshift.io/snapshot=openshift-pipelines-main-b7jj6
 build.appstudio.openshift.io/repo=https://github.com/openshift-pipelines/operator?rev=ba5e62e51af0c88bc6c3fd4201e789bdfc093daa

📌 Status
STARTED          DURATION         STATUS
27d ago          9m54s            Succeeded

⏱ Timeouts
Pipeline:   2h0m0s

⚓ Params
  NAME                          VALUE
  • git-url                     https://github.com/pramodbindal/operator
  • revision                    ba5e62e51af0c88bc6c3fd4201e789bdfc093daa

🗂  Workspaces
  NAME                SUB PATH            WORKSPACE BINDING
  • workspace          ---                VolumeClaimTemplate
  • git-auth           ---                Secret (secret=pac-gitauth-ceqzjt)

📦 Taskruns
  NAME                                                                         TASK NAME
  • operator-main-index-4-18-on-pull-request-7kssl-init                        init
  • operator-main-index-4-18-on-pull-request-7kssl-clone-repository            clone-repository
```

```
> tkn-results pr desc --uid=2fd28c48-388b-4e6a-9ec3-2bcd9dedebc3 
```


<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add pipelinerun describe command to describe a pipelinerun
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
