### PR TITLE
[CLI enhancement] Add `To be deprecated` message for the older commands

### DIFF
--- a/pkg/cli/cmd/help.txt
+++ b/pkg/cli/cmd/help.txt
@@ -1,33 +1,21 @@
-Environment Variables:
-    TKN_RESULTS_SSL_ROOTS_FILE_PATH: Path to local SSL cert to use.
-    TKN_RESULTS_SSL_SERVER_NAME_OVERRIDE: SSL server name override (useful if using with a proxy such as kubectl port-forward).
+tkn-results CLI
 
-Config:
-    A config file may be stored in `~/.config/tkn/results.yaml` to configure the CLI client.
+tkn-results is a command-line interface (CLI) designed to interact with Tekton Results. This CLI provides tools to configure how you interact with the Tekton Results API server, query TaskRuns and PipelineRuns and their associated data.
 
-    Fields:
-    - address: Results API Server address
-    - service_account: When specified, the CLI will first fetch a bearer token
-                       for the specified ServiceAccount and attach that to Result API requests.
-        - namespace: ServiceAccount namespace
-        - name: ServiceAccount name
-    - token: Bearer token to use for API requests. Takes priority over service_account.
-    - ssl: SSL connection options
-        - roots_file_path: Path to a certificate to include in the cert pool. Useful for adding allowed self-signed certs.
-        - server_name_override: For testing only. Sets the grpc.ssl_target_name_override value for requests.
-    - portforward: enable auto portforwarding to tekton-results-api-service when address is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-Example:
-
-    ```
-    address: results.dogfooding.tekton.dev:443
-    token: abcd1234
-    ssl:
-        roots_file_path: path/to/file
-        server_name_override: example.com
-    service_account:
-        namespace: default
-        name: result-reader
-    portforward: false
-    ```
-
+This CLI helps to:
+  config        Manage Tekton Results CLI configuration:
+                - set:  Configure the CLI to connect to a Tekton Results instance.
+                - view: Display the current CLI configuration.
+                - reset: Reset the CLI configuration to defaults.
+  taskrun       Query TaskRuns stored in Tekton Results:
+                - list:  List TaskRun with filtering options.
+                - describe:  Show detailed information about a specific TaskRun.
+                - logs: Get logs for a TaskRun.
+  pipelinerun   Query PipelineRuns stored in Tekton Results:
+                - list:  List PipelineRuns with filtering options.
+                - describe:  Show detailed information about a specific PipelineRun.
+Examples:
+  tkn-results config set
+  tkn-results config view
+  tkn-results taskrun list -n default
+  tkn-results pipelinerun describe my-pipelineRun

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -55,15 +55,16 @@ func Root(p common.Params) *cobra.Command {
 		},
 	}
 
-	c.PersistentFlags().StringP("addr", "a", "", "Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically")
-	c.PersistentFlags().StringP("authtoken", "t", "", "authorization bearer token to use for authenticated requests")
-	c.PersistentFlags().String("sa", "", "ServiceAccount to use instead of token for authorization and authentication")
-	c.PersistentFlags().String("sa-ns", "", "ServiceAccount Namespace, if not given, it will be taken from current context")
-	c.PersistentFlags().Bool("portforward", true, "enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically")
-	c.PersistentFlags().Bool("insecure", false, "determines whether to run insecure GRPC tls request")
-	c.PersistentFlags().Bool("v1alpha2", false, "use v1alpha2 API for get log command")
+	c.PersistentFlags().StringP("addr", "a", "", "[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically")
+	c.PersistentFlags().StringP("authtoken", "t", "", "[To be deprecated] authorization bearer token to use for authenticated requests")
+	c.PersistentFlags().String("sa", "", "[To be deprecated] ServiceAccount to use instead of token for authorization and authentication")
+	c.PersistentFlags().String("sa-ns", "", "[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context")
+	c.PersistentFlags().Bool("portforward", true, "[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically")
+	c.PersistentFlags().Bool("insecure", false, "[To be deprecated] determines whether to run insecure GRPC tls request")
+	c.PersistentFlags().Bool("v1alpha2", false, "[To be deprecated] use v1alpha2 API for get log command")
 
 	c.AddCommand(
+		// Commands to be deprecated
 		result.Command(params),
 		records.Command(params),
 		logs.Command(params),

--- a/pkg/cli/dev/cmd/logs/get.go
+++ b/pkg/cli/dev/cmd/logs/get.go
@@ -41,7 +41,7 @@ func GetLogCommand(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "get [flags] <log-name>",
 
-		Short: "Get Log by <log-name>",
+		Short: "[To be deprecated] Get Log by <log-name>",
 		Long:  "Get Log by <log-name>. <log-name> is typically of format <namespace>/results/<parent-run-uuid>/logs/<child-run-uuid>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resp grpc.ServerStreamingClient[httpbody.HttpBody]

--- a/pkg/cli/dev/cmd/logs/list.go
+++ b/pkg/cli/dev/cmd/logs/list.go
@@ -31,7 +31,7 @@ func ListLogsCommand(params *flags.Params) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list [flags] <result-name>",
-		Short: "List Logs for a given Result",
+		Short: "[To be deprecated] List Logs for a given Result",
 		Long:  "List Logs for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of <parent-run-uuid> to query all Logs for a given parent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := params.LogsClient.ListLogs(cmd.Context(), &pb.ListRecordsRequest{

--- a/pkg/cli/dev/cmd/logs/logs.go
+++ b/pkg/cli/dev/cmd/logs/logs.go
@@ -23,7 +23,7 @@ import (
 func Command(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Commands for finding and retrieving logs",
+		Short: "[To be deprecated] Commands for finding and retrieving logs",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cli/dev/cmd/records/get.go
+++ b/pkg/cli/dev/cmd/records/get.go
@@ -47,7 +47,7 @@ func GetRecordCommand(params *flags.Params) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get [flags] <record-name>",
-		Short: "Get Record by <record-name>",
+		Short: "[To be deprecated] Get Record by <record-name>",
 		Long:  "Get Record by <record-name>. <record-name> is typically of format <namespace>/results/<parent-run-uuid>/records/<child-run-uuid>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			record, err := params.ResultsClient.GetRecord(cmd.Context(), &pb.GetRecordRequest{

--- a/pkg/cli/dev/cmd/records/list.go
+++ b/pkg/cli/dev/cmd/records/list.go
@@ -17,7 +17,7 @@ func ListRecordsCommand(params *flags.Params) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list [flags] <result-name>",
-		Short: "List Records for a given Result",
+		Short: "[To be deprecated] List Records for a given Result",
 		Long:  "List Records for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of  <parent-run-uuid> to query all Records for a given parent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := params.ResultsClient.ListRecords(cmd.Context(), &pb.ListRecordsRequest{

--- a/pkg/cli/dev/cmd/records/records.go
+++ b/pkg/cli/dev/cmd/records/records.go
@@ -9,7 +9,7 @@ import (
 func Command(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "records",
-		Short: "Command sub-group for querying Records",
+		Short: "[To be deprecated] Command sub-group for querying Records",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cli/dev/cmd/result/describe.go
+++ b/pkg/cli/dev/cmd/result/describe.go
@@ -55,7 +55,7 @@ tkn-results result desc --parent default --uid 949eebd9-1cf7-478f-a547-9ee313035
 	cmd := &cobra.Command{
 		Use:     "describe [-p parent -u uid] [name]",
 		Aliases: []string{"desc"},
-		Short:   "Describes a Result",
+		Short:   "[To be deprecated] Describes a Result",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -89,8 +89,8 @@ tkn-results result desc --parent default --uid 949eebd9-1cf7-478f-a547-9ee313035
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Parent, "parent", "p", "", "parent of the result")
-	cmd.Flags().StringVarP(&opts.UID, "uid", "u", "", "uid of the result")
+	cmd.Flags().StringVarP(&opts.Parent, "parent", "p", "", "[To be deprecated] parent of the result")
+	cmd.Flags().StringVarP(&opts.UID, "uid", "u", "", "[To be deprecated] uid of the result")
 	return cmd
 }
 

--- a/pkg/cli/dev/cmd/result/list.go
+++ b/pkg/cli/dev/cmd/result/list.go
@@ -19,7 +19,7 @@ func ListCommand(params *flags.Params) *cobra.Command {
 		Use: `list [flags] <parent>
 
   <parent>: Parent name to query. This is typically corresponds to a namespace, but may vary depending on the API Server. "-" may be used to query all parents. This will list results for namespaces the token has access to`,
-		Short: "List Results",
+		Short: "[To be deprecated] List Results",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parent := args[0]
 			resp, err := params.ResultsClient.ListResults(cmd.Context(), &pb.ListResultsRequest{

--- a/pkg/cli/dev/cmd/result/result.go
+++ b/pkg/cli/dev/cmd/result/result.go
@@ -10,7 +10,7 @@ func Command(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "result",
 		Aliases: []string{"r", "results"},
-		Short:   "Query Results",
+		Short:   "[To be deprecated] Query Results",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cli/dev/flags/flags.go
+++ b/pkg/cli/dev/flags/flags.go
@@ -26,10 +26,10 @@ type ListOptions struct {
 
 // AddListFlags is a helper function that adds common flags for commands that list things
 func AddListFlags(options *ListOptions, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "CEL Filter")
-	cmd.Flags().Int32VarP(&options.Limit, "limit", "l", 0, "number of items to return. Response may be truncated due to server limits.")
-	cmd.Flags().StringVarP(&options.PageToken, "page", "p", "", "pagination token to use for next page")
-	cmd.Flags().StringVarP(&options.Format, "output", "o", "tab", "output format. Valid values: tab|textproto|json")
+	cmd.Flags().StringVarP(&options.Filter, "filter", "f", "", "[To be deprecated] CEL Filter")
+	cmd.Flags().Int32VarP(&options.Limit, "limit", "l", 0, "[To be deprecated] number of items to return. Response may be truncated due to server limits.")
+	cmd.Flags().StringVarP(&options.PageToken, "page", "p", "", "[To be deprecated] pagination token to use for next page")
+	cmd.Flags().StringVarP(&options.Format, "output", "o", "tab", "[To be deprecated] output format. Valid values: tab|textproto|json")
 }
 
 // GetOptions used on commands that get a single Result, Record or Log
@@ -39,5 +39,5 @@ type GetOptions struct {
 
 // AddGetFlags is a helper function that adds common flags for get commands
 func AddGetFlags(options *GetOptions, cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&options.Format, "output", "o", "json", "output format. Valid values: textproto|json")
+	cmd.Flags().StringVarP(&options.Format, "output", "o", "json", "[To be deprecated] output format. Valid values: textproto|json")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Follow-up PR towards the Results CLI enhancement TEP

[To be deprecated] will be shown only when the user is doing `--help`. This will not impact the usage of any of the existing commands. Future releases will mark these commands deprecated

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Results, records and logs commands to be deprecated in the next release
```



<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
