### PR TITLE
Fix usage of server related flags

### DIFF
--- a/pkg/cli/cmd/pipelinerun/describe.go
+++ b/pkg/cli/cmd/pipelinerun/describe.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/tektoncd/results/pkg/cli/options"
 
-	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/client/records"
 
 	"github.com/jonboulle/clockwork"
@@ -18,7 +17,7 @@ import (
 	"github.com/tektoncd/cli/pkg/formatted"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/results/pkg/cli/common"
-	"github.com/tektoncd/results/pkg/cli/config"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 
 	"k8s.io/cli-runtime/pkg/printers"
@@ -148,12 +147,10 @@ Describe a PipelineRun as json:
 			}
 			return nil
 		},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			c, err := config.NewConfig(p)
-			if err != nil {
-				return err
-			}
-			opts.Client, err = client.NewRESTClient(c.Get())
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Initialize the client using the shared prerun function
+			var err error
+			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/tektoncd/results/pkg/cli/options"
 
-	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/client/records"
 
 	"github.com/jonboulle/clockwork"
@@ -21,7 +20,7 @@ import (
 	"github.com/tektoncd/cli/pkg/formatted"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/results/pkg/cli/common"
-	"github.com/tektoncd/results/pkg/cli/config"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 )
 
@@ -86,11 +85,10 @@ List PipelineRuns with partial pipeline name match:
 			if allNs && nsSet {
 				return errors.New("cannot use --all-namespaces/-A and --namespace/-n together")
 			}
-			c, err := config.NewConfig(p)
-			if err != nil {
-				return err
-			}
-			opts.Client, err = client.NewRESTClient(c.Get())
+
+			// Initialize the client
+			var err error
+			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/cmd/pipelinerun/logs.go
+++ b/pkg/cli/cmd/pipelinerun/logs.go
@@ -9,11 +9,10 @@ import (
 	"github.com/tektoncd/results/pkg/cli/options"
 
 	"github.com/spf13/cobra"
-	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/client/logs"
 	"github.com/tektoncd/results/pkg/cli/client/records"
 	"github.com/tektoncd/results/pkg/cli/common"
-	"github.com/tektoncd/results/pkg/cli/config"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 )
 
@@ -59,12 +58,10 @@ Additionally, PipelineRun logs are not supported for S3 log storage.`,
 			}
 			return nil
 		},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			c, err := config.NewConfig(p)
-			if err != nil {
-				return err
-			}
-			opts.Client, err = client.NewRESTClient(c.Get())
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Initialize the client using the shared prerun function
+			var err error
+			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/cmd/taskrun/describe.go
+++ b/pkg/cli/cmd/taskrun/describe.go
@@ -12,10 +12,9 @@ import (
 	"github.com/tektoncd/cli/pkg/cli"
 	"github.com/tektoncd/cli/pkg/formatted"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/client/records"
 	"github.com/tektoncd/results/pkg/cli/common"
-	"github.com/tektoncd/results/pkg/cli/config"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
 	"github.com/tektoncd/results/pkg/cli/options"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 
@@ -109,12 +108,9 @@ Describe a TaskRun as json
 			}
 			return nil
 		},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			c, err := config.NewConfig(p)
-			if err != nil {
-				return err
-			}
-			opts.Client, err = client.NewRESTClient(c.Get())
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			var err error
+			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/tektoncd/results/pkg/cli/options"
 
-	"github.com/tektoncd/results/pkg/cli/client"
-
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
 	"github.com/tektoncd/cli/pkg/cli"
@@ -22,7 +20,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/results/pkg/cli/client/records"
 	"github.com/tektoncd/results/pkg/cli/common"
-	"github.com/tektoncd/results/pkg/cli/config"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 )
 
@@ -90,11 +88,10 @@ List TaskRuns for a specific PipelineRun:
 			if allNs && nsSet {
 				return errors.New("cannot use --all-namespaces/-A and --namespace/-n together")
 			}
-			c, err := config.NewConfig(p)
-			if err != nil {
-				return err
-			}
-			opts.Client, err = client.NewRESTClient(c.Get())
+
+			// Initialize the client using the shared prerun function
+			var err error
+			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/cmd/taskrun/logs.go
+++ b/pkg/cli/cmd/taskrun/logs.go
@@ -9,11 +9,10 @@ import (
 	"github.com/tektoncd/results/pkg/cli/options"
 
 	"github.com/spf13/cobra"
-	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/client/logs"
 	"github.com/tektoncd/results/pkg/cli/client/records"
 	"github.com/tektoncd/results/pkg/cli/common"
-	"github.com/tektoncd/results/pkg/cli/config"
+	"github.com/tektoncd/results/pkg/cli/common/prerun"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 )
 
@@ -61,12 +60,10 @@ Logs are not supported for the system namespace or for the default namespace use
 			}
 			return nil
 		},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			c, err := config.NewConfig(p)
-			if err != nil {
-				return err
-			}
-			opts.Client, err = client.NewRESTClient(c.Get())
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Initialize the client using the shared prerun function
+			var err error
+			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/common/prerun/prerun.go
+++ b/pkg/cli/common/prerun/prerun.go
@@ -2,7 +2,9 @@ package prerun
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/tektoncd/results/pkg/cli/client"
 	"github.com/tektoncd/results/pkg/cli/common"
+	"github.com/tektoncd/results/pkg/cli/config"
 	"github.com/tektoncd/results/pkg/cli/flags"
 )
 
@@ -20,4 +22,31 @@ func PersistentPreRunE(p common.Params) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
 		return flags.InitParams(p, cmd)
 	}
+}
+
+// InitClient initializes the REST client for the command based on direct connection flags or kubeconfig.
+//
+// Parameters:
+//   - p: common.Params containing configuration parameters.
+//   - cmd: The cobra.Command being executed.
+//
+// Returns:
+//   - *client.RESTClient: The initialized REST client.
+//   - error: An error if client initialization fails.
+func InitClient(p common.Params, cmd *cobra.Command) (*client.RESTClient, error) {
+	// Check if any of the direct connection flags are set
+	// if not fetch restConfig from k8s extension
+	if config.ServerConnectionFlagsChanged(cmd) {
+		cfg, err := config.BuildDirectClientConfig(p)
+		if err != nil {
+			return nil, err
+		}
+		return client.NewRESTClient(cfg)
+	}
+
+	c, err := config.NewConfig(p)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewRESTClient(c.Get())
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fix proper usage of server-related flags like `--host`, `--token` and `--api-path`
Earlier it was not getting used.

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
[CLI] Fix proper usage of server-related flags i.e. `--host, `--token`, `--api-path`, `--insecure-skip-tls-verify`
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
