### PR TITLE
[CLI] Fix end points for the all namespace flag

### DIFF
--- a/docs/cli/tkn-results_pipelinerun_logs.md
+++ b/docs/cli/tkn-results_pipelinerun_logs.md
@@ -26,9 +26,6 @@ Get logs for a PipelineRun in a specific namespace:
 Get logs for a PipelineRun by UID if there are multiple PipelineRuns with the same name:
   tkn-results pipelinerun logs --uid 12345678-1234-1234-1234-1234567890ab
 
-Get logs for a PipelineRun from all namespaces:
-  tkn-results pipelinerun logs foo -A
-
 ```
 
 ### Options

--- a/docs/cli/tkn-results_taskrun_logs.md
+++ b/docs/cli/tkn-results_taskrun_logs.md
@@ -25,9 +25,6 @@ Get logs for a TaskRun in a specific namespace:
 Get logs for a TaskRun by UID if there are multiple TaskRun with the same name:
   tkn-results taskrun logs --uid 12345678-1234-1234-1234-1234567890ab
 
-Get logs for a TaskRun from all namespaces:
-  tkn-results taskrun logs foo -A
-
 ```
 
 ### Options

--- a/docs/man/man1/tkn-results-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-results-pipelinerun-logs.1
@@ -95,9 +95,6 @@ Get logs for a PipelineRun in a specific namespace:
 Get logs for a PipelineRun by UID if there are multiple PipelineRuns with the same name:
   tkn-results pipelinerun logs --uid 12345678-1234-1234-1234-1234567890ab
 
-Get logs for a PipelineRun from all namespaces:
-  tkn-results pipelinerun logs foo -A
-
 .EE
 
 

--- a/docs/man/man1/tkn-results-taskrun-logs.1
+++ b/docs/man/man1/tkn-results-taskrun-logs.1
@@ -94,9 +94,6 @@ Get logs for a TaskRun in a specific namespace:
 Get logs for a TaskRun by UID if there are multiple TaskRun with the same name:
   tkn-results taskrun logs --uid 12345678-1234-1234-1234-1234567890ab
 
-Get logs for a TaskRun from all namespaces:
-  tkn-results taskrun logs foo -A
-
 .EE
 
 

--- a/pkg/cli/cmd/pipelinerun/describe.go
+++ b/pkg/cli/cmd/pipelinerun/describe.go
@@ -147,20 +147,20 @@ Describe a PipelineRun as json:
 			}
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Initialize the client using the shared prerun function
 			var err error
 			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
 			if len(args) > 0 {
 				opts.ResourceName = args[0]
 			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 
 			// Build filter string to find the PipelineRun
 			filter := common.BuildFilterString(opts)

--- a/pkg/cli/cmd/pipelinerun/list.go
+++ b/pkg/cli/cmd/pipelinerun/list.go
@@ -35,7 +35,7 @@ NAME	UID	STARTED	DURATION	STATUS
 {{ end -}}
 {{- end -}}
 {{- range $_, $pr := .PipelineRuns.Items }}{{- if $pr }}{{- if $.AllNamespaces -}}
-{{ $pr.Namespace }}	{{ $pr.Name }} {{ $pr.UID }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
+{{ $pr.Namespace }}	{{ $pr.Name }}	{{ $pr.UID }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
 {{ else -}}
 {{ $pr.Name }}	{{ $pr.UID }}	{{ formatAge $pr.Status.StartTime $.Time }}	{{ formatDuration $pr.Status.StartTime $pr.Status.CompletionTime }}	{{ formatCondition $pr.Status.Conditions }}
 {{ end -}}{{- end -}}{{- end -}}
@@ -85,27 +85,22 @@ List PipelineRuns with partial pipeline name match:
 			if allNs && nsSet {
 				return errors.New("cannot use --all-namespaces/-A and --namespace/-n together")
 			}
-
 			// Initialize the client
 			var err error
 			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}
-
 			if opts.Limit < 5 || opts.Limit > 1000 {
 				return errors.New("limit should be between 5 and 1000")
 			}
-
-			if len(args) > 0 {
-				opts.ResourceName = args[0]
-			}
-
 			// Validate label format if provided
 			if opts.Label != "" {
 				return common.ValidateLabels(opts.Label)
 			}
-
+			if len(args) > 0 {
+				opts.ResourceName = args[0]
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -115,7 +110,7 @@ List PipelineRuns with partial pipeline name match:
 			// Handle all namespaces
 			parent := fmt.Sprintf("%s/results/-", p.Namespace())
 			if opts.AllNamespaces {
-				parent = "*/results/-"
+				parent = common.AllNamespacesResultsParent
 			}
 
 			// Create initial request

--- a/pkg/cli/cmd/pipelinerun/list_test.go
+++ b/pkg/cli/cmd/pipelinerun/list_test.go
@@ -297,7 +297,7 @@ func TestListCommand(t *testing.T) {
 				// Handle all namespaces
 				parent := fmt.Sprintf("%s/results/-", params.Namespace())
 				if opts.AllNamespaces {
-					parent = "*/results/-"
+					parent = common.AllNamespacesResultsParent
 				}
 
 				// Create initial request

--- a/pkg/cli/cmd/pipelinerun/logs.go
+++ b/pkg/cli/cmd/pipelinerun/logs.go
@@ -30,9 +30,6 @@ Get logs for a PipelineRun in a specific namespace:
 
 Get logs for a PipelineRun by UID if there are multiple PipelineRuns with the same name:
   tkn-results pipelinerun logs --uid 12345678-1234-1234-1234-1234567890ab
-
-Get logs for a PipelineRun from all namespaces:
-  tkn-results pipelinerun logs foo -A
 `
 
 	cmd := &cobra.Command{
@@ -58,20 +55,20 @@ Additionally, PipelineRun logs are not supported for S3 log storage.`,
 			}
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Initialize the client using the shared prerun function
 			var err error
 			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
 			if len(args) > 0 {
 				opts.ResourceName = args[0]
 			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 
 			// Build filter string to find the PipelineRun
 			filter := common.BuildFilterString(opts)

--- a/pkg/cli/cmd/taskrun/describe.go
+++ b/pkg/cli/cmd/taskrun/describe.go
@@ -108,19 +108,19 @@ Describe a TaskRun as json
 			}
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
 			if len(args) > 0 {
 				opts.ResourceName = args[0]
 			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 
 			filter := common.BuildFilterString(opts)
 			parent := fmt.Sprintf("%s/results/-", p.Namespace())

--- a/pkg/cli/cmd/taskrun/list.go
+++ b/pkg/cli/cmd/taskrun/list.go
@@ -35,7 +35,7 @@ NAME	UID	STARTED	DURATION	STATUS
 {{ end -}}
 {{- end -}}
 {{- range $_, $tr := .TaskRuns.Items }}{{- if $tr }}{{- if $.AllNamespaces -}}
-{{ $tr.Namespace }}	{{ $tr.Name }} {{ $tr.UID }}	{{ formatAge $tr.Status.StartTime $.Time }}	{{ formatDuration $tr.Status.StartTime $tr.Status.CompletionTime }}	{{ formatCondition $tr.Status.Conditions }}
+{{ $tr.Namespace }}	{{ $tr.Name }}	{{ $tr.UID }}	{{ formatAge $tr.Status.StartTime $.Time }}	{{ formatDuration $tr.Status.StartTime $tr.Status.CompletionTime }}	{{ formatCondition $tr.Status.Conditions }}
 {{ else -}}
 {{ $tr.Name }}	{{ $tr.UID }}	{{ formatAge $tr.Status.StartTime $.Time }}	{{ formatDuration $tr.Status.StartTime $tr.Status.CompletionTime }}	{{ formatCondition $tr.Status.Conditions }}
 {{ end -}}{{- end -}}{{- end -}}
@@ -88,7 +88,6 @@ List TaskRuns for a specific PipelineRun:
 			if allNs && nsSet {
 				return errors.New("cannot use --all-namespaces/-A and --namespace/-n together")
 			}
-
 			// Initialize the client using the shared prerun function
 			var err error
 			opts.Client, err = prerun.InitClient(p, cmd)
@@ -99,12 +98,10 @@ List TaskRuns for a specific PipelineRun:
 			if opts.Limit < 5 || opts.Limit > 1000 {
 				return errors.New("limit should be between 5 and 1000")
 			}
-
 			// Validate label format if provided
 			if opts.Label != "" {
 				return common.ValidateLabels(opts.Label)
 			}
-
 			if len(args) > 0 {
 				opts.ResourceName = args[0]
 			}
@@ -131,7 +128,7 @@ func listTaskRuns(ctx context.Context, p common.Params, opts *options.ListOption
 	// Handle all namespaces
 	parent := fmt.Sprintf("%s/results/-", p.Namespace())
 	if opts.AllNamespaces {
-		parent = "*/results/-"
+		parent = common.AllNamespacesResultsParent
 	}
 
 	// Create initial request

--- a/pkg/cli/cmd/taskrun/list_test.go
+++ b/pkg/cli/cmd/taskrun/list_test.go
@@ -347,7 +347,7 @@ func TestListCommand(t *testing.T) {
 				// Handle all namespaces
 				parent := fmt.Sprintf("%s/results/-", params.Namespace())
 				if opts.AllNamespaces {
-					parent = "*/results/-"
+					parent = common.AllNamespacesResultsParent
 				}
 
 				// Create initial request

--- a/pkg/cli/cmd/taskrun/logs.go
+++ b/pkg/cli/cmd/taskrun/logs.go
@@ -33,9 +33,6 @@ Get logs for a TaskRun in a specific namespace:
 
 Get logs for a TaskRun by UID if there are multiple TaskRun with the same name:
   tkn-results taskrun logs --uid 12345678-1234-1234-1234-1234567890ab
-
-Get logs for a TaskRun from all namespaces:
-  tkn-results taskrun logs foo -A
 `
 
 	cmd := &cobra.Command{
@@ -60,20 +57,20 @@ Logs are not supported for the system namespace or for the default namespace use
 			}
 			return nil
 		},
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Initialize the client using the shared prerun function
 			var err error
 			opts.Client, err = prerun.InitClient(p, cmd)
 			if err != nil {
 				return err
 			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
 			if len(args) > 0 {
 				opts.ResourceName = args[0]
 			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 
 			// Build filter string to find the TaskRun
 			filter := common.BuildFilterString(opts)

--- a/pkg/cli/common/constants.go
+++ b/pkg/cli/common/constants.go
@@ -11,4 +11,6 @@ const (
 	// NameAndUIDField is the string used to fetch only name and
 	// UID in an API call
 	NameAndUIDField = "records.name,records.uid"
+	// AllNamespacesResultsParent is the parent path used for listing results across all namespaces.
+	AllNamespacesResultsParent = "-/results/-"
 )


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There is a bug in the endpoints of the all-namespaces flag. It was using the wrong pattern (`*/results/-`), which was incorrect.
Correct usage was `-/results/-`
Also moved the initialization of the params to the preRun to maintain consistency.

/kind bug

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
[CLI] Fix API calling end points when using `--all namespaces` flag in list commands
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
