### PR TITLE
[CLI] Initialize clock with clockwork.NewRealClock() to fix nil pointer issue in the describe commands

### DIFF
--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/jonboulle/clockwork"
+
 	"github.com/tektoncd/results/pkg/cli/cmd/taskrun"
 
 	"github.com/tektoncd/results/pkg/cli/cmd/pipelinerun"
@@ -35,6 +37,7 @@ var (
 
 // Root returns a cobra command for `tkn-results` root sub commands
 func Root(p common.Params) *cobra.Command {
+	// params values are populated in the preRun Handler
 	params := &flags.Params{}
 	var portForwardCloseChan chan struct{}
 	c := &cobra.Command{
@@ -124,6 +127,8 @@ func persistentPreRunHandler(c *cobra.Command, params *flags.Params, portForward
 		return err
 	}
 	params.PluginLogsClient = pluginLogsClient
+
+	params.Clock = clockwork.NewRealClock()
 
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
There was a bug in records get and results list command
due to which these commands were giving nil pointer error when used.
Clock from the params which was used to parse the data
was not initialized in root.go. Initializing the clock with
clockwork.NewRealClock() to fix the issue

/kind bug

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
[CLI] Fix nil pointer error when using records get and results describe command
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
