### PR TITLE
Fix the flaky unit test in field mask

### DIFF
--- a/internal/fieldmask/fieldmask_test.go
+++ b/internal/fieldmask/fieldmask_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 
@@ -77,7 +78,9 @@ func TestFieldMask_Paths(t *testing.T) {
 	f := &fieldmaskpb.FieldMask{Paths: p}
 	f.Normalize()
 	want := f.Paths
+	slices.Sort(want)
 	got := fm.Paths(nil)
+	slices.Sort(got)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Paths mismatch (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
Fixing the flaky unit test in field mask by sorting the field paths. Before this, field mask `got` path could return in any order and fail the test.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
