### PR TITLE
Add flag to Disable Live Collection of Runs

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -59,27 +59,28 @@ const (
 )
 
 var (
-	apiAddr                 = flag.String("api_addr", "localhost:8080", "Address of API server to report to")
-	authMode                = flag.String("auth_mode", "", "Authentication mode to use when making requests. If not set, no additional credentials will be used in the request. Valid values: [google]")
-	disableCRDUpdate        = flag.Bool("disable_crd_update", false, "Disables Tekton CRD annotation update on reconcile.")
-	authToken               = flag.String("token", "", "Authentication token to use in requests. If not specified, on-cluster configuration is assumed.")
-	completedRunGracePeriod = flag.Duration("completed_run_grace_period", 0, "Grace period duration before Runs should be deleted. If 0, Runs will not be deleted. If < 0, Runs will be deleted immediately.")
-	threadiness             = flag.Int("threadiness", controller.DefaultThreadsPerController, "Number of threads (Go routines) allocated to each controller")
-	qps                     = flag.Float64("qps", float64(rest.DefaultQPS), "Kubernetes client QPS setting")
-	burst                   = flag.Int("burst", rest.DefaultBurst, "Kubernetes client Burst setting")
-	logsAPI                 = flag.Bool("logs_api", false, "Disable sending logs. If not set, the logs will be sent only if server support API for it")
-	logsTimestamps          = flag.Bool("logs_timestamps", false, "Collect logs with timestamps")
-	labelSelector           = flag.String("label_selector", "", "Selector (label query) to filter objects to be deleted. Matching objects must satisfy all labels requirements to be eligible for deletion")
-	requeueInterval         = flag.Duration("requeue_interval", 10*time.Minute, "How long the Watcher waits to reprocess keys on certain events (e.g. an object doesn't match the provided selectors)")
-	namespace               = flag.String("namespace", corev1.NamespaceAll, "Should the Watcher only watch a single namespace, then this value needs to be set to the namespace name otherwise leave it empty.")
-	summaryLabels           = flag.String("summary_labels", "tekton.dev/pipeline", "List of Labels keys separated by comma which should be part of the summary of the result")
-	summaryAnnotations      = flag.String("summary_annotations", "", "List of Annotations keys separated by comma which should be part of the summary of the result")
-	checkOwner              = flag.Bool("check_owner", true, "If enabled, owner references will be checked while deleting objects")
-	updateLogTimeout        = flag.Duration("update_log_timeout", 300*time.Second, "How log the Watcher waits for the UpdateLog operation for storing logs to complete before it aborts.")
-	dynamicReconcileTimeout = flag.Duration("dynamic_reconcile_timeout", 30*time.Second, "How long the Watcher waits for the dynamic reconciler to complete before it aborts.")
-	storeEvent              = flag.Bool("store_event", false, "If enabled, events related to runs will also be stored")
-	storeDeadline           = flag.Duration("store_deadline", 10*time.Minute, "How long to wait for storing the PipelineRun and TaskRun resources before aborting and clearing the finalizer in case of delete event")
-	forwardBuffer           = flag.Duration("forward_buffer", 150*time.Second, "This determines duration since completion time of TaskRun to wait for forwarder to finish")
+	apiAddr                      = flag.String("api_addr", "localhost:8080", "Address of API server to report to")
+	authMode                     = flag.String("auth_mode", "", "Authentication mode to use when making requests. If not set, no additional credentials will be used in the request. Valid values: [google]")
+	disableCRDUpdate             = flag.Bool("disable_crd_update", false, "Disables Tekton CRD annotation update on reconcile.")
+	authToken                    = flag.String("token", "", "Authentication token to use in requests. If not specified, on-cluster configuration is assumed.")
+	completedRunGracePeriod      = flag.Duration("completed_run_grace_period", 0, "Grace period duration before Runs should be deleted. If 0, Runs will not be deleted. If < 0, Runs will be deleted immediately.")
+	threadiness                  = flag.Int("threadiness", controller.DefaultThreadsPerController, "Number of threads (Go routines) allocated to each controller")
+	qps                          = flag.Float64("qps", float64(rest.DefaultQPS), "Kubernetes client QPS setting")
+	burst                        = flag.Int("burst", rest.DefaultBurst, "Kubernetes client Burst setting")
+	logsAPI                      = flag.Bool("logs_api", false, "Disable sending logs. If not set, the logs will be sent only if server support API for it")
+	logsTimestamps               = flag.Bool("logs_timestamps", false, "Collect logs with timestamps")
+	labelSelector                = flag.String("label_selector", "", "Selector (label query) to filter objects to be deleted. Matching objects must satisfy all labels requirements to be eligible for deletion")
+	requeueInterval              = flag.Duration("requeue_interval", 10*time.Minute, "How long the Watcher waits to reprocess keys on certain events (e.g. an object doesn't match the provided selectors)")
+	namespace                    = flag.String("namespace", corev1.NamespaceAll, "Should the Watcher only watch a single namespace, then this value needs to be set to the namespace name otherwise leave it empty.")
+	summaryLabels                = flag.String("summary_labels", "tekton.dev/pipeline", "List of Labels keys separated by comma which should be part of the summary of the result")
+	summaryAnnotations           = flag.String("summary_annotations", "", "List of Annotations keys separated by comma which should be part of the summary of the result")
+	checkOwner                   = flag.Bool("check_owner", true, "If enabled, owner references will be checked while deleting objects")
+	updateLogTimeout             = flag.Duration("update_log_timeout", 300*time.Second, "How log the Watcher waits for the UpdateLog operation for storing logs to complete before it aborts.")
+	dynamicReconcileTimeout      = flag.Duration("dynamic_reconcile_timeout", 30*time.Second, "How long the Watcher waits for the dynamic reconciler to complete before it aborts.")
+	storeEvent                   = flag.Bool("store_event", false, "If enabled, events related to runs will also be stored")
+	disableStoringIncompleteRuns = flag.Bool("disable_storing_incomplete_runs", false, "If enabled, Runs will not be stored until they are complete. If disabled, Runs will be initially stored upon creation and continuously upserted until after they're deleted")
+	storeDeadline                = flag.Duration("store_deadline", 10*time.Minute, "How long to wait for storing the PipelineRun and TaskRun resources before aborting and clearing the finalizer in case of delete event")
+	forwardBuffer                = flag.Duration("forward_buffer", 150*time.Second, "This determines duration since completion time of TaskRun to wait for forwarder to finish")
 )
 
 func main() {
@@ -128,6 +129,7 @@ func main() {
 		LogsTimestamps:               *logsTimestamps,
 		SummaryLabels:                *summaryLabels,
 		SummaryAnnotations:           *summaryAnnotations,
+		DisableStoringIncompleteRuns: *disableStoringIncompleteRuns,
 	}
 
 	log.Printf("dynamic reconcile timeout %s and update log timeout is %s", cfg.DynamicReconcileTimeout.String(), cfg.UpdateLogTimeout.String())

--- a/docs/watcher/README.md
+++ b/docs/watcher/README.md
@@ -74,3 +74,12 @@ Results stores PipelineRun and TaskRun as v1. If there are older records, it's p
 Watcher implements a finalizer to block deletion by an external pruner when objects are stored via the Watcher.
 
 When deletion request comes, it will block until completion time + `completed_run_grace_period` period is passed. A hard limit could be set as `store_deadline` (default 10m), after which the object will be removed from the cluster even without confirmation it's been stored in the DB.
+
+
+## Disabling Incomplete Runs storage
+
+The `disable_storing_incomplete_runs` flag controls whether the Watcher should store PipelineRuns and TaskRuns that are still in progress (i.e., not yet completed, cancelled or failed).
+
+When set to `true`, the Watcher will only store Runs once they are completed. This is useful for reducing the load for API server and reconciliation queue. 
+
+When set to `false` (default), the Watcher will attempt to continuously store all Runs on every modification regardless of their completion status, allowing you to track the full lifecycle of your PipelineRuns and TaskRuns.

--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -72,6 +72,9 @@ type Config struct {
 
 	// SummaryAnnotations are annotations which should be part of the summary of the result
 	SummaryAnnotations string
+
+	// DisableStoringIncompleteRuns disables the collection of incomplete Runs data
+	DisableStoringIncompleteRuns bool
 }
 
 // GetDisableAnnotationUpdate returns whether annotation updates should be

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -66,6 +66,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *pipelinev1.PipelineR
 
 	logger.Infof("Initiating reconciliation for PipelineRun '%s/%s'", pr.Namespace, pr.Name)
 
+	if !pr.IsDone() && r.cfg.DisableStoringIncompleteRuns {
+		logger.Debugf("pipelinerun %s/%s is not done and incomplete runs are disabled, skipping storing", pr.Namespace, pr.Name)
+		return nil
+	}
+
 	pipelineRunClient := &dynamic.PipelineRunClient{
 		PipelineRunInterface: r.pipelineClient.TektonV1().PipelineRuns(pr.Namespace),
 	}

--- a/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
@@ -36,6 +36,39 @@ import (
 	knativereconciler "knative.dev/pkg/reconciler"
 )
 
+func TestReconcile(t *testing.T) {
+	cfg := &reconciler.Config{
+		DisableStoringIncompleteRuns: true,
+	}
+
+	pr := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+		},
+		Status: pipelinev1.PipelineRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					apis.Condition{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = logging.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+
+	r := &Reconciler{
+		cfg: cfg,
+	}
+	got := r.ReconcileKind(ctx, pr)
+	if got != nil {
+		t.Errorf("ReconcileKind() = %v, want nil", got)
+	}
+}
 func TestAreAllUnderlyingTaskRunsReadyForDeletion(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/watcher/reconciler/taskrun/reconciler.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler.go
@@ -47,6 +47,11 @@ var _ taskrunreconciler.Finalizer = (*Reconciler)(nil)
 func (r *Reconciler) ReconcileKind(ctx context.Context, tr *pipelinev1.TaskRun) knativereconciler.Event {
 	logger := logging.FromContext(ctx).With(zap.String("results.tekton.dev/kind", "TaskRun"))
 
+	if !tr.IsDone() && r.cfg.DisableStoringIncompleteRuns {
+		logger.Debugf("taskrun %s/%s is not done and incomplete runs are disabled, skipping storing", tr.Namespace, tr.Name)
+		return nil
+	}
+
 	taskRunClient := &dynamic.TaskRunClient{
 		TaskRunInterface: r.pipelineClient.TektonV1().TaskRuns(tr.Namespace),
 	}

--- a/pkg/watcher/reconciler/taskrun/reconciler_test.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler_test.go
@@ -34,6 +34,40 @@ import (
 	knativereconciler "knative.dev/pkg/reconciler"
 )
 
+func TestReconcile(t *testing.T) {
+	cfg := &reconciler.Config{
+		DisableStoringIncompleteRuns: true,
+	}
+
+	tr := &pipelinev1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "test-ns",
+		},
+		Status: pipelinev1.TaskRunStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					apis.Condition{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	ctx = logging.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+
+	r := &Reconciler{
+		cfg: cfg,
+	}
+	got := r.ReconcileKind(ctx, tr)
+	if got != nil {
+		t.Errorf("ReconcileKind() = %v, want nil", got)
+	}
+
+}
 func TestFinalize(t *testing.T) {
 	storeDeadline := time.Hour
 	finalizerRequeueInterval := time.Second

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -41,6 +41,7 @@ main() {
 
     # Build static binaries; otherwise go test complains.
     export CGO_ENABLED=0
+    kubectl get pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines -o yaml
     go test -v -count=1 --tags=e2e $(go list --tags=e2e ${REPO}/test/e2e/... | grep -v /client)
     kubectl apply -f ${REPO}/test/e2e/gcs-emulator.yaml
     kubectl delete pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-api | sed "s/^.\{4\}//") -n tekton-pipelines

--- a/test/e2e/kustomize/watcher.yaml
+++ b/test/e2e/kustomize/watcher.yaml
@@ -36,3 +36,6 @@
 - op: add
   path: "/spec/template/spec/containers/0/args/-"
   value: "-logs_api=true"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-disable_storing_incomplete_runs=true"


### PR DESCRIPTION
Add a flag in watcher to disable live collection of TaskRun and PipelineRun.
This enables us to reduce call to API server when under heavy load
and proceed with further reconciliation only when Runs are done.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
Added flag:  `disable_storing_incomplete_runs`  If set to true, Runs will not be stored until they are complete. If false, Runs will be initially stored upon creation and continuously upserted until after they're deleted"
```

