### PR TITLE
feat: enable readOnlyRootFilesystem and add required writable mounts

### DIFF
--- a/config/components/local-db/201-sql-deployment.yaml
+++ b/config/components/local-db/201-sql-deployment.yaml
@@ -51,18 +51,32 @@ spec:
           name: postgredb
         volumeMounts:
         - name: postgredb
-          mountPath: /bitnami/postgresql
+          mountPath: /bitnami/postgresql  # Persistent volume for PostgreSQL data
+        - name: tmp
+          mountPath: /tmp  # Writable tmp directory for general temp file usage
+        - name: postgresql-conf
+          mountPath: /opt/bitnami/postgresql/conf  # Writable config dir (e.g., pg_hba.conf)
+        - name: postgresql-tmp
+          mountPath: /opt/bitnami/postgresql/tmp  # Bitnami internal marker and temp files
         securityContext:
           seccompProfile:
             type: RuntimeDefault
           runAsNonRoot: true
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - ALL
             add:
               - NET_BIND_SERVICE
-  volumeClaimTemplates:
+      volumes: # Writable ephemeral volumes needed due to readOnlyRootFilesystem: true
+      - name: tmp
+        emptyDir: {}
+      - name: postgresql-conf
+        emptyDir: {}
+      - name: postgresql-tmp
+        emptyDir: {}
+  volumeClaimTemplates: # Persistent volume for actual PostgreSQL database data
   - metadata:
       name: postgredb
     spec:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR enables readOnlyRootFilesystem in the PostgreSQL container for enhanced security. To support this change, writable emptyDir volume mounts are added for directories that require write access during container startup and runtime.

- Enabled readOnlyRootFilesystem: true under container securityContext.
- Added emptyDir volumes and corresponding volumeMounts for:
   - /tmp – general temporary file usage
   - /opt/bitnami/postgresql/conf – for dynamic config file generation (pg_hba.conf, postgresql.conf)
   - /opt/bitnami/postgresql/tmp – for internal init tracking (.initialized)
   
closes: #1062
<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
