### PR TITLE
Resolve STS not starting when fsGroup is not set

### DIFF
--- a/config/components/local-db/201-sql-deployment.yaml
+++ b/config/components/local-db/201-sql-deployment.yaml
@@ -28,8 +28,6 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-results-postgres
 spec:
-  securityContext:
-    fsGroup: 1001
   serviceName: "postgres"
   replicas: 1
   selector:
@@ -40,6 +38,8 @@ spec:
       labels:
         app.kubernetes.io/name: tekton-results-postgres
     spec:
+      securityContext:
+        fsGroup: 1001
       containers:
       - name: postgres
         image: bitnami/postgresql@sha256:ac8dd0d6512c4c5fb146c16b1c5f05862bd5f600d73348506ab4252587e7fcc6 # 17.5.0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->
STS won't start after installing v0.75 of the tekton operator or later.
The permission denied issue: https://github.com/tektoncd/operator/issues/2671 is resolved by setting an fsGroup.
If fsGroup is set on the pod level the STS starts without any issue (on EKS).

After the initial STS start the property doesn't seem required.
Currently tested with the following procedure:

1.Deployment of tekton-operator replicas changed to 0
2.get postgres pod yaml.
3.add securitycontext fsgroup property
4. wait until pod stays available / logs contain message that pod was able to fully start.
5. change tekton operator replicas back to original value
6. sts gets restarted by tekton operator (securitycontext is reset but STS keeps working until deleted and thereby recreated).

Since tekton is a really complex project I wasn't able to find the location where additional securitycontext properties is added on the tekton pods:
```
 securityContext:
    runAsNonRoot: true
    seccompProfile:
      type: RuntimeDefault
 ```

I believe somewhere it might be set programmatically but due to my inability to find it I added the option to the postgres pod spec template in this pr.

fsgroup: setting is a recommended setting by the bitnami postgres chart.
See: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/templates/primary/statefulset.yaml (if you use helm to template the chart the fsgroup property is present in the securitycontext of the sts pod).

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
