### PR TITLE
Add support for fine-grained retention policies

### DIFF
--- a/config/base/config-results-retention-policy.yaml
+++ b/config/base/config-results-retention-policy.yaml
@@ -21,5 +21,5 @@ metadata:
 data:
   # runAt determines when to run pruning job in DB.
   runAt: "5 5 * * 0"
-  # max-retention in days determines for how long to keep the data in DB.
-  maxRetention: "30"
+  # default-retention in days determines for how long to keep the data in DB.
+  defaultRetention: "30"

--- a/docs/retention-policy-agent/README.md
+++ b/docs/retention-policy-agent/README.md
@@ -9,10 +9,78 @@ weight: 2
 
 # Result Retention Policy Agent
 
-The Results Retention Policy Agent removes older Results and their associated Records from the DB.
+The Results Retention Policy Agent removes older Results and their associated Records from the DB. The policies apply to both `PipelineRun` and top-level `TaskRun` results.
 
 ## Configuration
-The Results Retention Policy Agent config uses following field
 
-- `runAt`: determines when to run pruning job for DB.
-- `maxRetention`: for how long to keep results and records.
+The Results Retention Policy Agent is configured via the `tekton-results-config-results-retention-policy` ConfigMap.
+
+The following fields are supported:
+
+- `runAt`: Determines when to run the pruning job for the DB. It uses a cron schedule format. The default is `"7 7 * * 7"` (every Sunday at 7:07 AM).
+- `maxRetention`: The **fallback** retention period for how long to keep Results and Records when no specific policy matches. This value does **not** override the retention period of a matching policy; it only applies when no policies match a given Result. This can be a number (e.g., `30`), which is interpreted as days, or a duration string (e.g., `30d`, `24h`). The default is `30d`.
+- `policies`: A list of fine-grained retention policies that allow for more specific control over data retention.
+
+### Fine-Grained Retention Policies
+
+You can define a list of policies to control retention based on various criteria. The `policies` field in the ConfigMap accepts a YAML string containing a list of policy objects. Each policy has a `name`, a `selector`, and a `retention` period.
+
+When the retention job runs, it evaluates a Result against the policies in the order they are defined. The **first policy that matches** the Result will be applied. If no policies match, the default `maxRetention` period is used.
+
+#### Policy Fields:
+- `name`: A descriptive name for the policy.
+- `selector`: Defines the criteria for matching Results. All conditions within a selector are combined with an **AND** logic—a Result must meet all specified criteria (`matchNamespaces`, `matchLabels`, `matchAnnotations`, `matchStatuses`) for the policy to apply. If a particular selector type (e.g., `matchLabels`) is omitted from a policy, it will match all Results for that criterion. For example, a policy without a `matchNamespaces` selector will match Results from any namespace.
+  - `matchNamespaces`: A list of namespaces. A Result matches if its namespace is in this list (an **OR** logic is applied to the values in the list).
+  - `matchLabels`: A map where the key is a label name and the value is a list of possible label values. A Result must have all the specified label keys, and for each key, its value must be in the provided list (an **OR** logic is applied to the values in the list).
+  - `matchAnnotations`: A map where the key is an annotation name and the value is a list of possible annotation values. This works similarly to `matchLabels`.
+  - `matchStatuses`: A list of final statuses. A Result matches if its final status is in this list (an **OR** logic is applied to the values in the list). The status is determined by the `reason` field of the primary `Succeeded` condition in the `PipelineRun` or `TaskRun` status. Common values include `Succeeded`, `Failed`, `Cancelled`, `Running`, and `Pending`. For a more comprehensive list of possible status reasons, refer to the [Tekton documentation](https://tekton.dev/docs/pipelines/pipelineruns/#monitoring-execution-status).
+- `retention`: The retention period for Results matching this policy. This can be a number (e.g., `7`), which is interpreted as days, or a duration string (e.g., `24h`).
+
+#### Example ConfigMap:
+
+Here is an example of a `ConfigMap` that defines multiple, comprehensive retention policies:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-results-config-results-retention-policy
+  namespace: tekton-pipelines
+data:
+  runAt: "0 2 * * *" # Run every day at 2:00 AM
+  maxRetention: "30d"
+  policies: |
+    - name: "retain-critical-failures-long-term"
+      selector:
+        matchNamespaces:
+          - "production"
+          - "prod-east"
+        matchLabels:
+          "criticality": ["high"]
+        matchStatuses:
+          - "Failed"
+      retention: "180d"
+    - name: "retain-annotated-for-debug"
+      selector:
+        matchAnnotations:
+          "debug/retain": ["true"]
+      retention: "14d"
+    - name: "default-production-policy"
+      selector:
+        matchNamespaces:
+          - "production"
+          - "prod-east"
+      retention: "60d"
+    - name: "short-term-ci-retention"
+      selector:
+        matchNamespaces:
+          - "ci"
+      retention: "7d"
+```
+
+In this example:
+1.  A failed Result in the `production` or `prod-east` namespace with the label `criticality: high` will be kept for **180 days**.
+2.  Any Result with the annotation `debug/retain: "true"` will be kept for **14 days**.
+3.  Any other Result in the `production` or `prod-east` namespace will be kept for **60 days**.
+4.  Any Result in the `ci` namespace will be kept for **7 days**.
+5.  All other Results that do not match any of these policies will be kept for the default `maxRetention` period of **30 days**.

--- a/docs/retention-policy-agent/README.md
+++ b/docs/retention-policy-agent/README.md
@@ -18,14 +18,16 @@ The Results Retention Policy Agent is configured via the `tekton-results-config-
 The following fields are supported:
 
 - `runAt`: Determines when to run the pruning job for the DB. It uses a cron schedule format. The default is `"7 7 * * 7"` (every Sunday at 7:07 AM).
-- `maxRetention`: The **fallback** retention period for how long to keep Results and Records when no specific policy matches. This value does **not** override the retention period of a matching policy; it only applies when no policies match a given Result. This can be a number (e.g., `30`), which is interpreted as days, or a duration string (e.g., `30d`, `24h`). The default is `30d`.
+- `defaultRetention`: The **fallback** retention period for how long to keep Results and Records when no specific policy matches. This value does **not** override the retention period of a matching policy; it only applies when no policies match a given Result. This can be a number (e.g., `30`), which is interpreted as days, or a duration string (e.g., `30d`, `24h`). The default is `30d`.
+> **Note:**
+> `maxRetention` is deprecated and will be removed in a future release. If `defaultRetention` is not set, `maxRetention` will be used as the default retention period for backward compatibility.
 - `policies`: A list of fine-grained retention policies that allow for more specific control over data retention.
 
 ### Fine-Grained Retention Policies
 
 You can define a list of policies to control retention based on various criteria. The `policies` field in the ConfigMap accepts a YAML string containing a list of policy objects. Each policy has a `name`, a `selector`, and a `retention` period.
 
-When the retention job runs, it evaluates a Result against the policies in the order they are defined. The **first policy that matches** the Result will be applied. If no policies match, the default `maxRetention` period is used.
+When the retention job runs, it evaluates a Result against the policies in the order they are defined. The **first policy that matches** the Result will be applied. If no policies match, the default `defaultRetention` period is used.
 
 #### Policy Fields:
 - `name`: A descriptive name for the policy.
@@ -48,7 +50,7 @@ metadata:
   namespace: tekton-pipelines
 data:
   runAt: "0 2 * * *" # Run every day at 2:00 AM
-  maxRetention: "30d"
+  defaultRetention: "30d"
   policies: |
     - name: "retain-critical-failures-long-term"
       selector:
@@ -83,4 +85,4 @@ In this example:
 2.  Any Result with the annotation `debug/retain: "true"` will be kept for **14 days**.
 3.  Any other Result in the `production` or `prod-east` namespace will be kept for **60 days**.
 4.  Any Result in the `ci` namespace will be kept for **7 days**.
-5.  All other Results that do not match any of these policies will be kept for the default `maxRetention` period of **30 days**.
+5.  All other Results that do not match any of these policies will be kept for the default `defaultRetention` period of **30 days**.

--- a/pkg/apis/config/retention.go
+++ b/pkg/apis/config/retention.go
@@ -4,14 +4,17 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	runAt           = "runAt"
 	maxRetention    = "maxRetention"
+	policiesKey     = "policies"
 	retentionCMName = "tekton-results-config-results-retention-policy"
 	// DefaultRunAt is the default value for RunAt
 	DefaultRunAt = "7 7 * * 7"
@@ -19,10 +22,43 @@ const (
 	DefaultMaxRetention = time.Hour * 24 * 30
 )
 
+// ParseDuration parses a string into a time.Duration.
+// It handles standard formats like "24h", "90m", as well as the "d" suffix for days.
+// If no unit is specified, it defaults to days.
+func ParseDuration(durationStr string) (time.Duration, error) {
+	if strings.HasSuffix(durationStr, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(durationStr, "d"))
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	if days, err := strconv.Atoi(durationStr); err == nil {
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(durationStr)
+}
+
+// Policy defines a single retention policy rule.
+type Policy struct {
+	Name      string   `yaml:"name"`
+	Selector  Selector `yaml:"selector"`
+	Retention string   `yaml:"retention"`
+}
+
+// Selector defines the selection criteria for a policy.
+type Selector struct {
+	MatchNamespaces  []string            `yaml:"matchNamespaces"`
+	MatchLabels      map[string][]string `yaml:"matchLabels"`
+	MatchAnnotations map[string][]string `yaml:"matchAnnotations"`
+	MatchStatuses    []string            `yaml:"matchStatuses"`
+}
+
 // RetentionPolicy holds the configurations for the Retention Policy of the DB
 type RetentionPolicy struct {
 	RunAt        string
 	MaxRetention time.Duration
+	Policies     []Policy
 }
 
 // DeepCopy copying the receiver, creating a new RetentionPolicy.
@@ -31,6 +67,7 @@ func (cfg *RetentionPolicy) DeepCopy() *RetentionPolicy {
 	return &RetentionPolicy{
 		RunAt:        cfg.RunAt,
 		MaxRetention: cfg.MaxRetention,
+		Policies:     cfg.Policies,
 	}
 }
 
@@ -59,12 +96,21 @@ func newRetentionPolicyFromMap(cfgMap map[string]string) (*RetentionPolicy, erro
 	}
 
 	if duration, ok := cfgMap[maxRetention]; ok {
-		v, err := strconv.Atoi(duration)
+		v, err := ParseDuration(duration)
 		if err != nil {
-			return nil, fmt.Errorf("incorrect configuration for maxRetention:%s", err.Error())
+			return nil, fmt.Errorf("incorrect configuration for maxRetention: %w", err)
 		}
-		rp.MaxRetention = time.Hour * 24 * time.Duration(v)
+		rp.MaxRetention = v
 	}
+
+	if policiesYAML, ok := cfgMap[policiesKey]; ok {
+		var policies []Policy
+		if err := yaml.Unmarshal([]byte(policiesYAML), &policies); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal policies: %w", err)
+		}
+		rp.Policies = policies
+	}
+
 	return &rp, nil
 }
 

--- a/pkg/apis/config/retention.go
+++ b/pkg/apis/config/retention.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -12,14 +13,15 @@ import (
 )
 
 const (
-	runAt           = "runAt"
-	maxRetention    = "maxRetention"
-	policiesKey     = "policies"
-	retentionCMName = "tekton-results-config-results-retention-policy"
+	runAt            = "runAt"
+	maxRetention     = "maxRetention"
+	defaultRetention = "defaultRetention"
+	policiesKey      = "policies"
+	retentionCMName  = "tekton-results-config-results-retention-policy"
 	// DefaultRunAt is the default value for RunAt
 	DefaultRunAt = "7 7 * * 7"
-	// DefaultMaxRetention is the default value for MaxRetention
-	DefaultMaxRetention = time.Hour * 24 * 30
+	// DefaultDefaultRetention is the default value for DefaultRetention
+	DefaultDefaultRetention = time.Hour * 24 * 30
 )
 
 // ParseDuration parses a string into a time.Duration.
@@ -56,19 +58,67 @@ type Selector struct {
 
 // RetentionPolicy holds the configurations for the Retention Policy of the DB
 type RetentionPolicy struct {
-	RunAt        string
-	MaxRetention time.Duration
-	Policies     []Policy
+	RunAt            string
+	DefaultRetention time.Duration
+	Policies         []Policy
 }
 
 // DeepCopy copying the receiver, creating a new RetentionPolicy.
 // deepcopy-gen hasn't been introduced in results repo, so handcraft here for now
 func (cfg *RetentionPolicy) DeepCopy() *RetentionPolicy {
-	return &RetentionPolicy{
-		RunAt:        cfg.RunAt,
-		MaxRetention: cfg.MaxRetention,
-		Policies:     cfg.Policies,
+	if cfg == nil {
+		return nil
 	}
+	newCfg := &RetentionPolicy{
+		RunAt:            cfg.RunAt,
+		DefaultRetention: cfg.DefaultRetention,
+	}
+	if cfg.Policies != nil {
+		newCfg.Policies = make([]Policy, len(cfg.Policies))
+		for i, p := range cfg.Policies {
+			newCfg.Policies[i] = *p.DeepCopy()
+		}
+	}
+	return newCfg
+}
+
+// DeepCopy returns a deep copy of the Policy.
+func (p *Policy) DeepCopy() *Policy {
+	if p == nil {
+		return nil
+	}
+	return &Policy{
+		Name:      p.Name,
+		Selector:  *p.Selector.DeepCopy(),
+		Retention: p.Retention,
+	}
+}
+
+// DeepCopy returns a deep copy of the Selector.
+func (s *Selector) DeepCopy() *Selector {
+	if s == nil {
+		return nil
+	}
+	out := &Selector{}
+	if s.MatchNamespaces != nil {
+		out.MatchNamespaces = append([]string(nil), s.MatchNamespaces...)
+	}
+	if s.MatchStatuses != nil {
+		out.MatchStatuses = append([]string(nil), s.MatchStatuses...)
+	}
+	if s.MatchLabels != nil {
+		out.MatchLabels = make(map[string][]string, len(s.MatchLabels))
+		for k, v := range s.MatchLabels {
+			out.MatchLabels[k] = append([]string(nil), v...)
+		}
+	}
+	if s.MatchAnnotations != nil {
+		out.MatchAnnotations = make(map[string][]string, len(s.MatchAnnotations))
+		for k, v := range s.MatchAnnotations {
+			out.MatchAnnotations[k] = append([]string(nil), v...)
+		}
+	}
+	return out
 }
 
 // Equals returns true if two Configs are identical
@@ -82,25 +132,32 @@ func (cfg *RetentionPolicy) Equals(other *RetentionPolicy) bool {
 	}
 
 	return other.RunAt == cfg.RunAt &&
-		other.MaxRetention == cfg.MaxRetention
+		other.DefaultRetention == cfg.DefaultRetention
 }
 
 func newRetentionPolicyFromMap(cfgMap map[string]string) (*RetentionPolicy, error) {
 	rp := RetentionPolicy{
-		RunAt:        DefaultRunAt,
-		MaxRetention: DefaultMaxRetention,
+		RunAt:            DefaultRunAt,
+		DefaultRetention: DefaultDefaultRetention,
 	}
 
 	if schedule, ok := cfgMap[runAt]; ok {
 		rp.RunAt = schedule
 	}
 
-	if duration, ok := cfgMap[maxRetention]; ok {
+	if duration, ok := cfgMap[defaultRetention]; ok {
+		v, err := ParseDuration(duration)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect configuration for defaultRetention: %w", err)
+		}
+		rp.DefaultRetention = v
+	} else if duration, ok := cfgMap[maxRetention]; ok {
+		log.Println("WARNING: configuration key 'maxRetention' is deprecated; please use 'defaultRetention' instead.")
 		v, err := ParseDuration(duration)
 		if err != nil {
 			return nil, fmt.Errorf("incorrect configuration for maxRetention: %w", err)
 		}
-		rp.MaxRetention = v
+		rp.DefaultRetention = v
 	}
 
 	if policiesYAML, ok := cfgMap[policiesKey]; ok {

--- a/pkg/apis/config/retention_test.go
+++ b/pkg/apis/config/retention_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNewRetentionPolicyFromConfigMap(t *testing.T) {
+	type args struct {
+		config *corev1.ConfigMap
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *RetentionPolicy
+		wantErr bool
+	}{
+		{
+			name: "empty config",
+			args: args{config: &corev1.ConfigMap{}},
+			want: &RetentionPolicy{
+				RunAt:        DefaultRunAt,
+				MaxRetention: DefaultMaxRetention,
+			},
+		},
+		{
+			name: "maxRetention with d suffix",
+			args: args{config: &corev1.ConfigMap{
+				Data: map[string]string{
+					"maxRetention": "10d",
+				},
+			}},
+			want: &RetentionPolicy{
+				RunAt:        DefaultRunAt,
+				MaxRetention: 10 * 24 * time.Hour,
+			},
+		},
+		{
+			name: "maxRetention without suffix",
+			args: args{config: &corev1.ConfigMap{
+				Data: map[string]string{
+					"maxRetention": "10",
+				},
+			}},
+			want: &RetentionPolicy{
+				RunAt:        DefaultRunAt,
+				MaxRetention: 10 * 24 * time.Hour,
+			},
+		},
+		{
+			name: "with policies",
+			args: args{config: &corev1.ConfigMap{
+				Data: map[string]string{
+					"policies": `
+- name: "policy1"
+  selector:
+    matchLabels:
+      "app": ["foo"]
+  retention: "10d"
+`,
+				},
+			}},
+			want: &RetentionPolicy{
+				RunAt:        DefaultRunAt,
+				MaxRetention: DefaultMaxRetention,
+				Policies: []Policy{
+					{
+						Name: "policy1",
+						Selector: Selector{
+							MatchLabels: map[string][]string{"app": {"foo"}},
+						},
+						Retention: "10d",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid policies yaml",
+			args: args{config: &corev1.ConfigMap{
+				Data: map[string]string{
+					"policies": `
+- name: "policy1"
+  selector:
+    matchLabels:
+      "app": ["foo"]
+  retention: "10d"
+ :
+`,
+				},
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewRetentionPolicyFromConfigMap(tt.args.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewRetentionPolicyFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NewRetentionPolicyFromConfigMap() = %v, want %v, diff: %s", got, tt.want, diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/config/retention_test.go
+++ b/pkg/apis/config/retention_test.go
@@ -22,32 +22,44 @@ func TestNewRetentionPolicyFromConfigMap(t *testing.T) {
 			name: "empty config",
 			args: args{config: &corev1.ConfigMap{}},
 			want: &RetentionPolicy{
-				RunAt:        DefaultRunAt,
-				MaxRetention: DefaultMaxRetention,
+				RunAt:            DefaultRunAt,
+				DefaultRetention: DefaultDefaultRetention,
 			},
 		},
 		{
-			name: "maxRetention with d suffix",
+			name: "defaultRetention with d suffix",
 			args: args{config: &corev1.ConfigMap{
 				Data: map[string]string{
-					"maxRetention": "10d",
+					"defaultRetention": "10d",
 				},
 			}},
 			want: &RetentionPolicy{
-				RunAt:        DefaultRunAt,
-				MaxRetention: 10 * 24 * time.Hour,
+				RunAt:            DefaultRunAt,
+				DefaultRetention: 10 * 24 * time.Hour,
 			},
 		},
 		{
-			name: "maxRetention without suffix",
+			name: "defaultRetention without suffix",
+			args: args{config: &corev1.ConfigMap{
+				Data: map[string]string{
+					"defaultRetention": "10",
+				},
+			}},
+			want: &RetentionPolicy{
+				RunAt:            DefaultRunAt,
+				DefaultRetention: 10 * 24 * time.Hour,
+			},
+		},
+		{
+			name: "maxRetention(deprecated) without suffix",
 			args: args{config: &corev1.ConfigMap{
 				Data: map[string]string{
 					"maxRetention": "10",
 				},
 			}},
 			want: &RetentionPolicy{
-				RunAt:        DefaultRunAt,
-				MaxRetention: 10 * 24 * time.Hour,
+				RunAt:            DefaultRunAt,
+				DefaultRetention: 10 * 24 * time.Hour,
 			},
 		},
 		{
@@ -64,8 +76,8 @@ func TestNewRetentionPolicyFromConfigMap(t *testing.T) {
 				},
 			}},
 			want: &RetentionPolicy{
-				RunAt:        DefaultRunAt,
-				MaxRetention: DefaultMaxRetention,
+				RunAt:            DefaultRunAt,
+				DefaultRetention: DefaultDefaultRetention,
 				Policies: []Policy{
 					{
 						Name: "policy1",

--- a/pkg/retention/job.go
+++ b/pkg/retention/job.go
@@ -17,11 +17,13 @@ limitations under the License.
 package retention
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
-	"github.com/tektoncd/results/pkg/api/server/db"
 	"github.com/tektoncd/results/pkg/api/server/db/errors"
+	"github.com/tektoncd/results/pkg/apis/config"
 )
 
 func (a *Agent) start() {
@@ -42,23 +44,91 @@ func (a *Agent) stop() {
 }
 
 func (a *Agent) job() {
-	now := time.Now().Add(-a.MaxRetention)
-	a.Logger.Infof("retention job started at: %s, deleting data older than %s, retention policy: %s",
-		time.Now().String(), now, a.RetentionPolicy)
+	a.Logger.Infof("retention job started at: %s, retention policy: %+v", time.Now().String(), a.RetentionPolicy)
 
-	q := a.db.Unscoped().
-		Where("updated_time < ?", now).
-		Delete(&db.Record{})
-	if err := errors.Wrap(q.Error); err != nil {
-		a.Logger.Errorf("failed to delete record %s", err.Error())
+	caseStatement, err := buildCaseStatement(a.Policies, a.MaxRetention)
+	if err != nil {
+		a.Logger.Errorf("failed to build case statement: %v", err)
+		return
 	}
-	q = a.db.Unscoped().
-		Where("updated_time < ?", now).
-		Delete(&db.Result{})
-	if err := errors.Wrap(q.Error); err != nil {
-		a.Logger.Errorf("failed to delete result %s", err.Error())
-	}
+
+	// First, clean up PipelineRun results.
+	a.cleanupResults(caseStatement, "tekton.dev/v1.PipelineRun")
+
+	// Second, clean up top-level TaskRun results.
+	a.cleanupResults(caseStatement, "tekton.dev/v1.TaskRun")
 
 	a.Logger.Infof("retention job finished at: %s", time.Now().String())
+}
 
+func (a *Agent) cleanupResults(caseStatement, recordType string) {
+	deleteQuery := fmt.Sprintf(`
+        DELETE FROM results
+        WHERE id IN (
+            SELECT result_id FROM (
+                SELECT
+                    r.result_id,
+                    r.updated_time,
+                    %s AS expiration_time
+                FROM records r
+                WHERE r.type = '%s'
+            ) AS subquery
+            WHERE updated_time < expiration_time
+        )
+    `, caseStatement, recordType)
+
+	if err := errors.Wrap(a.db.Exec(deleteQuery).Error); err != nil {
+		a.Logger.Errorf("failed to delete results for record type %s: %s", recordType, err.Error())
+	}
+}
+
+func buildCaseStatement(policies []config.Policy, maxRetention time.Duration) (string, error) {
+	if len(policies) == 0 {
+		return fmt.Sprintf("NOW() - INTERVAL '%f seconds'", maxRetention.Seconds()), nil
+	}
+	var caseClauses []string
+	for _, policy := range policies {
+		whereClause, err := buildWhereClause(policy.Selector)
+		if err != nil {
+			return "", err
+		}
+		retentionDuration, err := config.ParseDuration(policy.Retention)
+		if err != nil {
+			return "", err
+		}
+		caseClauses = append(caseClauses, fmt.Sprintf("WHEN %s THEN NOW() - INTERVAL '%f seconds'", whereClause, retentionDuration.Seconds()))
+	}
+
+	maxRetentionSeconds := maxRetention.Seconds()
+	caseClauses = append(caseClauses, fmt.Sprintf("ELSE NOW() - INTERVAL '%f seconds'", maxRetentionSeconds))
+
+	return fmt.Sprintf("CASE %s END", strings.Join(caseClauses, " ")), nil
+}
+
+func buildWhereClause(selector config.Selector) (string, error) {
+	var conditions []string
+	if len(selector.MatchNamespaces) > 0 {
+		conditions = append(conditions, fmt.Sprintf("parent IN (%s)", quoteAndJoin(selector.MatchNamespaces)))
+	}
+	for key, values := range selector.MatchLabels {
+		conditions = append(conditions, fmt.Sprintf("data->'metadata'->'labels'->>'%s' IN (%s)", key, quoteAndJoin(values)))
+	}
+	for key, values := range selector.MatchAnnotations {
+		conditions = append(conditions, fmt.Sprintf("data->'metadata'->'annotations'->>'%s' IN (%s)", key, quoteAndJoin(values)))
+	}
+	if len(selector.MatchStatuses) > 0 {
+		conditions = append(conditions, fmt.Sprintf("data->'status'->'conditions'->0->>'reason' IN (%s)", quoteAndJoin(selector.MatchStatuses)))
+	}
+	if len(conditions) == 0 {
+		return "1=1", nil // No specific selectors, so match all.
+	}
+	return strings.Join(conditions, " AND "), nil
+}
+
+func quoteAndJoin(items []string) string {
+	quoted := make([]string, len(items))
+	for i, item := range items {
+		quoted[i] = fmt.Sprintf("'%s'", item)
+	}
+	return strings.Join(quoted, ",")
 }

--- a/pkg/retention/job_test.go
+++ b/pkg/retention/job_test.go
@@ -20,78 +20,148 @@ import (
 	"testing"
 	"time"
 
-	"github.com/robfig/cron/v3"
-	"github.com/tektoncd/results/pkg/api/server/db"
 	"github.com/tektoncd/results/pkg/apis/config"
-	"go.uber.org/zap"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
-func TestAgent_job(t *testing.T) {
-	// Setup in-memory SQLite database
-	dbMem, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("Failed to connect to in-memory database: %v", err)
+func Test_buildCaseStatement(t *testing.T) {
+	type args struct {
+		policies     []config.Policy
+		maxRetention time.Duration
 	}
-
-	// Auto migrate the schema
-	err = dbMem.AutoMigrate(&db.Record{}, &db.Result{})
-	if err != nil {
-		t.Fatalf("Failed to migrate database schema: %v", err)
-	}
-
-	// Create test agent
-	agent := &Agent{
-		db:     dbMem,
-		Logger: zap.NewExample().Sugar(),
-
-		RetentionPolicy: config.RetentionPolicy{
-			MaxRetention: 24 * time.Hour,
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "no policies",
+			args: args{
+				policies:     nil,
+				maxRetention: 30 * 24 * time.Hour,
+			},
+			want: "NOW() - INTERVAL '2592000.000000 seconds'",
 		},
-		cron: cron.New(),
+		{
+			name: "with policies",
+			args: args{
+				policies: []config.Policy{
+					{
+						Selector: config.Selector{
+							MatchLabels: map[string][]string{"app": {"foo"}},
+						},
+						Retention: "10d",
+					},
+				},
+				maxRetention: 30 * 24 * time.Hour,
+			},
+			want: "CASE WHEN data->'metadata'->'labels'->>'app' IN ('foo') THEN NOW() - INTERVAL '864000.000000 seconds' ELSE NOW() - INTERVAL '2592000.000000 seconds' END",
+		},
+		{
+			name: "with policies without suffix",
+			args: args{
+				policies: []config.Policy{
+					{
+						Selector: config.Selector{
+							MatchLabels: map[string][]string{"app": {"foo"}},
+						},
+						Retention: "10",
+					},
+				},
+				maxRetention: 30 * 24 * time.Hour,
+			},
+			want: "CASE WHEN data->'metadata'->'labels'->>'app' IN ('foo') THEN NOW() - INTERVAL '864000.000000 seconds' ELSE NOW() - INTERVAL '2592000.000000 seconds' END",
+		},
 	}
-
-	// Insert test data
-	now := time.Now()
-	oldResult := db.Result{UpdatedTime: now.Add(-25 * time.Hour), Parent: "foo", ID: "foo", Name: "foo"}
-	newResult := db.Result{UpdatedTime: now, Parent: "foo", ID: "foo-new", Name: "foo-new"}
-
-	oldRecord := db.Record{UpdatedTime: now.Add(-25 * time.Hour), Parent: "foo",
-		Result:     oldResult,
-		ResultName: "foo", ResultID: "foo", ID: "foo"}
-	newRecord := db.Record{UpdatedTime: now, Parent: "foo",
-		Result:     newResult,
-		ResultName: "foo-new", ResultID: "foo-new", ID: "foo-new"}
-
-	dbMem.Save(&oldRecord)
-	dbMem.Create(&newRecord)
-
-	// Run the job
-	agent.job()
-
-	// Check if old records and results are deleted
-	var count int64
-	dbMem.Model(&db.Record{}).Count(&count)
-	if count != 1 {
-		t.Errorf("Expected 1 record, got %d", count)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildCaseStatement(tt.args.policies, tt.args.maxRetention)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildCaseStatement() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buildCaseStatement() = %v, want %v", got, tt.want)
+			}
+		})
 	}
+}
 
-	dbMem.Model(&db.Result{}).Count(&count)
-	if count != 1 {
-		t.Errorf("Expected 1 result, got %d", count)
+func Test_buildWhereClause(t *testing.T) {
+	type args struct {
+		selector config.Selector
 	}
-
-	// Check if new records and results are retained
-	var remainingRecord db.Record
-	dbMem.First(&remainingRecord)
-	if !remainingRecord.UpdatedTime.Equal(newRecord.UpdatedTime) {
-		t.Errorf("Expected remaining record to be the new one")
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "empty selector",
+			args: args{
+				selector: config.Selector{},
+			},
+			want: "1=1",
+		},
+		{
+			name: "with labels",
+			args: args{
+				selector: config.Selector{
+					MatchLabels: map[string][]string{"app": {"foo"}},
+				},
+			},
+			want: "data->'metadata'->'labels'->>'app' IN ('foo')",
+		},
+		{
+			name: "with annotations",
+			args: args{
+				selector: config.Selector{
+					MatchAnnotations: map[string][]string{"tekton.dev/image": {"bar"}},
+				},
+			},
+			want: "data->'metadata'->'annotations'->>'tekton.dev/image' IN ('bar')",
+		},
+		{
+			name: "with status",
+			args: args{
+				selector: config.Selector{
+					MatchStatuses: []string{"Succeeded"},
+				},
+			},
+			want: "data->'status'->'conditions'->0->>'reason' IN ('Succeeded')",
+		},
+		{
+			name: "with namespace",
+			args: args{
+				selector: config.Selector{
+					MatchNamespaces: []string{"prod"},
+				},
+			},
+			want: "parent IN ('prod')",
+		},
+		{
+			name: "with multiple conditions",
+			args: args{
+				selector: config.Selector{
+					MatchNamespaces: []string{"prod"},
+					MatchLabels:     map[string][]string{"app": {"foo"}},
+					MatchStatuses:   []string{"Succeeded"},
+				},
+			},
+			want: "parent IN ('prod') AND data->'metadata'->'labels'->>'app' IN ('foo') AND data->'status'->'conditions'->0->>'reason' IN ('Succeeded')",
+		},
 	}
-
-	var remainingResult db.Result
-	dbMem.First(&remainingResult)
-	if !remainingResult.UpdatedTime.Equal(newResult.UpdatedTime) {
-		t.Errorf("Expected remaining result to be the new one")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildWhereClause(tt.args.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildWhereClause() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buildWhereClause() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/retention/job_test.go
+++ b/pkg/retention/job_test.go
@@ -25,8 +25,8 @@ import (
 
 func Test_buildCaseStatement(t *testing.T) {
 	type args struct {
-		policies     []config.Policy
-		maxRetention time.Duration
+		policies         []config.Policy
+		defaultRetention time.Duration
 	}
 	tests := []struct {
 		name    string
@@ -37,8 +37,8 @@ func Test_buildCaseStatement(t *testing.T) {
 		{
 			name: "no policies",
 			args: args{
-				policies:     nil,
-				maxRetention: 30 * 24 * time.Hour,
+				policies:         nil,
+				defaultRetention: 30 * 24 * time.Hour,
 			},
 			want: "NOW() - INTERVAL '2592000.000000 seconds'",
 		},
@@ -53,7 +53,7 @@ func Test_buildCaseStatement(t *testing.T) {
 						Retention: "10d",
 					},
 				},
-				maxRetention: 30 * 24 * time.Hour,
+				defaultRetention: 30 * 24 * time.Hour,
 			},
 			want: "CASE WHEN data->'metadata'->'labels'->>'app' IN ('foo') THEN NOW() - INTERVAL '864000.000000 seconds' ELSE NOW() - INTERVAL '2592000.000000 seconds' END",
 		},
@@ -68,14 +68,14 @@ func Test_buildCaseStatement(t *testing.T) {
 						Retention: "10",
 					},
 				},
-				maxRetention: 30 * 24 * time.Hour,
+				defaultRetention: 30 * 24 * time.Hour,
 			},
 			want: "CASE WHEN data->'metadata'->'labels'->>'app' IN ('foo') THEN NOW() - INTERVAL '864000.000000 seconds' ELSE NOW() - INTERVAL '2592000.000000 seconds' END",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildCaseStatement(tt.args.policies, tt.args.maxRetention)
+			got, err := buildCaseStatement(tt.args.policies, tt.args.defaultRetention)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("buildCaseStatement() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This allows defining multiple retention policies based on selectors like namespace, labels, and status, providing more granular control over result retention.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Tekton Results now supports fine-grained retention policies, allowing you to set different retention periods for `PipelineRun` and top-level `TaskRun` results based on their **namespace, labels, annotations, and status**.

This provides granular control to balance storage costs with compliance and debugging needs. The first policy that a result matches is applied. If no policy matches, the result falls back to the default `maxRetention` period.

The feature is configured by adding a `policies` key to the `tekton-results-config-results-retention-policy` `ConfigMap`.
```

