### PR TITLE
Refactor annotations package and switch to Server-Side Apply

### DIFF
--- a/pkg/watcher/reconciler/annotation/annotation.go
+++ b/pkg/watcher/reconciler/annotation/annotation.go
@@ -15,42 +15,55 @@
 package annotation
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 
+	"github.com/tektoncd/results/pkg/watcher/reconciler/client"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/logging"
 )
 
 const (
+	// annotationPrefix - all annotations managed by watcher should have this prefix
+	annotationPrefix = "results.tekton.dev/"
 
 	// Result identifier.
-	Result = "results.tekton.dev/result"
+	Result = annotationPrefix + "result"
 
 	// Record identifier.
-	Record = "results.tekton.dev/record"
+	Record = annotationPrefix + "record"
 
 	// Log identifier.
-	Log = "results.tekton.dev/log"
+	Log = annotationPrefix + "log"
 
 	// EventList identifier.
-	EventList = "results.tekton.dev/eventlist"
+	EventList = annotationPrefix + "eventlist"
 
 	// Stored is an annotation that signals to the controller that a given object
 	// has been stored by the Results API.
-	Stored = "results.tekton.dev/stored"
+	Stored = annotationPrefix + "stored"
 
 	// ResultAnnotations is an annotation that integrators should add to objects in order to store
 	// arbitrary keys/values into the Result.Annotations field.
-	ResultAnnotations = "results.tekton.dev/resultAnnotations"
+	ResultAnnotations = annotationPrefix + "resultAnnotations"
 
 	// RecordSummaryAnnotations is an annotation that integrators should add to objects
 	// in order to store arbitrary keys/values into the Result.Summary.Annotations field.
 	// This allows for additional information to be associated with the summary of a record.
-	RecordSummaryAnnotations = "results.tekton.dev/recordSummaryAnnotations"
+	RecordSummaryAnnotations = annotationPrefix + "recordSummaryAnnotations"
 
 	// ChildReadyForDeletion is an annotation that signals to the controller that a given child object
 	// (e.g. TaskRun owned by a PipelineRun) is done and up to date in the
 	// API server and therefore, ready to be garbage collected.
-	ChildReadyForDeletion = "results.tekton.dev/childReadyForDeletion"
+	ChildReadyForDeletion = annotationPrefix + "childReadyForDeletion"
+
+	// FieldManager identifier to be used with Server-Side Apply patches
+	fieldManager = "tekton-results-watcher"
 )
 
 // Annotation is wrapper for Kubernetes resource annotations stored in the metadata.
@@ -59,65 +72,117 @@ type Annotation struct {
 	Value string
 }
 
-type mergePatch struct {
-	Metadata metadata `json:"metadata"`
+// Server-side apply patch structure
+type applyPatch struct {
+	APIVersion string   `json:"apiVersion"`
+	Kind       string   `json:"kind"`
+	Metadata   metadata `json:"metadata"`
 }
 
 type metadata struct {
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
 	Annotations map[string]string `json:"annotations"`
 }
 
-// Patch creates a jsonpatch path used for adding result / record identifiers as
-// well as other internal annotations to an object's annotations field.
-func Patch(object metav1.Object, annotations ...Annotation) ([]byte, error) {
-	data := mergePatch{
+// Patch builds and applies a patch with the given annotations to the object using the provided object client.
+func Patch(
+	ctx context.Context,
+	object metav1.Object,
+	objectClient client.ObjectClient,
+	annotations ...Annotation,
+) error {
+
+	logger := logging.FromContext(ctx)
+
+	// Get the API version and kind from the object
+	var apiVersion, kind string
+	if runtimeObj, ok := object.(runtime.Object); ok {
+		if gvk := runtimeObj.GetObjectKind().GroupVersionKind(); !gvk.Empty() {
+			kind = gvk.Kind
+			apiVersion = gvk.GroupVersion().String()
+		}
+	}
+	// If we couldn't determine the kind or apiVersion, fail
+	if kind == "" || apiVersion == "" {
+		logger.Errorf("could not determine apiVersion and kind from object %s/%s", object.GetNamespace(), object.GetName())
+		return fmt.Errorf("could not determine apiVersion and kind from object %s/%s", object.GetNamespace(), object.GetName())
+	}
+
+	if IsPatched(object, annotations...) {
+		logger.Debugf("Skipping CRD annotation patch: annotations are already set ObjectName: %s", object.GetName())
+		return nil
+	}
+
+	data := applyPatch{
+		APIVersion: apiVersion,
+		Kind:       kind,
 		Metadata: metadata{
+			Name:        object.GetName(),
+			Namespace:   object.GetNamespace(),
 			Annotations: map[string]string{},
 		},
 	}
 
+	// Copy existing managed annotations from the object
+	// Only include annotations that we manage (results.tekton.dev/* annotations)
+	// to avoid conflicts with other controllers using server-side apply
+	currentAnnotations := object.GetAnnotations()
+	for key, value := range currentAnnotations {
+		if strings.HasPrefix(key, annotationPrefix) {
+			data.Metadata.Annotations[key] = value
+		}
+	}
+
+	// Add/overwrite with new annotations
 	for _, annotation := range annotations {
 		if len(annotation.Value) != 0 {
 			data.Metadata.Annotations[annotation.Name] = annotation.Value
 		}
 	}
-
-	if isChildAndDone(object) {
-		data.Metadata.Annotations[ChildReadyForDeletion] = "true"
-	}
-	return json.Marshal(data)
-}
-
-// isChildAndDone returns true if the object in question is a child resource
-// (i.e. has owner references) and it's done, therefore eligible to be patched
-// with the results.tekton.dev/childReadyForDeletion annotation.
-func isChildAndDone(objecct metav1.Object) bool {
-	if len(objecct.GetOwnerReferences()) == 0 {
-		return false
+	patch, err := json.Marshal(data)
+	if err != nil {
+		return err
 	}
 
-	doneObj, ok := objecct.(interface{ IsDone() bool })
-	if !ok {
-		return false
+	force := false
+	patchOptions := metav1.PatchOptions{
+		FieldManager: fieldManager,
+		Force:        &force,
 	}
-	return doneObj.IsDone()
+	err = objectClient.Patch(ctx, object.GetName(), types.ApplyPatchType, patch, patchOptions)
+	if apierrors.IsConflict(err) {
+		// Since we only update the list of annotations we manage, there shouldn't be any conflicts unless
+		// another controller/client is updating our annotations. We log the issue and force patch.
+		// TODO: We can expose the error as a metric
+		logger.Warnf("failed to patch object %s with annotations %v due to Server-Side Apply patch conflict, using force patch.", object.GetName(), data.Metadata.Annotations)
+		force = true
+		err = objectClient.Patch(ctx, object.GetName(), types.ApplyPatchType, patch, patchOptions)
+	}
+
+	// After successful patch, update in-memory object
+	if err == nil {
+		currentAnnotations := object.GetAnnotations()
+		if currentAnnotations == nil {
+			currentAnnotations = make(map[string]string)
+		}
+		for _, ann := range annotations {
+			currentAnnotations[ann.Name] = ann.Value
+		}
+		object.SetAnnotations(currentAnnotations)
+	}
+
+	return err
 }
 
 // IsPatched returns true if the object in question contains all relevant
 // annotations or false otherwise.
 func IsPatched(object metav1.Object, annotations ...Annotation) bool {
 	objAnnotations := object.GetAnnotations()
-	if isChildAndDone(object) {
-		if _, found := objAnnotations[ChildReadyForDeletion]; !found {
-			return false
-		}
-	}
-
 	for _, annotation := range annotations {
 		if objAnnotations[annotation.Name] != annotation.Value {
 			return false
 		}
 	}
-
 	return true
 }

--- a/pkg/watcher/reconciler/annotation/annotation_test.go
+++ b/pkg/watcher/reconciler/annotation/annotation_test.go
@@ -15,15 +15,47 @@
 package annotation
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+// Mock client for testing
+type mockObjectClient struct {
+	patchCalled     bool
+	lastPatch       []byte
+	lastOptions     metav1.PatchOptions
+	returnError     error
+	patchCallCount  int
+	conflictOnFirst bool // If true, return conflict error on first call
+}
+
+func (m *mockObjectClient) Delete(_ context.Context, _ string, _ metav1.DeleteOptions) error {
+	return nil
+}
+
+func (m *mockObjectClient) Patch(_ context.Context, _ string, _ types.PatchType, data []byte, opts metav1.PatchOptions, _ ...string) error {
+	m.patchCalled = true
+	m.lastPatch = data
+	m.lastOptions = opts
+	m.patchCallCount++
+
+	// Simulate conflict on first call if configured
+	if m.conflictOnFirst && m.patchCallCount == 1 {
+		return apierrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
+	}
+
+	// Return the configured error (if any) on subsequent calls
+	return m.returnError
+}
 
 func TestPatch(t *testing.T) {
 	const (
@@ -31,41 +63,44 @@ func TestPatch(t *testing.T) {
 		fakeRecordID = "foo/results/bar/records/baz"
 	)
 
-	annotations := []Annotation{{
-		Name:  Result,
-		Value: fakeResultID,
-	},
-		{
-			Name:  Record,
-			Value: fakeRecordID,
-		},
+	annotations := []Annotation{
+		{Name: Result, Value: fakeResultID},
+		{Name: Record, Value: fakeRecordID},
 	}
 
 	tests := []struct {
-		name string
-		in   func() metav1.Object
-		want mergePatch
-	}{{
-		name: "create a patch containing only the result and record identifiers since the object is a PipelineRun",
-		in: func() metav1.Object {
-			return &pipelinev1.PipelineRun{}
-		},
-		want: mergePatch{
-			Metadata: metadata{
-				Annotations: map[string]string{
-					Result: fakeResultID,
-					Record: fakeRecordID,
-				},
-			},
-		},
-	},
+		name        string
+		object      metav1.Object
+		annotations []Annotation
+		clientError error
+		wantError   bool
+		wantPatched bool
+		wantPatch   applyPatch
+	}{
 		{
-			name: "create a patch containing only the result and record identifiers since the TaskRun isn't owned by a PipelineRun",
-			in: func() metav1.Object {
-				return &pipelinev1.TaskRun{}
-			},
-			want: mergePatch{
+			name: "successful patch for PipelineRun",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pr",
+						Namespace: "test-ns",
+					},
+				}
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: annotations,
+			wantPatched: true,
+			wantPatch: applyPatch{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "PipelineRun",
 				Metadata: metadata{
+					Name:      "test-pr",
+					Namespace: "test-ns",
 					Annotations: map[string]string{
 						Result: fakeResultID,
 						Record: fakeRecordID,
@@ -74,19 +109,29 @@ func TestPatch(t *testing.T) {
 			},
 		},
 		{
-			name: "create a patch containing only the result and record identifiers since the TaskRun isn't done yet",
-			in: func() metav1.Object {
-				return &pipelinev1.TaskRun{
+			name: "successful patch for TaskRun",
+			object: func() metav1.Object {
+				tr := &pipelinev1.TaskRun{
 					ObjectMeta: metav1.ObjectMeta{
-						OwnerReferences: []metav1.OwnerReference{{
-							UID: types.UID("UID"),
-						},
-						},
+						Name:      "test-tr",
+						Namespace: "test-ns",
 					},
 				}
-			},
-			want: mergePatch{
+				tr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "TaskRun",
+				})
+				return tr
+			}(),
+			annotations: annotations,
+			wantPatched: true,
+			wantPatch: applyPatch{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "TaskRun",
 				Metadata: metadata{
+					Name:      "test-tr",
+					Namespace: "test-ns",
 					Annotations: map[string]string{
 						Result: fakeResultID,
 						Record: fakeRecordID,
@@ -95,49 +140,380 @@ func TestPatch(t *testing.T) {
 			},
 		},
 		{
-			name: "mark the TaskRun as ready for deletion since it's owned by a PipelineRun and is done",
-			in: func() metav1.Object {
-				taskRun := &pipelinev1.TaskRun{
+			name: "preserve existing managed annotations only",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
-						OwnerReferences: []metav1.OwnerReference{{
-							UID: types.UID("UID"),
-						},
+						Name:      "test-pr",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							"existing.annotation":       "existing-value", // Not managed by us
+							"another.annotation":        "another-value",  // Not managed by us
+							"results.tekton.dev/log":    "existing-log",   // Managed by us - should be preserved
+							"results.tekton.dev/stored": "false",          // Managed by us - should be preserved
 						},
 					},
 				}
-				taskRun.Status.MarkResourceFailed(pipelinev1.TaskRunReasonFailed, errors.New("Failed"))
-				return taskRun
-			},
-			want: mergePatch{
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: annotations,
+			wantPatched: true,
+			wantPatch: applyPatch{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "PipelineRun",
 				Metadata: metadata{
+					Name:      "test-pr",
+					Namespace: "test-ns",
 					Annotations: map[string]string{
-						Result:                fakeResultID,
-						Record:                fakeRecordID,
-						ChildReadyForDeletion: "true",
+						// Only our managed annotations should be included
+						"results.tekton.dev/log":    "existing-log", // Preserved existing managed annotation
+						"results.tekton.dev/stored": "false",        // Preserved existing managed annotation
+						Result:                      fakeResultID,   // New annotation
+						Record:                      fakeRecordID,   // New annotation
+					},
+				},
+			},
+		},
+		{
+			name: "skip patching when already patched",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pr",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							Result: fakeResultID,
+							Record: fakeRecordID,
+						},
+					},
+				}
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: annotations,
+			wantPatched: false, // Should skip patching
+		},
+		{
+			name: "error when GVK is empty",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+				},
+			},
+			annotations: annotations,
+			wantError:   true,
+			wantPatched: false,
+		},
+		{
+			name: "error from client",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pr",
+						Namespace: "test-ns",
+					},
+				}
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: annotations,
+			clientError: errors.New("patch failed"),
+			wantError:   true,
+			wantPatched: true, // Patch should be attempted
+		},
+		{
+			name: "skip empty annotation values",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pr",
+						Namespace: "test-ns",
+					},
+				}
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: []Annotation{
+				{Name: Result, Value: fakeResultID},
+				{Name: Record, Value: ""},  // Empty value should be skipped
+				{Name: Log, Value: "test"}, // Non-empty should be included
+			},
+			wantPatched: true,
+			wantPatch: applyPatch{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "PipelineRun",
+				Metadata: metadata{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						Log:    "test",
+						// Record should not be present due to empty value
+					},
+				},
+			},
+		},
+		{
+			name: "conflict handling - successful retry with force",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pr",
+						Namespace: "test-ns",
+					},
+				}
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: annotations,
+			wantPatched: true,
+			wantPatch: applyPatch{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "PipelineRun",
+				Metadata: metadata{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						Record: fakeRecordID,
+					},
+				},
+			},
+		},
+		{
+			name: "only managed annotations included in patch",
+			object: func() metav1.Object {
+				pr := &pipelinev1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pr",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							"other.example.com/annotation":  "should-be-excluded",
+							"results.tekton.dev/existing":   "should-be-included",
+							"kubernetes.io/some-annotation": "should-be-excluded",
+							"results.tekton.dev/another":    "should-be-included",
+						},
+					},
+				}
+				pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "tekton.dev",
+					Version: "v1",
+					Kind:    "PipelineRun",
+				})
+				return pr
+			}(),
+			annotations: annotations,
+			wantPatched: true,
+			wantPatch: applyPatch{
+				APIVersion: "tekton.dev/v1",
+				Kind:       "PipelineRun",
+				Metadata: metadata{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						// Only results.tekton.dev/* annotations should be included
+						"results.tekton.dev/existing": "should-be-included",
+						"results.tekton.dev/another":  "should-be-included",
+						Result:                        fakeResultID,
+						Record:                        fakeRecordID,
 					},
 				},
 			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			object := test.in()
-			patch, err := Patch(object, annotations...)
-			if err != nil {
-				t.Fatal(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockObjectClient{returnError: tt.clientError}
+
+			// Special handling for conflict test case
+			if tt.name == "conflict handling - successful retry with force" {
+				client.conflictOnFirst = true
 			}
 
-			var got mergePatch
-			if err := json.Unmarshal(patch, &got); err != nil {
-				t.Fatal(err)
+			ctx := context.Background()
+
+			err := Patch(ctx, tt.object, client, tt.annotations...)
+
+			// Check error expectations
+			if tt.wantError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("Mismatch (-want +got):\n%s", diff)
+			// Check if patch was called
+			if tt.wantPatched != client.patchCalled {
+				t.Errorf("expected patch called: %v, got: %v", tt.wantPatched, client.patchCalled)
+			}
+
+			// Special handling for conflict test case
+			if tt.name == "conflict handling - successful retry with force" && err == nil {
+				if client.patchCallCount != 2 {
+					t.Errorf("expected 2 patch calls for conflict retry, got %d", client.patchCallCount)
+				}
+				if client.lastOptions.Force == nil || !*client.lastOptions.Force {
+					t.Errorf("expected Force=true on retry, got %v", client.lastOptions.Force)
+				}
+			}
+
+			// If patch was expected and called, verify the patch content
+			if tt.wantPatched && client.patchCalled && err == nil {
+				var actualPatch applyPatch
+				if err := json.Unmarshal(client.lastPatch, &actualPatch); err != nil {
+					t.Fatalf("failed to unmarshal patch: %v", err)
+				}
+
+				if diff := cmp.Diff(tt.wantPatch, actualPatch); diff != "" {
+					t.Errorf("patch mismatch (-want +got):\n%s", diff)
+				}
+
+				// Verify patch options (skip force check for conflict test)
+				if client.lastOptions.FieldManager != fieldManager {
+					t.Errorf("expected field manager %q, got %q", fieldManager, client.lastOptions.FieldManager)
+				}
+				if tt.name != "conflict handling - successful retry with force" {
+					if client.lastOptions.Force == nil || *client.lastOptions.Force {
+						t.Errorf("expected Force=false initially, got %v", client.lastOptions.Force)
+					}
+				}
+
+				// Verify in-memory object was updated
+				objAnnotations := tt.object.GetAnnotations()
+				for _, ann := range tt.annotations {
+					if ann.Value != "" && objAnnotations[ann.Name] != ann.Value {
+						t.Errorf("annotation %s not updated in object, expected %q, got %q",
+							ann.Name, ann.Value, objAnnotations[ann.Name])
+					}
+				}
 			}
 		})
 	}
+}
+
+func TestPatchConflictHandling(t *testing.T) {
+	const (
+		fakeResultID = "foo/results/bar"
+		fakeRecordID = "foo/results/bar/records/baz"
+	)
+
+	annotations := []Annotation{
+		{Name: Result, Value: fakeResultID},
+		{Name: Record, Value: fakeRecordID},
+	}
+
+	pr := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+		},
+	}
+	pr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "tekton.dev",
+		Version: "v1",
+		Kind:    "PipelineRun",
+	})
+
+	t.Run("successful retry after conflict", func(t *testing.T) {
+		// Create a fresh object for this test
+		testPr := &pipelinev1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pr-conflict",
+				Namespace: "test-ns",
+			},
+		}
+		testPr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "tekton.dev",
+			Version: "v1",
+			Kind:    "PipelineRun",
+		})
+
+		client := &mockObjectClient{conflictOnFirst: true}
+		ctx := context.Background()
+
+		err := Patch(ctx, testPr, client, annotations...)
+
+		// Should succeed after retry
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// Should have been called twice (once with conflict, once with force)
+		if client.patchCallCount != 2 {
+			t.Errorf("expected 2 patch calls, got %d", client.patchCallCount)
+		}
+
+		// Final call should have Force=true
+		if client.lastOptions.Force == nil || !*client.lastOptions.Force {
+			t.Errorf("expected Force=true on retry, got %v", client.lastOptions.Force)
+		}
+
+		// Verify in-memory object was updated
+		objAnnotations := testPr.GetAnnotations()
+		for _, ann := range annotations {
+			if objAnnotations[ann.Name] != ann.Value {
+				t.Errorf("annotation %s not updated in object, expected %q, got %q",
+					ann.Name, ann.Value, objAnnotations[ann.Name])
+			}
+		}
+	})
+
+	t.Run("persistent error after conflict retry", func(t *testing.T) {
+		// Create a fresh object for this test
+		testPr := &pipelinev1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pr-error",
+				Namespace: "test-ns",
+			},
+		}
+		testPr.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "tekton.dev",
+			Version: "v1",
+			Kind:    "PipelineRun",
+		})
+
+		permanentError := errors.New("persistent error")
+		client := &mockObjectClient{
+			conflictOnFirst: true,
+			returnError:     permanentError, // This will be returned on the retry
+		}
+		ctx := context.Background()
+
+		err := Patch(ctx, testPr, client, annotations...)
+
+		// Should fail with the permanent error
+		if err != permanentError {
+			t.Errorf("expected permanent error, got %v", err)
+		}
+
+		// Should have been called twice
+		if client.patchCallCount != 2 {
+			t.Errorf("expected 2 patch calls, got %d", client.patchCallCount)
+		}
+	})
 }
 
 func TestIsPatched(t *testing.T) {
@@ -146,103 +522,109 @@ func TestIsPatched(t *testing.T) {
 		fakeRecordID = "foo/results/bar/records/baz"
 	)
 
-	annotations := []Annotation{{
-		Name:  Result,
-		Value: fakeResultID,
-	},
-		{
-			Name:  Record,
-			Value: fakeRecordID,
-		},
+	annotations := []Annotation{
+		{Name: Result, Value: fakeResultID},
+		{Name: Record, Value: fakeRecordID},
 	}
 
 	tests := []struct {
-		name string
-		in   func() metav1.Object
-		want bool
-	}{{
-		name: "result and record identifiers are missing in the PipelineRun",
-		in: func() metav1.Object {
-			return &pipelinev1.PipelineRun{}
-		},
-		want: false,
-	},
+		name        string
+		object      metav1.Object
+		annotations []Annotation
+		want        bool
+	}{
 		{
-			name: "the record identifier is missing in the PipelineRun",
-			in: func() metav1.Object {
-				return &pipelinev1.PipelineRun{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							Result: fakeResultID,
-						},
-					},
-				}
+			name: "no annotations present",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{},
 			},
-			want: false,
+			annotations: annotations,
+			want:        false,
 		},
 		{
-			name: "the PipelineRun contains all relevant annotations",
-			in: func() metav1.Object {
-				return &pipelinev1.PipelineRun{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							Result: fakeResultID,
-							Record: fakeRecordID,
-						},
+			name: "partial annotations present",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						// Record is missing
 					},
-				}
+				},
 			},
-			want: true,
+			annotations: annotations,
+			want:        false,
 		},
 		{
-			name: "the TaskRun contains all relevant annotations",
-			in: func() metav1.Object {
-				taskRun := &pipelinev1.TaskRun{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							Result:                fakeResultID,
-							Record:                fakeRecordID,
-							ChildReadyForDeletion: "true",
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							UID: types.UID("UID"),
-						},
-						},
+			name: "all annotations present",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						Record: fakeRecordID,
 					},
-				}
-				taskRun.Status.MarkResourceFailed(pipelinev1.TaskRunReasonFailed, errors.New("Failed"))
-				return taskRun
+				},
 			},
-			want: true,
+			annotations: annotations,
+			want:        true,
 		},
 		{
-			name: "the TaskRun should be marked as ready to be deleted",
-			in: func() metav1.Object {
-				taskRun := &pipelinev1.TaskRun{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							Result: fakeResultID,
-							Record: fakeRecordID,
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							UID: types.UID("UID"),
-						},
-						},
+			name: "all annotations present with extras",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						Result:               fakeResultID,
+						Record:               fakeRecordID,
+						"extra.annotation":   "extra-value",
+						"another.annotation": "another-value",
 					},
-				}
-				taskRun.Status.MarkResourceFailed(pipelinev1.TaskRunReasonFailed, errors.New("Failed"))
-				return taskRun
+				},
 			},
-			want: false,
+			annotations: annotations,
+			want:        true,
+		},
+		{
+			name: "annotation value mismatch",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						Result: "wrong-value",
+						Record: fakeRecordID,
+					},
+				},
+			},
+			annotations: annotations,
+			want:        false,
+		},
+		{
+			name: "nil annotations map",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			annotations: annotations,
+			want:        false,
+		},
+		{
+			name: "empty annotations list",
+			object: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						Result: fakeResultID,
+						Record: fakeRecordID,
+					},
+				},
+			},
+			annotations: []Annotation{}, // Empty list
+			want:        true,           // Should return true for empty list
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			object := test.in()
-			got := IsPatched(object, annotations...)
-			if test.want != got {
-				t.Errorf("Want %t, but got %t", test.want, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsPatched(tt.object, tt.annotations...)
+			if got != tt.want {
+				t.Errorf("IsPatched() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/watcher/reconciler/client/client.go
+++ b/pkg/watcher/reconciler/client/client.go
@@ -1,4 +1,19 @@
-package dynamic
+// Copyright 2024 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client provides utilities for interacting with watcher reconciler clients.
+package client
 
 import (
 	"context"
@@ -27,7 +42,7 @@ func (c *TaskRunClient) Patch(ctx context.Context, name string, pt types.PatchTy
 	return err
 }
 
-// PipelineRunClient implements the dynamic ObjectClient for TaskRuns.
+// PipelineRunClient implements the dynamic ObjectClient for PipelineRuns.
 type PipelineRunClient struct {
 	pipelinev1.PipelineRunInterface
 }

--- a/pkg/watcher/reconciler/dynamic/dynamic_test.go
+++ b/pkg/watcher/reconciler/dynamic/dynamic_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tektoncd/results/pkg/internal/test"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
+	"github.com/tektoncd/results/pkg/watcher/reconciler/client"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -131,7 +132,7 @@ func TestReconcile_TaskRun(t *testing.T) {
 	fakeclock := clockwork.NewFakeClockAt(time.Now())
 	clock = fakeclock
 
-	trclient := &TaskRunClient{TaskRunInterface: pipelineclient.Get(ctx).TektonV1().TaskRuns(taskrun.GetNamespace())}
+	trclient := &client.TaskRunClient{TaskRunInterface: pipelineclient.Get(ctx).TektonV1().TaskRuns(taskrun.GetNamespace())}
 	if _, err := trclient.Create(ctx, taskrun, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +441,7 @@ func TestReconcile_PipelineRun(t *testing.T) {
 	fakeclock := clockwork.NewFakeClockAt(time.Now())
 	clock = fakeclock
 
-	prclient := &PipelineRunClient{PipelineRunInterface: pipelineclient.Get(ctx).TektonV1().PipelineRuns(pipelinerun.GetNamespace())}
+	prclient := &client.PipelineRunClient{PipelineRunInterface: pipelineclient.Get(ctx).TektonV1().PipelineRuns(pipelinerun.GetNamespace())}
 	if _, err := prclient.Create(ctx, pipelinerun, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -27,8 +27,8 @@ import (
 	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
 	pipelinev1listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
-
 	resultsannotation "github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
+	"github.com/tektoncd/results/pkg/watcher/reconciler/client"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/dynamic"
 	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
@@ -80,7 +80,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *pipelinev1.PipelineR
 		}
 	}
 
-	pipelineRunClient := &dynamic.PipelineRunClient{
+	pipelineRunClient := &client.PipelineRunClient{
 		PipelineRunInterface: r.pipelineClient.TektonV1().PipelineRuns(pr.Namespace),
 	}
 

--- a/pkg/watcher/reconciler/taskrun/reconciler.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	resultsannotation "github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
+	"github.com/tektoncd/results/pkg/watcher/reconciler/client"
 	"github.com/tektoncd/results/pkg/watcher/reconciler/dynamic"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
@@ -61,7 +62,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *pipelinev1.TaskRun) 
 		}
 	}
 
-	taskRunClient := &dynamic.TaskRunClient{
+	taskRunClient := &client.TaskRunClient{
 		TaskRunInterface: r.pipelineClient.TektonV1().TaskRuns(tr.Namespace),
 	}
 


### PR DESCRIPTION
Removed business logic from the annotation package. Now it only provides functionality to manage annotations, but no logic when to set them. Consolidated check (if to apply), generation and actual object update. Before that change, the caller had to check if the patch is needed, call the generation of the patch and apply the patch. Now it's a single call to the Patch function.
Switched to Server-Side Apply patches from Merge patches, which provide a more robust way to update k8s objects.
Switched clients.go to a separate package to avoid cyclic imports.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind design
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
NONE
```

