### PR TITLE
[CLI] feat: implement namespace-independent config storage for CLI

### DIFF
--- a/docs/cli/tkn-results_config_set.md
+++ b/docs/cli/tkn-results_config_set.md
@@ -6,6 +6,12 @@ Set Tekton Results CLI configuration values
 
 Configure how the CLI connects to the Tekton Results API server.
 
+Configuration Storage:
+The configuration is stored in a namespace-independent way in your kubeconfig file.
+This means the configuration persists across namespace switches (e.g., 'kubectl config 
+set-context --current --namespace=production' or 'oc project production').
+You only need to configure once per cluster/user combination.
+
 Usage Modes:
 1. Interactive: Prompts for values with defaults where available
    `tkn-results config set`

--- a/docs/man/man1/tkn-results-config-set.1
+++ b/docs/man/man1/tkn-results-config-set.1
@@ -13,6 +13,13 @@ tkn-results-config-set - Set Tekton Results CLI configuration values
 Configure how the CLI connects to the Tekton Results API server.
 
 .PP
+Configuration Storage:
+The configuration is stored in a namespace-independent way in your kubeconfig file.
+This means the configuration persists across namespace switches (e.g., 'kubectl config
+set-context --current --namespace=production' or 'oc project production').
+You only need to configure once per cluster/user combination.
+
+.PP
 Usage Modes:
 1. Interactive: Prompts for values with defaults where available
    \fBtkn-results config set\fR

--- a/pkg/cli/cmd/config/reset_test.go
+++ b/pkg/cli/cmd/config/reset_test.go
@@ -65,7 +65,7 @@ func TestResetCommandExecution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kubeconfigPath := testutils.CreateTestKubeconfig(t)
+			kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 			// Set up params
 			params := &common.ResultsParams{}

--- a/pkg/cli/cmd/config/set.go
+++ b/pkg/cli/cmd/config/set.go
@@ -40,6 +40,12 @@ Configure with custom kubeconfig and context:
 		Example: eg,
 		Long: `Configure how the CLI connects to the Tekton Results API server.
 
+Configuration Storage:
+The configuration is stored in a namespace-independent way in your kubeconfig file.
+This means the configuration persists across namespace switches (e.g., 'kubectl config 
+set-context --current --namespace=production' or 'oc project production').
+You only need to configure once per cluster/user combination.
+
 Usage Modes:
 1. Interactive: Prompts for values with defaults where available
    ` + "`" + `tkn-results config set` + "`" + `

--- a/pkg/cli/cmd/config/view_test.go
+++ b/pkg/cli/cmd/config/view_test.go
@@ -72,7 +72,7 @@ func TestViewCommandExecution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kubeconfigPath := testutils.CreateTestKubeconfig(t)
+			kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 			// Create test params
 			params := &common.ResultsParams{}

--- a/pkg/cli/common/utils.go
+++ b/pkg/cli/common/utils.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// BuildConfigContextInfo extracts cluster name, username, and constructs the config context name
+// from a Kubernetes context.
+//
+// Parameters:
+//   - context: The Kubernetes context object from kubeconfig
+//
+// Returns:
+//   - configContextName: The config context name in format "tekton-results-config/{cluster}/{user}".
+//   - clusterName: The cluster name from the context.
+//   - userName: The extracted username (part before "/" if present).
+//   - error: An error if the context is missing cluster/user information.
+func BuildConfigContextInfo(context *api.Context) (configContextName, clusterName, userName string, err error) {
+	if context == nil {
+		return "", "", "", errors.New("context is nil")
+	}
+
+	clusterName = context.Cluster
+	if clusterName == "" {
+		return "", "", "", errors.New("no cluster specified in context")
+	}
+
+	userName = context.AuthInfo
+	if userName == "" {
+		return "", "", "", errors.New("no user specified in context")
+	}
+
+	// Extract just the username part before "/" for config context isolation
+	// In some cases user also has cluster name in the format "user/cluster"
+	if slashIndex := strings.Index(userName, "/"); slashIndex != -1 {
+		userName = userName[:slashIndex]
+	}
+
+	// Construct the config context name (tekton-results-config context for config storage)
+	configContextName = fmt.Sprintf("tekton-results-config/%s/%s", clusterName, userName)
+	return configContextName, clusterName, userName, nil
+}

--- a/pkg/cli/config/config_test.go
+++ b/pkg/cli/config/config_test.go
@@ -17,7 +17,7 @@ import (
 
 // TestNewConfig tests the NewConfig function with various scenarios
 func TestNewConfig(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	tests := []struct {
 		name        string
@@ -148,7 +148,7 @@ func TestNewConfig(t *testing.T) {
 
 // TestSet tests the Set function
 func TestSet(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	p := &common.ResultsParams{}
 	p.SetKubeConfigPath(kubeconfigPath)
@@ -206,7 +206,7 @@ func TestSet(t *testing.T) {
 
 // TestReset tests the Reset function
 func TestReset(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	p := &common.ResultsParams{}
 	p.SetKubeConfigPath(kubeconfigPath)
@@ -282,7 +282,7 @@ func TestReset(t *testing.T) {
 
 // TestLoadClientConfig tests the LoadClientConfig function
 func TestLoadClientConfig(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	p := &common.ResultsParams{}
 	p.SetKubeConfigPath(kubeconfigPath)
@@ -331,7 +331,7 @@ func TestLoadClientConfig(t *testing.T) {
 
 // TestSetWithPrompt tests the Set function with prompt enabled
 func TestSetWithPrompt(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	// Create a mock REST config that will fail when used
 	mockConfig := &rest.Config{
@@ -385,7 +385,7 @@ func TestSetWithPrompt(t *testing.T) {
 
 // TestPersist tests the Persist function
 func TestPersist(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	p := &common.ResultsParams{}
 	p.SetKubeConfigPath(kubeconfigPath)
@@ -451,7 +451,7 @@ func TestPersist(t *testing.T) {
 
 // TestSetVersion tests the SetVersion function
 func TestSetVersion(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	p := &common.ResultsParams{}
 	p.SetKubeConfigPath(kubeconfigPath)
@@ -504,7 +504,7 @@ func TestSetVersion(t *testing.T) {
 
 // TestHost tests the Host function
 func TestHost(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	tests := []struct {
 		name        string
@@ -558,7 +558,7 @@ func TestHost(t *testing.T) {
 
 // TestToken tests the Token function
 func TestToken(t *testing.T) {
-	kubeconfigPath := testutils.CreateTestKubeconfig(t)
+	kubeconfigPath := testutils.CreateTestKubeconfig(t, "")
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change ensures configuration persists across namespace operations, eliminating the need to reconfigure after switching namespaces.

- Store CLI configuration in dedicated default namespace context to prevent loss during namespace switches (kubectl/oc project commands)
- Use tekton-results-config/{cluster}/{user} context naming
- Update unit test to include the behaviour changes
- Update documentation to clarify one-time configuration per cluster/user

Fixes: Configuration loss when using 'oc project' or 'kubectl config set-context --namespace'

/kind feature

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[CLI] feat: Configuration now persists across namespace switches - no need to run 'tkn-results config set' again after switching namespaces
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
