### PR TITLE
Fix watcher CreateResult race condition

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -48,6 +48,7 @@ import (
 	_ "net/http/pprof"
 
 	serverdb "github.com/tektoncd/results/pkg/api/server/db"
+	_ "github.com/tektoncd/results/pkg/api/server/db/errors/postgres"
 
 	"github.com/golang-jwt/jwt/v4"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"

--- a/cmd/retention-policy-agent/main.go
+++ b/cmd/retention-policy-agent/main.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/tektoncd/results/pkg/api/server/config"
+	_ "github.com/tektoncd/results/pkg/api/server/db/errors/postgres"
 	"github.com/tektoncd/results/pkg/api/server/logger"
 	"github.com/tektoncd/results/pkg/retention"
 

--- a/pkg/api/server/db/errors/postgres/postgres.go
+++ b/pkg/api/server/db/errors/postgres/postgres.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package postgres provides postgres-specific error checking.
+package postgres
+
+import (
+	"errors"
+
+	dberrors "github.com/tektoncd/results/pkg/api/server/db/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	sqlStateUniqueViolation = "23505"
+	sqlStateForeignKey      = "23503"
+)
+
+// sqlStateError captures the subset of PgError behavior we rely on.
+type sqlStateError interface {
+	SQLState() string
+}
+
+// translate converts postgres error codes to gRPC status codes.
+func translate(err error) codes.Code {
+	var sqlErr sqlStateError
+	if errors.As(err, &sqlErr) {
+		switch sqlErr.SQLState() {
+		case sqlStateUniqueViolation:
+			return codes.AlreadyExists
+		case sqlStateForeignKey:
+			return codes.FailedPrecondition
+		}
+	}
+	return status.Code(err)
+}
+
+func init() {
+	dberrors.RegisterErrorSpace(translate)
+}

--- a/pkg/api/server/db/errors/postgres/postgres_test.go
+++ b/pkg/api/server/db/errors/postgres/postgres_test.go
@@ -1,0 +1,45 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgconn"
+	pgxpgconn "github.com/jackc/pgx/v5/pgconn"
+	"google.golang.org/grpc/codes"
+)
+
+func TestTranslate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{
+			name: "github.com/jackc/pgconn",
+			err:  &pgconn.PgError{Code: sqlStateUniqueViolation},
+			want: codes.AlreadyExists,
+		},
+		{
+			name: "github.com/jackc/pgx/v5/pgconn",
+			err:  &pgxpgconn.PgError{Code: sqlStateForeignKey},
+			want: codes.FailedPrecondition,
+		},
+		{
+			name: "unknown error",
+			err:  errors.New("boom"),
+			want: codes.Unknown,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := translate(tc.err); got != tc.want {
+				t.Fatalf("translate() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/postgres-migrate/main.go
+++ b/tools/postgres-migrate/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgconn"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/results/pkg/api/server/db"
+	_ "github.com/tektoncd/results/pkg/api/server/db/errors/postgres"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"


### PR DESCRIPTION
Handle better the SQLSTATE duplicate key value violates unique constraint issue, indicating a record was already created. This happens when PipelineRun and TaskRun handlers compete for creating the same record. When creating the record fails with such error, we re-fetch it. We also map the SQL error to gRPC error which fixes rpc error: code = Unknown.

Assisted-by: codex-cli

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind bug
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
NONE
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
