### PR TITLE
Replace deprecated apimachinery wait.PollImmediate

### DIFF
--- a/test/e2e/e2e_gcs_test.go
+++ b/test/e2e/e2e_gcs_test.go
@@ -69,7 +69,7 @@ func TestGCSLog(t *testing.T) {
 
 	t.Run("check log annotation", func(t *testing.T) {
 		// Wait for Result ID to show up.
-		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			pr, err := tc.PipelineRuns(defaultNamespace).Get(ctx, pr.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting PipelineRun: %v", err)
@@ -103,8 +103,8 @@ func TestGCSLog(t *testing.T) {
 		if logName == "" {
 			t.Skip("log name not found")
 		}
-		if err := wait.PollImmediate(1*time.Second, 10*time.Second, func() (done bool, err error) {
-			logClient, err := gc.GetLog(context.Background(), &resultsv1alpha2.GetLogRequest{Name: logName})
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			logClient, err := gc.GetLog(ctx, &resultsv1alpha2.GetLogRequest{Name: logName})
 			if err != nil {
 				t.Logf("Error getting Log Client: %v", err)
 				return false, nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -143,7 +143,7 @@ func TestTaskRun(t *testing.T) {
 
 	// Wait for Result ID to show up.
 	t.Run("check annotations", func(t *testing.T) {
-		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) { //nolint:staticcheck
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			tr, err := tc.TaskRuns(defaultNamespace).Get(ctx, tr.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting TaskRun: %v", err)
@@ -162,7 +162,7 @@ func TestTaskRun(t *testing.T) {
 	})
 
 	t.Run("check deletion", func(t *testing.T) {
-		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) { //nolint:staticcheck
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			_, err = tc.TaskRuns(defaultNamespace).Get(ctx, tr.GetName(), metav1.GetOptions{})
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
@@ -234,7 +234,7 @@ func TestPipelineRun(t *testing.T) {
 
 	t.Run("check annotations", func(t *testing.T) {
 		// Wait for Result ID to show up.
-		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) { //nolint:staticcheck
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			pr, err := tc.PipelineRuns(defaultNamespace).Get(ctx, pr.GetName(), metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Error getting PipelineRun: %v", err)
@@ -253,7 +253,7 @@ func TestPipelineRun(t *testing.T) {
 	})
 
 	t.Run("check deletion", func(t *testing.T) {
-		if err := wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) { //nolint:staticcheck
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 1*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			_, err = tc.PipelineRuns(defaultNamespace).Get(ctx, pr.GetName(), metav1.GetOptions{})
 			if err != nil {
 				if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
This replaces the deprecated PollImmediate method with PollUntilContextTimeout.
From the ducumentation:
Deprecated: This method does not return errors from context, use PollUntilContextTimeout. Will be removed in a future release.
Furthermore we optimize the connection healthcheck. gorm.Open() tries to ping the DB instance, but that ping does not respect the context timeout and can hang for much longer. Instead we disable that default behavior and call sqlConn.PingContext() where the context timeout is respected.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind misc
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
NONE
```

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
