### PR TITLE
fix: prioritize maxRetention over defaultRetention for backward compatibility

### DIFF
--- a/docs/retention-policy-agent/README.md
+++ b/docs/retention-policy-agent/README.md
@@ -19,8 +19,18 @@ The following fields are supported:
 
 - `runAt`: Determines when to run the pruning job for the DB. It uses a cron schedule format. The default is `"7 7 * * 7"` (every Sunday at 7:07 AM).
 - `defaultRetention`: The **fallback** retention period for how long to keep Results and Records when no specific policy matches. This value does **not** override the retention period of a matching policy; it only applies when no policies match a given Result. This can be a number (e.g., `30`), which is interpreted as days, or a duration string (e.g., `30d`, `24h`). The default is `30d`.
-> **Note:**
-> `maxRetention` is deprecated and will be removed in a future release. If `defaultRetention` is not set, `maxRetention` will be used as the default retention period for backward compatibility.
+
+> **⚠️ IMPORTANT - Migration from `maxRetention` to `defaultRetention`. DATA LOSS RISK**
+> 
+> `maxRetention` is **deprecated** and will be removed in a future release. Please migrate to `defaultRetention` as soon as possible. If a user has `maxRetention` set higher than 30 days and does not migrate to `defaultRetention`, when `maxRetention` is removed the `defaultRetention` records older than the default `defaultRetention` may be deleted.
+> 
+> To migrate: modify the `tekton-results-config-results-retention-policy` ConfigMap to rename `data.maxRetention` to `data.defaultRetention`.
+> 
+> **Backward Compatibility Behavior:**
+> - If both `maxRetention` and `defaultRetention` are present, `maxRetention` takes priority to maintain backward compatibility.
+> - If only `maxRetention` is set, it will be used (with a deprecation warning in logs).
+> - If only `defaultRetention` is set, it will be used (recommended).
+
 - `policies`: A list of fine-grained retention policies that allow for more specific control over data retention.
 
 ### Fine-Grained Retention Policies
@@ -86,3 +96,7 @@ In this example:
 3.  Any other Result in the `production` or `prod-east` namespace will be kept for **60 days**.
 4.  Any Result in the `ci` namespace will be kept for **7 days**.
 5.  All other Results that do not match any of these policies will be kept for the default `defaultRetention` period of **30 days**.
+
+## Migrating from `maxRetention` to `defaultRetention`
+
+In the `tekton-results-config-results-retention-policy` ConfigMap, rename `data.maxRetention` to `data.defaultRetention`.

--- a/pkg/apis/config/retention.go
+++ b/pkg/apis/config/retention.go
@@ -145,17 +145,17 @@ func newRetentionPolicyFromMap(cfgMap map[string]string) (*RetentionPolicy, erro
 		rp.RunAt = schedule
 	}
 
-	if duration, ok := cfgMap[defaultRetention]; ok {
-		v, err := ParseDuration(duration)
-		if err != nil {
-			return nil, fmt.Errorf("incorrect configuration for defaultRetention: %w", err)
-		}
-		rp.DefaultRetention = v
-	} else if duration, ok := cfgMap[maxRetention]; ok {
-		log.Println("WARNING: configuration key 'maxRetention' is deprecated; please use 'defaultRetention' instead.")
+	if duration, ok := cfgMap[maxRetention]; ok {
+		log.Println("WARNING: configuration key 'maxRetention' is deprecated and will be removed in a future release. See migration guide: https://github.com/tektoncd/results/blob/main/docs/retention-policy-agent/README.md#migrating-from-maxretention-to-defaultretention")
 		v, err := ParseDuration(duration)
 		if err != nil {
 			return nil, fmt.Errorf("incorrect configuration for maxRetention: %w", err)
+		}
+		rp.DefaultRetention = v
+	} else if duration, ok := cfgMap[defaultRetention]; ok {
+		v, err := ParseDuration(duration)
+		if err != nil {
+			return nil, fmt.Errorf("incorrect configuration for defaultRetention: %w", err)
 		}
 		rp.DefaultRetention = v
 	}

--- a/pkg/apis/config/retention_test.go
+++ b/pkg/apis/config/retention_test.go
@@ -63,6 +63,19 @@ func TestNewRetentionPolicyFromConfigMap(t *testing.T) {
 			},
 		},
 		{
+			name: "maxRetention overrides defaultRetention for backward compatibility",
+			args: args{config: &corev1.ConfigMap{
+				Data: map[string]string{
+					"defaultRetention": "30",
+					"maxRetention":     "15",
+				},
+			}},
+			want: &RetentionPolicy{
+				RunAt:            DefaultRunAt,
+				DefaultRetention: 15 * 24 * time.Hour,
+			},
+		},
+		{
 			name: "with policies",
 			args: args{config: &corev1.ConfigMap{
 				Data: map[string]string{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The shipped ConfigMap includes a default `defaultRetention: "30"` value. When users had an existing `maxRetention` setting, both values are seen to be present in the ConfigMap. The configuration parsing logic checked `defaultRetention` first, and since it was always present (from the shipped default), it would always be used, completely ignoring the user's `maxRetention` setting.

This impacted:
- Users with existing `maxRetention: "40"` would always get 30-day retention (from the shipped `defaultRetention` default) instead of their configured 40 days
- The shipped `defaultRetention: "30"` always overrode user's `maxRetention` setting
- This resulted in premature data deletion for users with retention > 30 days
- Deprecation was not backward compatible

Solution:
Switch the configuration parsing priority to check `maxRetention` first, maintaining backward compatibility during the deprecation period.
<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind bug, documentation
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes
```release-note
Retention configuration parsing now checks `maxRetention` first, maintaining backward compatibility during the deprecation period.
```
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
