### PR TITLE
feature: update release cheatsheet and pipeline

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,3 @@
+---
+# The default base image, cgr.dev/chainguard/static, as used in tektoncd/pipeline
+defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -1,0 +1,276 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: publish-release-results
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
+spec:
+  params:
+    - name: package
+      description: package to release (e.g. github.com/<org>/<project>)
+      default: github.com/tektoncd/results
+    - name: images
+      description: List of cmd/* paths to be published as images
+      default: "api retention-policy-agent watcher"
+    - name: koExtraArgs
+      description: Extra args to be passed to ko
+      default: "--preserve-import-paths"
+    - name: versionTag
+      description: The version, vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly that the artifacts should be tagged with (including `v`).
+    - name: imageRegistry
+      description: The target image registry
+      default: ghcr.io
+    - name: imageRegistryPath
+      description: The path (project) in the image registry
+    - name: imageRegistryRegions
+      description: The target image registry regions
+      default: ""
+    - name: imageRegistryUser
+      description: Username to be used to login to the container registry
+      default: "_json_key"
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as Pipelines latest
+      default: "true"
+    - name: platforms
+      description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: serviceAccountPath
+      description: The name of the service account path within the release-secret workspace
+  workspaces:
+    - name: source
+      description: >-
+        The workspace where the repo has been cloned. This should ideally
+        be /go/src/$(params.package) however that is not possible today,
+        see https://github.com/tektoncd/pipeline/issues/3786. To use this
+        task on a fork of pipeline change the mountPath below
+      mountPath: /go/src/github.com/tektoncd/results
+    - name: release-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
+    - name: output
+      description: The release YAML will be written to this workspace
+  stepTemplate:
+    env:
+      - name: "PROJECT_ROOT"
+        value: "$(workspaces.source.path)"
+      - name: CONTAINER_REGISTRY_CREDENTIALS
+        value: "$(workspaces.release-secret.path)/$(params.serviceAccountPath)"
+      - name: CONTAINER_REGISTRY
+        value: "$(params.imageRegistry)/$(params.imageRegistryPath)"
+      - name: IMAGE_REGISTRY_PATH
+        value: "$(params.imageRegistryPath)"
+      - name: CONTAINER_REGISTRY_USER
+        value: "$(params.imageRegistryUser)"
+      - name: REGIONS
+        value: "$(params.imageRegistryRegions)"
+      - name: OUTPUT_RELEASE_DIR
+        value: "$(workspaces.output.path)/$(params.versionTag)"
+      - name: KO_EXTRA_ARGS
+        value: "$(params.koExtraArgs)"
+  results:
+  # IMAGES result is picked up by Tekton Chains to sign the release.
+  # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
+  - name: IMAGES
+  steps:
+
+  - name: container-registry-auth
+    image: cgr.dev/chainguard/crane:latest-dev@sha256:501999c3e3c8fe7060d6f66519ad0168cfca75c0897262033a14a901245f62e4
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Login to the container registry
+      DOCKER_CONFIG=$(cat ${CONTAINER_REGISTRY_CREDENTIALS} | \
+        crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin $(params.imageRegistry) 2>&1 | \
+        sed -n 's,^.*logged in via \(.*\)$,\1,p')
+
+      # Auth with account credentials for all regions.
+      for region in ${REGIONS}
+      do
+        HOSTNAME=${region}.$(params.imageRegistry)
+        cat ${CONTAINER_REGISTRY_CREDENTIALS} | crane auth login -u ${CONTAINER_REGISTRY_USER} --password-stdin ${HOSTNAME}
+      done
+      cp ${DOCKER_CONFIG} /workspace/docker-config.json
+
+  - name: create-ko-yaml
+    image: cgr.dev/chainguard/go:latest-dev@sha256:2f71c4d2c68eb401c9311611663d2d12a0632fb29895bbccf3c840d79a4d0f9f
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Change to directory with vendor/
+      cd ${PROJECT_ROOT}
+
+      # Copy the repository's .ko.yaml as the base configuration, or create a default if missing
+      if [ -f ${PROJECT_ROOT}/.ko.yaml ]; then
+        cp ${PROJECT_ROOT}/.ko.yaml /workspace/.ko.yaml
+      else
+        echo "---" > /workspace/.ko.yaml
+        echo "defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7" >> /workspace/.ko.yaml
+      fi
+
+      cat /workspace/.ko.yaml
+  
+  - name: run-ko
+    image: ghcr.io/tektoncd/plumbing/ko@sha256:d95b8e80ddea355c33a1598df3272214eb71f5f523df4955daf168d71fc0fcb5
+    env:
+    - name: KO_DOCKER_REPO
+      value: $(params.imageRegistry)/$(params.imageRegistryPath)
+    - name: GOFLAGS
+      value: "-mod=vendor"
+    script: |
+      #!/usr/bin/env sh
+      set -ex
+
+      # Fix Git ownership issue for the repository directory
+      git config --global --add safe.directory ${PROJECT_ROOT}
+
+      # Use the generated `.ko.yaml`
+      export KO_CONFIG_PATH=/workspace
+      cat ${KO_CONFIG_PATH}/.ko.yaml
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Change to directory with our .ko.yaml
+      cd ${PROJECT_ROOT}
+
+      # For each cmd/* directory, include a full gzipped tar of all source in
+      # vendor/. This is overkill. Some deps' licenses require the source to be
+      # included in the container image when they're used as a dependency.
+      # Rather than trying to determine which deps have this requirement (and
+      # probably get it wrong), we'll just targz up the whole vendor tree and
+      # include it. As of 9/20/2019, this amounts to about 11MB of additional
+      # data in each image.
+      TMPDIR=$(mktemp -d)
+      tar cfz ${TMPDIR}/source.tar.gz vendor/
+      for d in cmd/*; do
+        if [ -d ${d}/kodata/ ]; then
+          ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
+        fi
+      done
+
+      # Publish images and create release.yaml
+      # Results requires kustomize so that namespace is applied to all resources (including
+      # ClusterRoleBinding subjects). Without it, release YAML is invalid (subjects[].namespace required).
+      mkdir -p $OUTPUT_RELEASE_DIR
+
+      # Make a local git tag to make git status happy :)
+      git tag $(params.versionTag)
+
+      # Template version into kustomization files (same as release/release.sh)
+      sed -i "s/devel$/$(params.versionTag)/g" ${PROJECT_ROOT}/release/kustomization.yaml
+      sed -i "s/devel$/$(params.versionTag)/g" ${PROJECT_ROOT}/config/base/config-info.yaml
+
+      # Build with kustomize (adds namespace tekton-pipelines) then resolve images with ko.
+      # Use kustomize build (same as kubectl kustomize); the ko image has kustomize but not kubectl.
+      # Publish images and create release_base.yaml (with tags)
+      kustomize build ${PROJECT_ROOT}/release | ko resolve \
+        --image-label=org.opencontainers.image.source=https://$(params.package) \
+        --platform=$(params.platforms) \
+        -t $(params.versionTag) \
+        -R ${KO_EXTRA_ARGS} \
+        -f - > $OUTPUT_RELEASE_DIR/release_base.yaml
+        
+      # Publish images and create release_base.notags.yaml (without tags)
+      # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
+      # This is currently the case for `cri-o` (and most likely others)
+      kustomize build ${PROJECT_ROOT}/release | ko resolve \
+        --image-label=org.opencontainers.image.source=https://$(params.package) \
+        --platform=$(params.platforms) \
+        -R ${KO_EXTRA_ARGS} \
+        -f - > $OUTPUT_RELEASE_DIR/release_base.notags.yaml
+
+      # Assemble full release.yaml / release.notags.yaml by combining base + localdb
+      cp $OUTPUT_RELEASE_DIR/release_base.yaml $OUTPUT_RELEASE_DIR/release.yaml
+      kustomize build ${PROJECT_ROOT}/release/localdb >> $OUTPUT_RELEASE_DIR/release.yaml
+
+      cp $OUTPUT_RELEASE_DIR/release_base.notags.yaml $OUTPUT_RELEASE_DIR/release.notags.yaml
+      kustomize build ${PROJECT_ROOT}/release/localdb >> $OUTPUT_RELEASE_DIR/release.notags.yaml
+
+      # Rewrite "devel" to params.versionTag
+      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.yaml
+      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' ${OUTPUT_RELEASE_DIR}/release.notags.yaml
+
+  - name: koparse
+    image: ghcr.io/tektoncd/plumbing/koparse@sha256:71f041a28d278f6f4a37cdab5a3534e935a512e104e7f2fb280eda3971342b3c
+    script: |
+      set -ex
+
+      # Find "--preserve-import-paths" in a list of args
+      function find_preserve_import_path() {
+        for arg in $@; do
+          if [[ "$arg" == "--preserve-import-paths" ]]; then
+            return 0
+          fi
+        done
+        return 1
+      }
+
+      # If "--preserve-import-paths" is used, include "package" in the expected path
+      find_preserve_import_path \
+        $(echo $KO_EXTRA_ARGS) && \
+        PRESERVE_IMPORT_PATH="--preserve-path" || \
+        PRESERVE_IMPORT_PATH="--no-preserve-path"
+
+      for cmd in $(params.images)
+      do
+        IMAGES="${IMAGES} $(params.package)/cmd/${cmd}:$(params.versionTag)"
+      done
+
+      # Parse the built images from the release.yaml generated by ko
+      koparse \
+        --path $OUTPUT_RELEASE_DIR/release.yaml \
+        --base $(params.package) \
+        --container-registry ${CONTAINER_REGISTRY} \
+        --images ${IMAGES} \
+        ${PRESERVE_IMPORT_PATH} > /workspace/built_images
+
+  - name: tag-images
+    image: cgr.dev/chainguard/crane:latest-dev@sha256:501999c3e3c8fe7060d6f66519ad0168cfca75c0897262033a14a901245f62e4
+    script: |
+      #!/bin/sh
+      set -ex
+
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/config.json
+
+      # Tag the images and put them in all the regions
+      for IMAGE in $(cat /workspace/built_images)
+      do
+        IMAGE_WITHOUT_SHA=${IMAGE%%@*}
+        IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
+        IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
+
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
+        if [[ "$(params.releaseAsLatest)" == "true" ]]
+        then
+          crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
+        fi
+
+        for REGION in ${REGIONS}
+        do
+          if [[ "$(params.releaseAsLatest)" == "true" ]]
+          then
+            for TAG in "latest" $(params.versionTag)
+            do
+              crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            done
+          else
+            TAG="$(params.versionTag)"
+            crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+          fi
+          # Until we are able to store larger results, we cannot include the
+          # regional copies of the images in the result - see https://github.com/tektoncd/pipeline/issues/4282
+          # echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+        done
+      done

--- a/tekton/release-cheatsheet.md
+++ b/tekton/release-cheatsheet.md
@@ -6,118 +6,194 @@ the results repo, a terminal window and a text editor.
 
 1. [Setup a context to connect to the dogfooding cluster](#setup-dogfooding-context) if you haven't already.
 
+1. Install the [rekor CLI](https://docs.sigstore.dev/rekor/installation/) if you haven't already.
+
+1. [Install kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize) if you haven't already.
+
 1. `cd` to root of Results git checkout.
 
-1. Make sure the release `Pipeline` is up-to-date on the
-   cluster.
+1. Select the commit you would like to build the release from (NOTE: the commit is full (40-digit) hash.)
+    - Select the most recent commit on the ***main branch*** if you are cutting a major or minor release i.e. `x.0.0` or `0.x.0`
+    - Select the most recent commit on the ***`release-<version number>x` branch***, e.g. [`release-v0.47.x`](https://github.com/tektoncd/results/tree/release-v0.47.x) if you are patching a release i.e. `v0.47.2`.
 
-   - [results-release](https://github.com/tektoncd/results/blob/main/tekton/release.yaml)
-
-     This uses [ko](https://github.com/google/ko) to build all container images we release and generate the `release.yaml`
-     ```shell script
-     kubectl apply -f tekton/release.yaml
-     ```
-
-1. Select the commit you would like to build the release from, most likely the
-   most recent commit at https://github.com/tektoncd/results/commits/main
-   and note the commit's hash.
-
-1. Create environment variables for bash scripts in later steps.
+1. Create a `release.env` file with environment variables for bash scripts in later steps, and source it:
 
     ```bash
-    VERSION_TAG=# UPDATE THIS. Example: v0.5.0
-    RELEASE_GIT_SHA=# SHA of the release to be released
+    cat <<EOF > release.env
+    TEKTON_VERSION= # Example: v0.19.0
+    TEKTON_RELEASE_GIT_SHA= # SHA of the release to be released, e.g. 5b082b1106753e093593d12152c82e1c4b0f37e5
+    TEKTON_OLD_VERSION= # Example: v0.18.0
+    TEKTON_PACKAGE=tektoncd/results
+    TEKTON_REPO_NAME=results
+    EOF
+    . ./release.env
     ```
 
 1. Confirm commit SHA matches what you want to release.
 
     ```bash
-    git show $RELEASE_GIT_SHA
+    git show $TEKTON_RELEASE_GIT_SHA
     ```
 
 1. Create a workspace template file:
 
    ```bash
-   cat <<EOF > workspace-template.yaml
+   WORKSPACE_TEMPLATE=$(mktemp /tmp/workspace-template.XXXXXX.yaml)
+   cat <<'EOF' > $WORKSPACE_TEMPLATE
    spec:
-     accessModes:
-     - ReadWriteOnce
-     resources:
-       requests:
-         storage: 1Gi
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
    EOF
    ```
 
-1. Execute the release pipeline.
+1. Execute the release pipeline (take ~45 mins).
+    
+    **The minimum required tkn version is v0.30.0 or later**
 
-
-    ```bash
-        tkn --context dogfooding pipeline start results-release \
-        --param=revision="${RELEASE_GIT_SHA}"  \
-        --param=version="${VERSION_TAG}" \
-        --param=docker_repo=ghcr.io/tektoncd/results \
-        --param=bucket=gs://tekton-releases/results \
-        --workspace name=release-secret,secret=ghcr-creds \
-        --workspace  name=ws,volumeClaimTemplateFile=workspace-template.yaml \
-        --workspace name=gcp-secret,secret=release-secret
-    ```
-
-1. Watch logs of result-release.
-
-1. Once the pipeline run is complete, check its results:
+    **If you are back-porting include this flag: `--param=releaseAsLatest="false"`**
 
    ```bash
-   tkn --context dogfooding pr describe <pipeline-run-name>
-
-   (...)
-   📝 Params
-
-   NAME                    VALUE
-   revision                 6ea31d92a97420d4b7af94745c45b02447ceaa19
-
-   (...)
+    tkn --context dogfooding pipeline start tekton-results-release \
+      --filename=tekton/results-release-pipeline.yaml \
+      --param package=github.com/tektoncd/results \
+      --param repoName="${TEKTON_REPO_NAME}" \
+      --param gitRevision="${TEKTON_RELEASE_GIT_SHA}" \
+      --param imageRegistry=ghcr.io \
+      --param imageRegistryPath=tektoncd/results \
+      --param imageRegistryRegions="" \
+      --param imageRegistryUser=tekton-robot \
+      --param serviceAccountImagesPath=credentials \
+      --param versionTag="${TEKTON_VERSION}" \
+      --param releaseBucket=tekton-releases \
+      --param koExtraArgs="" \
+      --workspace name=release-secret,secret=oci-release-secret \
+      --workspace name=release-images-secret,secret=ghcr-creds \
+      --workspace name=workarea,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
+      --tasks-timeout 2h \
+      --pipeline-timeout 3h
    ```
 
-   The `commit-sha` should match `$RELEASE_GIT_SHA`.
-   The two URLs can be opened in the browser or via `curl` to download the release manifests.
+    Accept the default values of the parameters (except for "releaseAsLatest" if backporting).
 
-    1. The YAMLs are now released! Anyone installing Tekton Results will now get the new version. Time to create a new GitHub release announcement:
+1. Watch logs of results-release.
 
-    1. Create additional environment variables
-
-    ```bash
-    OLD_VERSION=# Example v0.4.0
-    TEKTON_PACKAGE=tektoncd/results
-    ```
-
-
-    1. Execute the Draft Release task.
+1. Once the pipeline is complete, check its results:
 
     ```bash
-    tkn --context dogfooding pipeline start   \
-    --workspace name=shared,volumeClaimTemplateFile=workspace-template.yaml    \
-    --workspace name=credentials,secret=release-secret  \
-    -p package="${TEKTON_PACKAGE}"     -p git-revision="${RELEASE_GIT_SHA}"  \
-    -p release-tag="${VERSION_TAG}"     -p previous-release-tag="${OLD_VERSION}"   \
-    -p release-name="Tekton Results"     -p bucket="gs://tekton-releases/results"   \
-    -p rekor-uuid="$REKOR_UUID"  release-draft
+    tkn --context dogfooding pr describe <pipeline-run-name>
+
+    (...)
+    📝 Results
+
+    NAME                    VALUE
+    ∙ commit-sha            ff6d7abebde12460aecd061ab0f6fd21053ba8a7
+    ∙ release-file           https://infra.tekton.dev/tekton-releases/results/previous/v0.13.0/release.yaml
+    ∙ release-file-no-tag    https://infra.tekton.dev/tekton-releases/results/previous/v0.13.0/release.notags.yaml
+    (...)
     ```
 
-    1. Watch logs of create-draft-release
+    The `commit-sha` should match `$TEKTON_RELEASE_GIT_SHA`.
+    The two URLs can be opened in the browser or via `curl` to download the release manifests.
+
+
+1. The YAMLs are now released! Anyone installing Tekton Results will get the new version. Time to create a new GitHub release announcement:
+
+    1. Find the Rekor UUID for the release
+
+    ```bash
+    RELEASE_FILE=https://infra.tekton.dev/tekton-releases/results/previous/${TEKTON_VERSION}/release.yaml
+    WATCHER_IMAGE_SHA=$(curl -L $RELEASE_FILE | sed -n 's/"//g;s/.*ghcr\.io.*watcher.*@//p;')
+    REKOR_UUID=$(rekor-cli search --sha $WATCHER_IMAGE_SHA | grep -v Found | head -1)
+    echo -e "WATCHER_IMAGE_SHA: ${WATCHER_IMAGE_SHA}\nREKOR_UUID: ${REKOR_UUID}"
+    ```
+
+    1. Execute the Draft Release Pipeline.
+
+        Create a pod template file:
+
+        ```shell
+        POD_TEMPLATE=$(mktemp /tmp/pod-template.XXXXXX.yaml)
+        cat <<'EOF' > $POD_TEMPLATE
+        securityContext:
+          fsGroup: 65532
+          runAsUser: 65532
+          runAsNonRoot: true
+        EOF
+        ```
+
+        ```shell
+        tkn pipeline start \
+          --workspace name=shared,volumeClaimTemplateFile="${WORKSPACE_TEMPLATE}" \
+          --workspace name=credentials,secret=oci-release-secret \
+          --pod-template "${POD_TEMPLATE}" \
+          -p package="${TEKTON_PACKAGE}" \
+          -p git-revision="$TEKTON_RELEASE_GIT_SHA" \
+          -p release-tag="${TEKTON_VERSION}" \
+          -p previous-release-tag="${TEKTON_OLD_VERSION}" \
+          -p release-name="${TEKTON_RELEASE_NAME}" \
+          -p repo-name="${TEKTON_REPO_NAME}" \
+          -p bucket="tekton-releases" \
+          -p rekor-uuid="${REKOR_UUID}" \
+          release-draft-oci
+        ```
+
+    1. Watch logs of resulting pipeline run on pipeline `release-draft-oci`
 
     1. On successful completion, a URL will be logged. Visit that URL and look through the release notes.
       1. Manually add upgrade and deprecation notices based on the generated release notes
       1. Double-check that the list of commits here matches your expectations
          for the release. You might need to remove incorrect commits or copy/paste commits
          from the release branch. Refer to previous releases to confirm the expected format.
-    1. Un-check the "Set as a pre-release" checkbox since you're making a legit for-reals release!
+
+    1. Un-check the "This is a pre-release" checkbox since you're making a legit for-reals release!
 
     1. Publish the GitHub release once all notes are correct and in order.
-    1. Mark the release as "the default release" if it's not a patch release or the patch release of the latest release.
 
+1. Create a branch for the release named `release-<version number>x`, e.g. [`release-v0.28.x`](https://github.com/tektoncd/results/tree/release-v0.28.x)
+   and push it to the repo https://github.com/tektoncd/results.
+   (This can be done on the Github UI.)
+   Make sure to fetch the commit specified in `TEKTON_RELEASE_GIT_SHA` to create the released branch.
+   > Background: The reason why we need to create a branch for the release named `release-<version number>x` is for future patch releases. Cherrypicked PRs for the patch release will be merged to this branch. For example, [v0.47.0](https://github.com/tektoncd/results/releases/tag/v0.47.0) has been already released, but later on we found that an important [PR](https://github.com/tektoncd/results/pull/6622) should have been included to that release. Therefore, we need to do a patch release i.e. v0.47.1 by [cherrypicking this PR](https://github.com/tektoncd/results/pull/6622#pullrequestreview-1414804838), which will trigger [tekton-robot to create a new PR](https://github.com/tektoncd/results/pull/6622#issuecomment-1539030091) to merge the changes to the [release-v0.47.x branch](https://github.com/tektoncd/results/tree/release-v0.47.x).
 
+1. If the release introduces a new minimum version of Kubernetes required,
+   edit `README.md` on `main` branch and add the new requirement with in the
+   "Required Kubernetes Version" section
 
-1. Announce the release in Slack channels #general and #results.
+1. Edit `releases.md` on the `main` branch, add an entry for the release.
+   - In case of a patch release, replace the latest release with the new one,
+     including links to docs and examples. Append the new release to the list
+     of patch releases as well.
+   - In case of a minor or major release, add a new entry for the
+     release, including links to docs and example
+   - Check if any release is EOL, if so move it to the "End of Life Releases"
+     section
+
+1. Push & make PR for updated `releases.md` and `README.md`
+
+1. Test release that you just made against your own cluster (note `--context my-dev-cluster`):
+
+    ```bash
+    # Test latest
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/results/latest/release.yaml
+    ```
+
+    ```bash
+    # Test backport
+    kubectl --context my-dev-cluster apply --filename https://infra.tekton.dev/tekton-releases/results/previous/v0.11.2/release.yaml
+    ```
+
+1. Announce the release in Slack channels #general, #announcements and #results.
+
+1. Update [the catalog repo](https://github.com/tektoncd/catalog) test infrastructure
+to use the new release by updating the test matrix in the `[ci.yaml](https://github.com/tektoncd/catalog/blob/main/.github/workflows/ci.yaml)`.
+
+1. Update [the plumbing repo](https://github.com/tektoncd/plumbing/blob/main/tekton/cd/results/base/kustomization.yaml#L2) to deploy the latest version to the dogfooging cluster on OCI.
+
+1. For major releases, the [website sync configuration](https://github.com/tektoncd/website/blob/main/sync/config/pipelines.yaml)
+   to include the new release.
 
 Congratulations, you're done!
 
@@ -126,19 +202,26 @@ Congratulations, you're done!
 1. Configure `kubectl` to connect to
    [the dogfooding cluster](https://github.com/tektoncd/plumbing/blob/main/docs/dogfooding.md):
 
+   The dogfooding cluster is currently an OKE cluster in oracle cloud. we need the Oracle Cloud CLI client. Install oracle cloud cli (https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) 
+
     ```bash
-        oci ce cluster create-kubeconfig --cluster-id <CLUSTER-OCID> --file $HOME/.kube/config --region <CLUSTER-REGION> --token-version 2.0.0  --kube-endpoint PUBLIC_ENDPOINT
+    oci ce cluster create-kubeconfig --cluster-id <CLUSTER-OCID> --file $HOME/.kube/config --region <CLUSTER-REGION> --token-version 2.0.0  --kube-endpoint PUBLIC_ENDPOINT
     ```
 
 1. Give [the context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
    a short memorable name such as `dogfooding`:
 
    ```bash
-   kubectl config rename-context $(kubectl config current-context) dogfooding
+   kubectl config current-context
+   ```
+   get the context name and replace with current_context_name
+
+   ```bash
+   kubectl config rename-context <current_context_name> dogfooding
    ```
 
-## Important: Switch `kubectl` back to your own cluster by default.
+1. **Important: Switch `kubectl` back to your own cluster by default.**
 
-```bash
-kubectl config use-context my-dev-cluster
-```
+    ```bash
+    kubectl config use-context my-dev-cluster
+    ```

--- a/tekton/results-release-pipeline.yaml
+++ b/tekton/results-release-pipeline.yaml
@@ -1,0 +1,308 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: tekton-results-release
+spec:
+  params:
+    - name: package
+      description: package to release
+      default: github.com/tektoncd/results
+    - name: repoName
+      description: repository name (e.g., pipeline, triggers, etc.)
+      default: results
+    - name: gitRevision
+      description: the git revision to release
+    - name: imageRegistry
+      description: The target image registry
+      default: ghcr.io
+    - name: imageRegistryPath
+      description: The path (project) in the image registry
+      default: "tekton-releases-nightly"  # Will be overridden based on releaseMode
+    - name: imageRegistryRegions
+      description: The target image registry regions
+      default: ""  # Empty for GHCR, "us eu asia" for GCR
+    - name: imageRegistryUser
+      description: The user for the image registry credentials
+      default: _json_key
+    - name: versionTag
+      description: Version tag (vX.Y.Z for stable, vYYYYMMDD-abc1234 for nightly)
+    - name: releaseBucket
+      description: bucket where the release is stored. The bucket must be project specific.
+      default: "tekton-nightly"  # Will be overridden based on releaseMode
+    - name: releaseAsLatest
+      description: Whether to tag and publish this release as latest
+      default: "false"  # Will be overridden based on releaseMode
+    - name: buildPlatforms
+      description: Platforms to build images for (e.g. linux/amd64,linux/arm64)
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+    - name: publishPlatforms
+      description: |
+        Platforms to publish images for (e.g. linux/amd64,linux/arm64,windows/amd64). This
+        can differ from buildPlatforms due to the fact that a windows-compatible base image
+        is constructed for the publishing phase.)
+      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+    - name: koExtraArgs
+      description: Extra args to be passed to ko
+      default: "--preserve-import-paths"
+    - name: serviceAccountImagesPath
+      description: The path to the service account file or credentials within the release-images-secret workspace
+    - name: runTests
+      description: If set to something other than "true", skip the build and test tasks
+      default: "true"
+  workspaces:
+    - name: workarea
+      description: The workspace where the repo will be cloned.
+    - name: release-secret
+      description: The secret that contains auth credentials to push to the output bucket
+    - name: release-images-secret
+      description: The secret that contains a service account authorized to push to the imageRegistry
+  results:
+    - name: commit-sha
+      description: the sha of the commit that was released
+      value: $(tasks.git-clone.results.commit)
+    - name: release-file
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release)
+    - name: release-file-no-tag
+      description: the URL of the release file
+      value: $(tasks.report-bucket.results.release-no-tag)
+  tasks:
+    - name: git-clone
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.7
+          - name: name
+            value: git-clone
+          - name: kind
+            value: task
+      workspaces:
+        - name: output
+          workspace: workarea
+          subPath: git
+      params:
+        - name: url
+          value: https://$(params.package)
+        - name: revision
+          value: $(params.gitRevision)
+
+    - name: precheck
+      runAfter: [git-clone]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/plumbing
+          - name: revision
+            value: 8d3152d3d39982ce1768325b373d321efaa83031
+          - name: pathInRepo
+            value: tekton/resources/release/base/prerelease_checks_oci.yaml
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: releaseBucket
+          value: $(params.releaseBucket)/$(params.repoName)
+      workspaces:
+        - name: source-to-release
+          workspace: workarea
+          subPath: git
+        - name: oci-credentials
+          workspace: release-secret
+
+    - name: unit-tests
+      runAfter: [precheck]
+      when:
+        - cel: "'$(params.runTests)' == 'true'"
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-test:0.2
+          - name: name
+            value: golang-test
+          - name: kind
+            value: task
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: "./..."
+        - name: flags
+          value: -v -mod=vendor
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+
+    - name: build
+      runAfter: [precheck]
+      when:
+        - cel: "'$(params.runTests)' == 'true'"
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/golang-build:0.3
+          - name: name
+            value: golang-build
+          - name: kind
+            value: task
+      params:
+        - name: package
+          value: $(params.package)
+        - name: packages
+          value: ./cmd/...
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+
+    - name: publish-images
+      runAfter: [unit-tests, build]
+      taskRef:
+        resolver: git
+        params:
+          - name: repo
+            value: results
+          - name: org
+            value: tektoncd
+          - name: revision
+            value: $(params.gitRevision)
+          - name: pathInRepo
+            value: tekton/publish.yaml
+      params:
+        - name: package
+          value: $(params.package)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: imageRegistry
+          value: $(params.imageRegistry)
+        - name: imageRegistryPath
+          value: $(params.imageRegistryPath)
+        - name: imageRegistryUser
+          value: $(params.imageRegistryUser)
+        - name: imageRegistryRegions
+          value: $(params.imageRegistryRegions)
+        - name: releaseAsLatest
+          value: $(params.releaseAsLatest)
+        - name: serviceAccountPath
+          value: $(params.serviceAccountImagesPath)
+        - name: platforms
+          value: $(params.publishPlatforms)
+        - name: koExtraArgs
+          value: $(params.koExtraArgs)
+      workspaces:
+        - name: source
+          workspace: workarea
+          subPath: git
+        - name: output
+          workspace: workarea
+          subPath: bucket
+        - name: release-secret
+          workspace: release-images-secret
+      timeout: 3h
+
+    - name: publish-to-bucket
+      runAfter: [publish-images]
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
+          - name: name
+            value: oracle-cloud-storage-upload
+          - name: kind
+            value: task
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subPath: bucket
+      params:
+        - name: path
+          value: $(params.versionTag)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: $(params.repoName)/previous/$(params.versionTag)/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+
+    - name: publish-to-bucket-latest
+      runAfter: [publish-images]
+      when:
+        - input: "$(params.releaseAsLatest)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: bundles
+        params:
+          - name: bundle
+            value: ghcr.io/tektoncd/catalog/upstream/tasks/oracle-cloud-storage-upload:0.2
+          - name: name
+            value: oracle-cloud-storage-upload
+          - name: kind
+            value: task
+      workspaces:
+        - name: credentials
+          workspace: release-secret
+        - name: source
+          workspace: workarea
+          subPath: bucket
+      params:
+        - name: path
+          value: $(params.versionTag)
+        - name: bucketName
+          value: $(params.releaseBucket)
+        - name: objectPrefix
+          value: $(params.repoName)/latest/
+        - name: replaceExistingFiles
+          value: "true"
+        - name: recursive
+          value: "true"
+        - name: deleteExtraFiles
+          value: "true"  # Uses sync to copy content into latest
+
+    - name: report-bucket
+      runAfter: [publish-to-bucket]
+      params:
+        - name: releaseBucket
+          value: $(params.releaseBucket)
+        - name: versionTag
+          value: $(params.versionTag)
+        - name: repoName
+          value: $(params.repoName)
+      taskSpec:
+        params:
+          - name: releaseBucket
+          - name: versionTag
+          - name: repoName
+        results:
+          - name: release
+            description: The full URL of the release file in the bucket
+          - name: release-no-tag
+            description: The full URL of the release file (no tag) in the bucket
+        steps:
+          - name: create-results
+            image: docker.io/library/alpine:3.20.3@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
+            env:
+              - name: RELEASE_BUCKET
+                value: $(params.releaseBucket)
+              - name: VERSION_TAG
+                value: $(params.versionTag)
+              - name: REPO_NAME
+                value: $(params.repoName)
+            script: |
+              # Oracle Cloud Storage: Construct public URL
+              # Format: https://infra.tekton.dev/<releaseBucket>/<repoName>/previous/<versionTag>
+              BASE_URL="https://infra.tekton.dev/${RELEASE_BUCKET}/${REPO_NAME}/previous/${VERSION_TAG}"
+
+              echo "${BASE_URL}/release.yaml" > $(results.release.path)
+              echo "${BASE_URL}/release.notags.yaml" > $(results.release-no-tag.path)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This pull request updates the Tekton Results release process by introducing a new `publish-release` Tekton Task and updating the release documentation. The changes streamline the release workflow in line with other tektoncd components. The documentation now includes new prerequisites, environment variable conventions, improved branching guidance, and additional post-release steps.

**Key changes include:**

### 1. New Tekton Task for Publishing Releases
- Added `tekton/publish.yaml`, defining a comprehensive `publish-release` Tekton Task. This task automates container image publishing, registry authentication, image tagging, and release YAML generation, supporting multi-platform builds and regional registries.

### 2. Major Improvements to Release Documentation
- Rewrote `tekton/release-cheatsheet.md` for clarity and completeness:
  - Added installation steps for required tools (`rekor`, `kustomize`), and clarified environment variable usage via a `release.env` file.
  - Updated instructions for selecting commits, running the release pipeline, and handling backports. Provided explicit `tkn` commands with new parameters and workspace conventions.
  - Expanded post-release steps: finding Rekor UUIDs, running the draft release pipeline, creating release branches, updating documentation, testing releases, and announcing in relevant Slack channels. Added guidance for updating the catalog, plumbing, and website repositories.
  - Added instructions for configuring `kubectl` for the dogfooding cluster, including Oracle Cloud CLI usage.

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [X] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [X] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
/kind cleanup