### PR TITLE
CI: Remove manual PR author check from presubmit workflow

### DIFF
--- a/.github/workflows/presubmit-ci.yaml
+++ b/.github/workflows/presubmit-ci.yaml
@@ -12,7 +12,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   SHELL: /bin/bash
@@ -21,50 +20,9 @@ env:
   KIND_CLUSTER_NAME: tekton-results
 
 jobs:
-  prepare-pr-check:
-    name: Check PR Author / ok-to-test
-    runs-on: ubuntu-latest
-    outputs:
-      run_tests: ${{ steps.check.outputs.run_tests }}
-    steps:
-      - name: Install Python yq
-        run: |
-          python3 -m pip install --user yq
-
-      - name: Check PR author against org.yaml or /ok-to-test label
-        id: check
-        run: |
-          echo "Fetching Tekton org.yaml..."
-          ORG_YAML_URL="https://raw.githubusercontent.com/tektoncd/community/refs/heads/main/org/org.yaml"
-          ORG_YAML=$(curl -sSL "$ORG_YAML_URL")
-
-          # Use Python yq (wraps jq) to extract members and admins
-          IS_MEMBER=$(echo "$ORG_YAML" | ~/.local/bin/yq -r '.orgs.tektoncd.members[]' | grep -Fx "$GITHUB_ACTOR" || true)
-          IS_ADMIN=$(echo "$ORG_YAML" | ~/.local/bin/yq -r '.orgs.tektoncd.admins[]' | grep -Fx "$GITHUB_ACTOR" || true)
-
-          if [[ -n "$IS_MEMBER" || -n "$IS_ADMIN" ]]; then
-            echo " $GITHUB_ACTOR is a Tekton org member or admin."
-            echo "run_tests=true" >> "$GITHUB_OUTPUT"
-          else
-            echo " $GITHUB_ACTOR is NOT a Tekton org member/admin. Checking for /ok-to-test label..."
-
-            LABELS=$(jq -r '.pull_request.labels[].name' < "$GITHUB_EVENT_PATH")
-            if echo "$LABELS" | grep -q '^ok-to-test$'; then
-              echo " /ok-to-test label found."
-              echo "run_tests=true" >> "$GITHUB_OUTPUT"
-            else
-              echo " Not a member and no /ok-to-test label. Skipping tests."
-              echo "run_tests=false" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-
   unit-tests:
     name: Unit Tests
-    needs: prepare-pr-check
     runs-on: ubuntu-latest
-    if: needs.prepare-pr-check.outputs.run_tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -89,9 +47,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    needs: prepare-pr-check
     runs-on: ubuntu-latest
-    if: needs.prepare-pr-check.outputs.run_tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -134,9 +90,7 @@ jobs:
 
   build-tests:
     name: Build Tests
-    needs: prepare-pr-check
     runs-on: ubuntu-latest
-    if: needs.prepare-pr-check.outputs.run_tests == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Removes the custom shell script step that checked for Tekton organization membership or the 'ok-to-test' label. This isn't needed now.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
