### PR TITLE
ci: Add CI summary fan-in job to presubmit workflow

### DIFF
--- a/.github/workflows/presubmit-ci.yaml
+++ b/.github/workflows/presubmit-ci.yaml
@@ -166,4 +166,24 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
         run: ./test/presubmit-tests.sh --build-tests
 
+  ci-summary:
+    name: CI summary
+    if: always()
+    needs:
+      - unit-tests
+      - integration-tests
+      - build-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          results=(${{ join(needs.*.result, ' ') }})
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "One or more jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped"
+
 


### PR DESCRIPTION
# Changes

Add a `ci-summary` fan-in job to the presubmit CI workflow that depends on all
test jobs (`unit-tests`, `integration-tests`, `build-tests`). This provides a
single status check that can be used for branch protection instead of requiring
each individual job to pass.

The job runs with `if: always()` and treats both `success` and `skipped` as
passing states, failing only if any job returned `failure` or `cancelled`.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```