### PR TITLE
fix(watcher): populate RecordSummary StartTime/EndTime from Status fields

### DIFF
--- a/pkg/watcher/results/results.go
+++ b/pkg/watcher/results/results.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/google/go-cmp/cmp"
+	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
 	"github.com/tektoncd/results/pkg/watcher/convert"
@@ -124,8 +125,8 @@ func (c *Client) ensureResult(ctx context.Context, o Object, opts ...grpc.CallOp
 			Record:    recName,
 			Type:      convert.TypeName(o),
 			Status:    convert.Status(o.GetStatusCondition()),
-			StartTime: getTimestamp(o.GetStatusCondition().GetCondition(apis.ConditionReady)),
-			EndTime:   getTimestamp(o.GetStatusCondition().GetCondition(apis.ConditionSucceeded)),
+			StartTime: getStartTime(o),
+			EndTime:   getEndTime(o),
 		}
 	}
 
@@ -246,11 +247,44 @@ func copyKeys(in, out map[string]string) {
 	}
 }
 
-func getTimestamp(c *apis.Condition) *timestamppb.Timestamp {
-	if c == nil || c.IsFalse() {
-		return nil
+// getStartTime returns the start time of the object (PipelineRun or
+// TaskRun) in question.
+func getStartTime(o Object) *timestamppb.Timestamp {
+	var startTime *timestamppb.Timestamp
+
+	switch obj := o.(type) {
+
+	case *pipelinev1.PipelineRun:
+		if obj.Status.StartTime != nil {
+			startTime = timestamppb.New(obj.Status.StartTime.Time)
+		}
+
+	case *pipelinev1.TaskRun:
+		if obj.Status.StartTime != nil {
+			startTime = timestamppb.New(obj.Status.StartTime.Time)
+		}
 	}
-	return timestamppb.New(c.LastTransitionTime.Inner.Time)
+	return startTime
+}
+
+// getEndTime returns the completion time of the object (PipelineRun or
+// TaskRun) in question.
+func getEndTime(o Object) *timestamppb.Timestamp {
+	var endTime *timestamppb.Timestamp
+
+	switch obj := o.(type) {
+
+	case *pipelinev1.PipelineRun:
+		if obj.Status.CompletionTime != nil {
+			endTime = timestamppb.New(obj.Status.CompletionTime.Time)
+		}
+
+	case *pipelinev1.TaskRun:
+		if obj.Status.CompletionTime != nil {
+			endTime = timestamppb.New(obj.Status.CompletionTime.Time)
+		}
+	}
+	return endTime
 }
 
 // resultName gets the result name to use for the given object.

--- a/pkg/watcher/results/results.go
+++ b/pkg/watcher/results/results.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
 	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
 	"github.com/tektoncd/results/pkg/watcher/convert"
@@ -247,8 +248,8 @@ func copyKeys(in, out map[string]string) {
 	}
 }
 
-// getStartTime returns the start time of the object (PipelineRun or
-// TaskRun) in question.
+// getStartTime returns the Status.StartTime of a PipelineRun, TaskRun or
+// CustomRun, or nil for any other type.
 func getStartTime(o Object) *timestamppb.Timestamp {
 	var startTime *timestamppb.Timestamp
 
@@ -263,12 +264,20 @@ func getStartTime(o Object) *timestamppb.Timestamp {
 		if obj.Status.StartTime != nil {
 			startTime = timestamppb.New(obj.Status.StartTime.Time)
 		}
+
+	case *pipelinev1beta1.CustomRun:
+		if obj.Status.StartTime != nil {
+			startTime = timestamppb.New(obj.Status.StartTime.Time)
+		}
+
+	default:
+		return nil
 	}
 	return startTime
 }
 
-// getEndTime returns the completion time of the object (PipelineRun or
-// TaskRun) in question.
+// getEndTime returns the Status.CompletionTime of a PipelineRun, TaskRun or
+// CustomRun, or nil for any other type.
 func getEndTime(o Object) *timestamppb.Timestamp {
 	var endTime *timestamppb.Timestamp
 
@@ -283,6 +292,14 @@ func getEndTime(o Object) *timestamppb.Timestamp {
 		if obj.Status.CompletionTime != nil {
 			endTime = timestamppb.New(obj.Status.CompletionTime.Time)
 		}
+
+	case *pipelinev1beta1.CustomRun:
+		if obj.Status.CompletionTime != nil {
+			endTime = timestamppb.New(obj.Status.CompletionTime.Time)
+		}
+
+	default:
+		return nil
 	}
 	return endTime
 }

--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/tektoncd/results/pkg/api/server/config"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,7 +34,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	logtest "knative.dev/pkg/logging/testing"
 )
 
@@ -628,5 +633,297 @@ func client(t *testing.T) *Client {
 	return &Client{
 		ResultsClient: resultsClient,
 		LogsClient:    logsClient,
+	}
+}
+
+func TestGetStartTime(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		object Object
+		want   *timestamppb.Timestamp
+	}{
+		{
+			name: "PipelineRun with StartTime",
+			object: &pipelinev1.PipelineRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: ts},
+					},
+				},
+			},
+			want: timestamppb.New(ts),
+		},
+		{
+			name: "PipelineRun without StartTime",
+			object: &pipelinev1.PipelineRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "TaskRun with StartTime",
+			object: &pipelinev1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Status: pipelinev1.TaskRunStatus{
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime: &metav1.Time{Time: ts},
+					},
+				},
+			},
+			want: timestamppb.New(ts),
+		},
+		{
+			name: "TaskRun without StartTime",
+			object: &pipelinev1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStartTime(tt.object)
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("getStartTime() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetEndTime(t *testing.T) {
+	ts := time.Date(2024, 1, 1, 10, 5, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		object Object
+		want   *timestamppb.Timestamp
+	}{
+		{
+			name: "PipelineRun with CompletionTime",
+			object: &pipelinev1.PipelineRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						CompletionTime: &metav1.Time{Time: ts},
+					},
+				},
+			},
+			want: timestamppb.New(ts),
+		},
+		{
+			name: "PipelineRun without CompletionTime",
+			object: &pipelinev1.PipelineRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "TaskRun with CompletionTime",
+			object: &pipelinev1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				Status: pipelinev1.TaskRunStatus{
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						CompletionTime: &metav1.Time{Time: ts},
+					},
+				},
+			},
+			want: timestamppb.New(ts),
+		},
+		{
+			name: "TaskRun without CompletionTime",
+			object: &pipelinev1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getEndTime(tt.object)
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("getEndTime() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnsureResult_Timestamps(t *testing.T) {
+	ctx := logtest.TestContextWithLogger(t)
+	client := client(t)
+
+	start := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 1, 10, 5, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		object     Object
+		wantStatus pb.RecordSummary_Status
+	}{
+		{
+			name: "PipelineRun succeeded",
+			object: &pipelinev1.PipelineRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-ok",
+					Namespace: "test",
+					UID:       "pr-ok-id",
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+								Reason: pipelinev1.PipelineRunReasonSuccessful.String(),
+							},
+						},
+					},
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: start},
+						CompletionTime: &metav1.Time{Time: end},
+					},
+				},
+			},
+			wantStatus: pb.RecordSummary_SUCCESS,
+		},
+		{
+			name: "PipelineRun failed",
+			object: &pipelinev1.PipelineRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "PipelineRun",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pr-fail",
+					Namespace: "test",
+					UID:       "pr-fail-id",
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionFalse,
+								Reason: pipelinev1.PipelineRunReasonFailed.String(),
+							},
+						},
+					},
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: start},
+						CompletionTime: &metav1.Time{Time: end},
+					},
+				},
+			},
+			wantStatus: pb.RecordSummary_FAILURE,
+		},
+		{
+			name: "TaskRun succeeded",
+			object: &pipelinev1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-ok",
+					Namespace: "test",
+					UID:       "tr-ok-id",
+				},
+				Status: pipelinev1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+								Reason: pipelinev1.TaskRunReasonSuccessful.String(),
+							},
+						},
+					},
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime:      &metav1.Time{Time: start},
+						CompletionTime: &metav1.Time{Time: end},
+					},
+				},
+			},
+			wantStatus: pb.RecordSummary_SUCCESS,
+		},
+		{
+			name: "TaskRun failed",
+			object: &pipelinev1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1",
+					Kind:       "TaskRun",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tr-fail",
+					Namespace: "test",
+					UID:       "tr-fail-id",
+				},
+				Status: pipelinev1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionFalse,
+								Reason: pipelinev1.TaskRunReasonFailed.String(),
+							},
+						},
+					},
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime:      &metav1.Time{Time: start},
+						CompletionTime: &metav1.Time{Time: end},
+					},
+				},
+			},
+			wantStatus: pb.RecordSummary_FAILURE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := client.ensureResult(ctx, tt.object)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			name := fmt.Sprintf("test/results/%s", tt.object.GetUID())
+			want := &pb.RecordSummary{
+				Record:    recordName(name, tt.object),
+				Type:      convert.TypeName(tt.object),
+				Status:    tt.wantStatus,
+				StartTime: timestamppb.New(start),
+				EndTime:   timestamppb.New(end),
+			}
+			if diff := cmp.Diff(want, res.GetSummary(), protocmp.Transform()); diff != "" {
+				t.Errorf("RecordSummary mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/watcher/results/results_test.go
+++ b/pkg/watcher/results/results_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/results/pkg/internal/protoutil"
 	"github.com/tektoncd/results/pkg/internal/test"
 	"github.com/tektoncd/results/pkg/watcher/convert"
@@ -636,6 +637,12 @@ func client(t *testing.T) *Client {
 	}
 }
 
+// unknownObject satisfies the Object interface without matching any type
+// handled by getStartTime and getEndTime.
+type unknownObject struct {
+	pipelinev1.TaskRun
+}
+
 func TestGetStartTime(t *testing.T) {
 	ts := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
 	tests := []struct {
@@ -689,6 +696,44 @@ func TestGetStartTime(t *testing.T) {
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "tekton.dev/v1",
 					Kind:       "TaskRun",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "CustomRun with StartTime",
+			object: &pipelinev1beta1.CustomRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "CustomRun",
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
+						StartTime: &metav1.Time{Time: ts},
+					},
+				},
+			},
+			want: timestamppb.New(ts),
+		},
+		{
+			name: "CustomRun without StartTime",
+			object: &pipelinev1beta1.CustomRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "CustomRun",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "unrecognized type",
+			object: &unknownObject{
+				TaskRun: pipelinev1.TaskRun{
+					Status: pipelinev1.TaskRunStatus{
+						TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+							StartTime: &metav1.Time{Time: ts},
+						},
+					},
 				},
 			},
 			want: nil,
@@ -757,6 +802,44 @@ func TestGetEndTime(t *testing.T) {
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "tekton.dev/v1",
 					Kind:       "TaskRun",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "CustomRun with CompletionTime",
+			object: &pipelinev1beta1.CustomRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "CustomRun",
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
+						CompletionTime: &metav1.Time{Time: ts},
+					},
+				},
+			},
+			want: timestamppb.New(ts),
+		},
+		{
+			name: "CustomRun without CompletionTime",
+			object: &pipelinev1beta1.CustomRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "CustomRun",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "unrecognized type",
+			object: &unknownObject{
+				TaskRun: pipelinev1.TaskRun{
+					Status: pipelinev1.TaskRunStatus{
+						TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+							CompletionTime: &metav1.Time{Time: ts},
+						},
+					},
 				},
 			},
 			want: nil,
@@ -897,6 +980,66 @@ func TestEnsureResult_Timestamps(t *testing.T) {
 						},
 					},
 					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						StartTime:      &metav1.Time{Time: start},
+						CompletionTime: &metav1.Time{Time: end},
+					},
+				},
+			},
+			wantStatus: pb.RecordSummary_FAILURE,
+		},
+		{
+			name: "CustomRun succeeded",
+			object: &pipelinev1beta1.CustomRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "CustomRun",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cr-ok",
+					Namespace: "test",
+					UID:       "cr-ok-id",
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+								Reason: "Succeeded",
+							},
+						},
+					},
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
+						StartTime:      &metav1.Time{Time: start},
+						CompletionTime: &metav1.Time{Time: end},
+					},
+				},
+			},
+			wantStatus: pb.RecordSummary_SUCCESS,
+		},
+		{
+			name: "CustomRun failed",
+			object: &pipelinev1beta1.CustomRun{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "CustomRun",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cr-fail",
+					Namespace: "test",
+					UID:       "cr-fail-id",
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionFalse,
+								Reason: "Failed",
+							},
+						},
+					},
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
 						StartTime:      &metav1.Time{Time: start},
 						CompletionTime: &metav1.Time{Time: end},
 					},


### PR DESCRIPTION
`RecordSummary.StartTime` is always NULL and `EndTime` is NULL for
failed/timed-out/cancelled runs.

The watcher derived timestamps from Knative conditions via `getTimestamp()`.
This is broken for two reasons:

1. **StartTime** was read from `ConditionReady`. Tekton PipelineRun and TaskRun
   are batch resources (`NewBatchConditionSet`) whose happy condition is
   `ConditionSucceeded`. `ConditionReady` is for living resources like Knative
   Services and is never set on batch resources, so the lookup always returned
   nil.

2. **EndTime** was read from `ConditionSucceeded`, but `getTimestamp()` returned
   nil when the condition `IsFalse()`. For failed, timed-out, and cancelled runs
   `ConditionSucceeded` is False, so EndTime was nil even though the run had
   completed.

## Fix

Read `Status.StartTime` and `Status.CompletionTime` directly from the
PipelineRun/TaskRun object via type switch. These fields are set by the Tekton
controller for all terminal states. This follows the existing pattern used by
`getCompletionTime()` in the dynamic reconciler.

- Add `getStartTime()` and `getEndTime()` helpers
- Update `ensureResult()` to use the new helpers
- Remove the now-unused `getTimestamp()` function
- Add unit and integration tests covering both run types in success and failure
  states

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix RecordSummary StartTime always being NULL and EndTime being NULL for
failed/timed-out/cancelled runs. Timestamps are now read directly from the
run's Status.StartTime and Status.CompletionTime fields instead of from
Knative conditions.
```

