### PR TITLE
chore(cli): deprecate legacy commands and flags

### DIFF
--- a/docs/cli/tkn-results.md
+++ b/docs/cli/tkn-results.md
@@ -23,22 +23,12 @@ The following commands are supported:
 ### Options
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-  -h, --help               help for tkn-results
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -h, --help   help for tkn-results
 ```
 
 ### SEE ALSO
 
 * [tkn-results config](tkn-results_config.md)	 - Manage Tekton Results CLI configuration
-* [tkn-results logs](tkn-results_logs.md)	 - [To be deprecated] Commands for finding and retrieving logs
 * [tkn-results pipelinerun](tkn-results_pipelinerun.md)	 - Query PipelineRuns
-* [tkn-results records](tkn-results_records.md)	 - [To be deprecated] Command sub-group for querying Records
-* [tkn-results result](tkn-results_result.md)	 - [To be deprecated] Query Results
 * [tkn-results taskrun](tkn-results_taskrun.md)	 - Query TaskRuns
 

--- a/docs/cli/tkn-results_config.md
+++ b/docs/cli/tkn-results_config.md
@@ -47,18 +47,6 @@ Reset configuration to defaults:
       --token string               bearer token to use (default: value provided in config set command)
 ```
 
-### Options inherited from parent commands
-
-```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
-```
-
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI

--- a/docs/cli/tkn-results_config_reset.md
+++ b/docs/cli/tkn-results_config_reset.md
@@ -43,20 +43,13 @@ Reset and immediately reconfigure:
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_config_set.md
+++ b/docs/cli/tkn-results_config_set.md
@@ -71,18 +71,6 @@ Configure with custom kubeconfig and context:
       --token string               bearer token to use (default: value provided in config set command)
 ```
 
-### Options inherited from parent commands
-
-```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
-```
-
 ### SEE ALSO
 
 * [tkn-results config](tkn-results_config.md)	 - Manage Tekton Results CLI configuration

--- a/docs/cli/tkn-results_config_view.md
+++ b/docs/cli/tkn-results_config_view.md
@@ -34,20 +34,13 @@ View current configuration:
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_logs.md
+++ b/docs/cli/tkn-results_logs.md
@@ -1,6 +1,9 @@
 ## tkn-results logs
 
-[To be deprecated] Commands for finding and retrieving logs
+**[DEPRECATED]** Commands for finding and retrieving logs
+
+> **Deprecation Notice**: This command is deprecated and will be removed in a future release.
+> Use `tkn-results pipelinerun logs` or `tkn-results taskrun logs` commands instead.
 
 ### Options
 
@@ -11,18 +14,18 @@
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. Use 'config set --host=<host>' instead
+  -t, --authtoken string   [DEPRECATED] authorization bearer token. Use 'config set --token=<token>' instead
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request. Use 'config set --insecure' instead
+      --portforward        [DEPRECATED] enable auto portforwarding. Use 'config set' instead (default true)
+      --sa string          [DEPRECATED] ServiceAccount for authorization. Use 'config set' instead
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace. Use 'config set' instead
+      --v1alpha2           [DEPRECATED] use v1alpha2 API. This flag is no longer needed
 ```
 
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI
-* [tkn-results logs get](tkn-results_logs_get.md)	 - [To be deprecated] Get Log by <log-name>
-* [tkn-results logs list](tkn-results_logs_list.md)	 - [To be deprecated] List Logs for a given Result
+* [tkn-results logs get](tkn-results_logs_get.md)	 - **[DEPRECATED]** Get Log by <log-name> - use `pipelinerun logs` or `taskrun logs` instead
+* [tkn-results logs list](tkn-results_logs_list.md)	 - **[DEPRECATED]** List Logs for a given Result - use `pipelinerun logs` or `taskrun logs` instead
 

--- a/docs/cli/tkn-results_logs_get.md
+++ b/docs/cli/tkn-results_logs_get.md
@@ -1,6 +1,8 @@
 ## tkn-results logs get
 
-[To be deprecated] Get Log by <log-name>
+**[DEPRECATED]** Get Log by <log-name>
+
+> **Deprecation Notice**: Use `tkn-results pipelinerun logs` or `tkn-results taskrun logs` instead.
 
 ### Synopsis
 
@@ -32,22 +34,22 @@ tkn-results logs get [flags] <log-name>
 
 ```
   -h, --help            help for get
-  -o, --output string   [To be deprecated] output format. Valid values: textproto|json (default "json")
+  -o, --output string   [DEPRECATED] output format. Valid values: textproto|json (default "json")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+  -t, --authtoken string   [DEPRECATED] authorization bearer token to use for authenticated requests
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request
+      --portforward        [DEPRECATED] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string          [DEPRECATED] ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace, if not given, it will be taken from current context
+      --v1alpha2           [DEPRECATED] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO
 
-* [tkn-results logs](tkn-results_logs.md)	 - [To be deprecated] Commands for finding and retrieving logs
+* [tkn-results logs](tkn-results_logs.md)	 - [DEPRECATED] Commands for finding and retrieving logs
 

--- a/docs/cli/tkn-results_logs_list.md
+++ b/docs/cli/tkn-results_logs_list.md
@@ -1,6 +1,8 @@
 ## tkn-results logs list
 
-[To be deprecated] List Logs for a given Result
+**[DEPRECATED]** List Logs for a given Result
+
+> **Deprecation Notice**: Use `tkn-results pipelinerun logs` or `tkn-results taskrun logs` instead.
 
 ### Synopsis
 
@@ -24,26 +26,26 @@ tkn-results logs list [flags] <result-name>
 ### Options
 
 ```
-  -f, --filter string   [To be deprecated] CEL Filter
+  -f, --filter string   [DEPRECATED] CEL Filter
   -h, --help            help for list
-  -l, --limit int32     [To be deprecated] number of items to return. Response may be truncated due to server limits.
-  -o, --output string   [To be deprecated] output format. Valid values: tab|textproto|json (default "tab")
-  -p, --page string     [To be deprecated] pagination token to use for next page
+  -l, --limit int32     [DEPRECATED] number of items to return. Response may be truncated due to server limits.
+  -o, --output string   [DEPRECATED] output format. Valid values: tab|textproto|json (default "tab")
+  -p, --page string     [DEPRECATED] pagination token to use for next page
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+  -t, --authtoken string   [DEPRECATED] authorization bearer token to use for authenticated requests
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request
+      --portforward        [DEPRECATED] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string          [DEPRECATED] ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace, if not given, it will be taken from current context
+      --v1alpha2           [DEPRECATED] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO
 
-* [tkn-results logs](tkn-results_logs.md)	 - [To be deprecated] Commands for finding and retrieving logs
+* [tkn-results logs](tkn-results_logs.md)	 - [DEPRECATED] Commands for finding and retrieving logs
 

--- a/docs/cli/tkn-results_pipelinerun.md
+++ b/docs/cli/tkn-results_pipelinerun.md
@@ -35,18 +35,6 @@ Examples:
       --token string               bearer token to use (default: value provided in config set command)
 ```
 
-### Options inherited from parent commands
-
-```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
-```
-
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI

--- a/docs/cli/tkn-results_pipelinerun_describe.md
+++ b/docs/cli/tkn-results_pipelinerun_describe.md
@@ -38,20 +38,13 @@ Describe a PipelineRun as json:
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_pipelinerun_list.md
+++ b/docs/cli/tkn-results_pipelinerun_list.md
@@ -45,20 +45,13 @@ List PipelineRuns with partial pipeline name match:
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_pipelinerun_logs.md
+++ b/docs/cli/tkn-results_pipelinerun_logs.md
@@ -39,20 +39,13 @@ Get logs for a PipelineRun by UID if there are multiple PipelineRuns with the sa
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_records.md
+++ b/docs/cli/tkn-results_records.md
@@ -1,6 +1,9 @@
 ## tkn-results records
 
-[To be deprecated] Command sub-group for querying Records
+**[DEPRECATED]** Command sub-group for querying Records
+
+> **Deprecation Notice**: This command is deprecated and will be removed in a future release.
+> Use `tkn-results pipelinerun` or `tkn-results taskrun` commands instead.
 
 ### Options
 
@@ -11,18 +14,18 @@
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. Use 'config set --host=<host>' instead
+  -t, --authtoken string   [DEPRECATED] authorization bearer token. Use 'config set --token=<token>' instead
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request. Use 'config set --insecure' instead
+      --portforward        [DEPRECATED] enable auto portforwarding. Use 'config set' instead (default true)
+      --sa string          [DEPRECATED] ServiceAccount for authorization. Use 'config set' instead
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace. Use 'config set' instead
+      --v1alpha2           [DEPRECATED] use v1alpha2 API. This flag is no longer needed
 ```
 
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI
-* [tkn-results records get](tkn-results_records_get.md)	 - [To be deprecated] Get Record by <record-name>
-* [tkn-results records list](tkn-results_records_list.md)	 - [To be deprecated] List Records for a given Result
+* [tkn-results records get](tkn-results_records_get.md)	 - **[DEPRECATED]** Get Record by <record-name> - use `pipelinerun describe` or `taskrun describe` instead
+* [tkn-results records list](tkn-results_records_list.md)	 - **[DEPRECATED]** List Records for a given Result - use `pipelinerun list` or `taskrun list` instead
 

--- a/docs/cli/tkn-results_records_get.md
+++ b/docs/cli/tkn-results_records_get.md
@@ -1,6 +1,8 @@
 ## tkn-results records get
 
-[To be deprecated] Get Record by <record-name>
+**[DEPRECATED]** Get Record by <record-name>
+
+> **Deprecation Notice**: Use `tkn-results pipelinerun describe` or `tkn-results taskrun describe` instead.
 
 ### Synopsis
 
@@ -32,22 +34,22 @@ tkn-results records get [flags] <record-name>
 
 ```
   -h, --help            help for get
-  -o, --output string   [To be deprecated] output format. Valid values: textproto|json (default "json")
+  -o, --output string   [DEPRECATED] output format. Valid values: textproto|json (default "json")
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+  -t, --authtoken string   [DEPRECATED] authorization bearer token to use for authenticated requests
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request
+      --portforward        [DEPRECATED] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string          [DEPRECATED] ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace, if not given, it will be taken from current context
+      --v1alpha2           [DEPRECATED] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO
 
-* [tkn-results records](tkn-results_records.md)	 - [To be deprecated] Command sub-group for querying Records
+* [tkn-results records](tkn-results_records.md)	 - [DEPRECATED] Command sub-group for querying Records
 

--- a/docs/cli/tkn-results_records_list.md
+++ b/docs/cli/tkn-results_records_list.md
@@ -1,6 +1,8 @@
 ## tkn-results records list
 
-[To be deprecated] List Records for a given Result
+**[DEPRECATED]** List Records for a given Result
+
+> **Deprecation Notice**: Use `tkn-results pipelinerun list` or `tkn-results taskrun list` instead.
 
 ### Synopsis
 
@@ -26,26 +28,26 @@ tkn-results records list [flags] <result-name>
 ### Options
 
 ```
-  -f, --filter string   [To be deprecated] CEL Filter
+  -f, --filter string   [DEPRECATED] CEL Filter
   -h, --help            help for list
-  -l, --limit int32     [To be deprecated] number of items to return. Response may be truncated due to server limits.
-  -o, --output string   [To be deprecated] output format. Valid values: tab|textproto|json (default "tab")
-  -p, --page string     [To be deprecated] pagination token to use for next page
+  -l, --limit int32     [DEPRECATED] number of items to return. Response may be truncated due to server limits.
+  -o, --output string   [DEPRECATED] output format. Valid values: tab|textproto|json (default "tab")
+  -p, --page string     [DEPRECATED] pagination token to use for next page
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+  -t, --authtoken string   [DEPRECATED] authorization bearer token to use for authenticated requests
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request
+      --portforward        [DEPRECATED] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string          [DEPRECATED] ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace, if not given, it will be taken from current context
+      --v1alpha2           [DEPRECATED] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO
 
-* [tkn-results records](tkn-results_records.md)	 - [To be deprecated] Command sub-group for querying Records
+* [tkn-results records](tkn-results_records.md)	 - [DEPRECATED] Command sub-group for querying Records
 

--- a/docs/cli/tkn-results_result.md
+++ b/docs/cli/tkn-results_result.md
@@ -1,6 +1,9 @@
 ## tkn-results result
 
-[To be deprecated] Query Results
+**[DEPRECATED]** Query Results
+
+> **Deprecation Notice**: This command is deprecated and will be removed in a future release.
+> Use `tkn-results pipelinerun` or `tkn-results taskrun` commands instead.
 
 ### Options
 
@@ -11,18 +14,18 @@
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. Use 'config set --host=<host>' instead
+  -t, --authtoken string   [DEPRECATED] authorization bearer token. Use 'config set --token=<token>' instead
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request. Use 'config set --insecure' instead
+      --portforward        [DEPRECATED] enable auto portforwarding. Use 'config set' instead (default true)
+      --sa string          [DEPRECATED] ServiceAccount for authorization. Use 'config set' instead
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace. Use 'config set' instead
+      --v1alpha2           [DEPRECATED] use v1alpha2 API. This flag is no longer needed
 ```
 
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI
-* [tkn-results result describe](tkn-results_result_describe.md)	 - [To be deprecated] Describes a Result
-* [tkn-results result list](tkn-results_result_list.md)	 - [To be deprecated] List Results
+* [tkn-results result describe](tkn-results_result_describe.md)	 - **[DEPRECATED]** Describes a Result - use `pipelinerun describe` or `taskrun describe` instead
+* [tkn-results result list](tkn-results_result_list.md)	 - **[DEPRECATED]** List Results - use `pipelinerun list` or `taskrun list` instead
 

--- a/docs/cli/tkn-results_result_describe.md
+++ b/docs/cli/tkn-results_result_describe.md
@@ -1,6 +1,8 @@
 ## tkn-results result describe
 
-[To be deprecated] Describes a Result
+**[DEPRECATED]** Describes a Result
+
+> **Deprecation Notice**: Use `tkn-results pipelinerun describe` or `tkn-results taskrun describe` instead.
 
 ```
 tkn-results result describe [-p parent -u uid] [name]
@@ -21,23 +23,23 @@ tkn-results result desc --parent default --uid 949eebd9-1cf7-478f-a547-9ee313035
 
 ```
   -h, --help            help for describe
-  -p, --parent string   [To be deprecated] parent of the result
-  -u, --uid string      [To be deprecated] uid of the result
+  -p, --parent string   [DEPRECATED] parent of the result
+  -u, --uid string      [DEPRECATED] uid of the result
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+  -t, --authtoken string   [DEPRECATED] authorization bearer token to use for authenticated requests
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request
+      --portforward        [DEPRECATED] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string          [DEPRECATED] ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace, if not given, it will be taken from current context
+      --v1alpha2           [DEPRECATED] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO
 
-* [tkn-results result](tkn-results_result.md)	 - [To be deprecated] Query Results
+* [tkn-results result](tkn-results_result.md)	 - [DEPRECATED] Query Results
 

--- a/docs/cli/tkn-results_result_list.md
+++ b/docs/cli/tkn-results_result_list.md
@@ -1,6 +1,8 @@
 ## tkn-results result list
 
-[To be deprecated] List Results
+**[DEPRECATED]** List Results
+
+> **Deprecation Notice**: Use `tkn-results pipelinerun list` or `tkn-results taskrun list` instead.
 
 ```
 tkn-results result list [flags] <parent>
@@ -11,26 +13,26 @@ tkn-results result list [flags] <parent>
 ### Options
 
 ```
-  -f, --filter string   [To be deprecated] CEL Filter
+  -f, --filter string   [DEPRECATED] CEL Filter
   -h, --help            help for list
-  -l, --limit int32     [To be deprecated] number of items to return. Response may be truncated due to server limits.
-  -o, --output string   [To be deprecated] output format. Valid values: tab|textproto|json (default "tab")
-  -p, --page string     [To be deprecated] pagination token to use for next page
+  -l, --limit int32     [DEPRECATED] number of items to return. Response may be truncated due to server limits.
+  -o, --output string   [DEPRECATED] output format. Valid values: tab|textproto|json (default "tab")
+  -p, --page string     [DEPRECATED] pagination token to use for next page
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
+  -a, --addr string        [DEPRECATED] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
+  -t, --authtoken string   [DEPRECATED] authorization bearer token to use for authenticated requests
+      --insecure           [DEPRECATED] determines whether to run insecure GRPC tls request
+      --portforward        [DEPRECATED] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
+      --sa string          [DEPRECATED] ServiceAccount to use instead of token for authorization and authentication
+      --sa-ns string       [DEPRECATED] ServiceAccount Namespace, if not given, it will be taken from current context
+      --v1alpha2           [DEPRECATED] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO
 
-* [tkn-results result](tkn-results_result.md)	 - [To be deprecated] Query Results
+* [tkn-results result](tkn-results_result.md)	 - [DEPRECATED] Query Results
 

--- a/docs/cli/tkn-results_taskrun.md
+++ b/docs/cli/tkn-results_taskrun.md
@@ -35,18 +35,6 @@ Examples:
       --token string               bearer token to use (default: value provided in config set command)
 ```
 
-### Options inherited from parent commands
-
-```
-  -a, --addr string        [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-  -t, --authtoken string   [To be deprecated] authorization bearer token to use for authenticated requests
-      --insecure           [To be deprecated] determines whether to run insecure GRPC tls request
-      --portforward        [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string          [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string       [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-      --v1alpha2           [To be deprecated] use v1alpha2 API for get log command
-```
-
 ### SEE ALSO
 
 * [tkn-results](tkn-results.md)	 - Tekton Results CLI

--- a/docs/cli/tkn-results_taskrun_describe.md
+++ b/docs/cli/tkn-results_taskrun_describe.md
@@ -38,20 +38,13 @@ Describe a TaskRun as json
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_taskrun_list.md
+++ b/docs/cli/tkn-results_taskrun_list.md
@@ -49,20 +49,13 @@ List TaskRuns for a specific PipelineRun:
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/cli/tkn-results_taskrun_logs.md
+++ b/docs/cli/tkn-results_taskrun_logs.md
@@ -38,20 +38,13 @@ Get logs for a TaskRun by UID if there are multiple TaskRun with the same name:
 ### Options inherited from parent commands
 
 ```
-  -a, --addr string                [To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
       --api-path string            api path to use (default: value provided in config set command)
-  -t, --authtoken string           [To be deprecated] authorization bearer token to use for authenticated requests
   -c, --context string             name of the kubeconfig context to use (default: kubectl config current-context)
       --host string                host to use (default: value provided in config set command)
-      --insecure                   [To be deprecated] determines whether to run insecure GRPC tls request
       --insecure-skip-tls-verify   skip server's certificate validation for requests (default: false)
   -k, --kubeconfig string          kubectl config file (default: $HOME/.kube/config)
   -n, --namespace string           namespace to use (default: from $KUBECONFIG)
-      --portforward                [To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically (default true)
-      --sa string                  [To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-      --sa-ns string               [To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
       --token string               bearer token to use (default: value provided in config set command)
-      --v1alpha2                   [To be deprecated] use v1alpha2 API for get log command
 ```
 
 ### SEE ALSO

--- a/docs/man/man1/tkn-results-config-reset.1
+++ b/docs/man/man1/tkn-results-config-reset.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-config-reset - Reset CLI configuration to defaults
@@ -32,16 +32,8 @@ Warning: This will remove all custom configuration settings.
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -50,10 +42,6 @@ Warning: This will remove all custom configuration settings.
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -68,24 +56,8 @@ Warning: This will remove all custom configuration settings.
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-config-set.1
+++ b/docs/man/man1/tkn-results-config-set.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-config-set - Set Tekton Results CLI configuration values
@@ -82,35 +82,6 @@ If your route deviates from this standard format, use manual configuration.
 .PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-
-.SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
-
-.PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-config-view.1
+++ b/docs/man/man1/tkn-results-config-view.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-config-view - Display current CLI configuration
@@ -29,16 +29,8 @@ The configuration is displayed in YAML format.
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -47,10 +39,6 @@ The configuration is displayed in YAML format.
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -65,24 +53,8 @@ The configuration is displayed in YAML format.
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-config.1
+++ b/docs/man/man1/tkn-results-config.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-config - Manage Tekton Results CLI configuration
@@ -58,35 +58,6 @@ Available subcommands:
 .PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-
-.SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
-
-.PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-pipelinerun-describe.1
+++ b/docs/man/man1/tkn-results-pipelinerun-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-pipelinerun-describe - Describe a PipelineRun
@@ -27,16 +27,8 @@ Describe a PipelineRun by name or UID. If --uid is provided, then PipelineRun na
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -45,10 +37,6 @@ Describe a PipelineRun by name or UID. If --uid is provided, then PipelineRun na
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -63,24 +51,8 @@ Describe a PipelineRun by name or UID. If --uid is provided, then PipelineRun na
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-pipelinerun-list.1
+++ b/docs/man/man1/tkn-results-pipelinerun-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-pipelinerun-list - List PipelineRuns in a namespace
@@ -35,16 +35,8 @@ List PipelineRuns in a namespace
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -53,10 +45,6 @@ List PipelineRuns in a namespace
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -71,24 +59,8 @@ List PipelineRuns in a namespace
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-pipelinerun-logs.1
+++ b/docs/man/man1/tkn-results-pipelinerun-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-pipelinerun-logs - Get logs for a PipelineRun
@@ -29,16 +29,8 @@ Logs are only available for completed PipelineRuns. Running PipelineRuns do not 
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -47,10 +39,6 @@ Logs are only available for completed PipelineRuns. Running PipelineRuns do not 
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -65,24 +53,8 @@ Logs are only available for completed PipelineRuns. Running PipelineRuns do not 
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-pipelinerun.1
+++ b/docs/man/man1/tkn-results-pipelinerun.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-pipelinerun - Query PipelineRuns
@@ -65,35 +65,6 @@ Examples:
 .PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-
-.SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
-
-.PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-results-taskrun-describe.1
+++ b/docs/man/man1/tkn-results-taskrun-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-taskrun-describe - Describe a TaskRun
@@ -27,16 +27,8 @@ Describe a TaskRun by name or UID. If --uid is provided, then TaskRun name is op
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -45,10 +37,6 @@ Describe a TaskRun by name or UID. If --uid is provided, then TaskRun name is op
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -63,24 +51,8 @@ Describe a TaskRun by name or UID. If --uid is provided, then TaskRun name is op
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-taskrun-list.1
+++ b/docs/man/man1/tkn-results-taskrun-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-taskrun-list - List TaskRuns in a namespace
@@ -39,16 +39,8 @@ List TaskRuns in a namespace
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -57,10 +49,6 @@ List TaskRuns in a namespace
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -75,24 +63,8 @@ List TaskRuns in a namespace
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-taskrun-logs.1
+++ b/docs/man/man1/tkn-results-taskrun-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-taskrun-logs - Get logs for a TaskRun
@@ -28,16 +28,8 @@ Logs are only available for completed TaskRuns. Running TaskRuns do not have log
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
 \fB--api-path\fP=""
 	api path to use (default: value provided in config set command)
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
 
 .PP
 \fB-c\fP, \fB--context\fP=""
@@ -46,10 +38,6 @@ Logs are only available for completed TaskRuns. Running TaskRuns do not have log
 .PP
 \fB--host\fP=""
 	host to use (default: value provided in config set command)
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
 
 .PP
 \fB--insecure-skip-tls-verify\fP[=false]
@@ -64,24 +52,8 @@ Logs are only available for completed TaskRuns. Running TaskRuns do not have log
 	namespace to use (default: from $KUBECONFIG)
 
 .PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH EXAMPLE

--- a/docs/man/man1/tkn-results-taskrun.1
+++ b/docs/man/man1/tkn-results-taskrun.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results-taskrun - Query TaskRuns
@@ -65,35 +65,6 @@ Examples:
 .PP
 \fB--token\fP=""
 	bearer token to use (default: value provided in config set command)
-
-
-.SH OPTIONS INHERITED FROM PARENT COMMANDS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
-
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
-
-.PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
 
 
 .SH SEE ALSO

--- a/docs/man/man1/tkn-results.1
+++ b/docs/man/man1/tkn-results.1
@@ -1,5 +1,5 @@
 .nh
-.TH "TKN-RESULTS" "1" "Aug 2025" "Tekton Results CLI" ""
+.TH "TKN-RESULTS" "1" "Apr 2026" "Tekton Results CLI" ""
 
 .SH NAME
 tkn-results - Tekton Results CLI
@@ -29,37 +29,9 @@ The following commands are supported:
 
 
 .SH OPTIONS
-\fB-a\fP, \fB--addr\fP=""
-	[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically
-
-.PP
-\fB-t\fP, \fB--authtoken\fP=""
-	[To be deprecated] authorization bearer token to use for authenticated requests
-
-.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for tkn-results
 
-.PP
-\fB--insecure\fP[=false]
-	[To be deprecated] determines whether to run insecure GRPC tls request
-
-.PP
-\fB--portforward\fP[=true]
-	[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically
-
-.PP
-\fB--sa\fP=""
-	[To be deprecated] ServiceAccount to use instead of token for authorization and authentication
-
-.PP
-\fB--sa-ns\fP=""
-	[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context
-
-.PP
-\fB--v1alpha2\fP[=false]
-	[To be deprecated] use v1alpha2 API for get log command
-
 
 .SH SEE ALSO
-\fBtkn-results-config(1)\fP, \fBtkn-results-logs(1)\fP, \fBtkn-results-pipelinerun(1)\fP, \fBtkn-results-records(1)\fP, \fBtkn-results-result(1)\fP, \fBtkn-results-taskrun(1)\fP
+\fBtkn-results-config(1)\fP, \fBtkn-results-pipelinerun(1)\fP, \fBtkn-results-taskrun(1)\fP

--- a/pkg/cli/cmd/root.go
+++ b/pkg/cli/cmd/root.go
@@ -59,13 +59,20 @@ func Root(p common.Params) *cobra.Command {
 		},
 	}
 
-	c.PersistentFlags().StringP("addr", "a", "", "[To be deprecated] Result API server address. If not specified, tkn-result would port-forward to service/tekton-results-api-service automatically")
-	c.PersistentFlags().StringP("authtoken", "t", "", "[To be deprecated] authorization bearer token to use for authenticated requests")
-	c.PersistentFlags().String("sa", "", "[To be deprecated] ServiceAccount to use instead of token for authorization and authentication")
-	c.PersistentFlags().String("sa-ns", "", "[To be deprecated] ServiceAccount Namespace, if not given, it will be taken from current context")
-	c.PersistentFlags().Bool("portforward", true, "[To be deprecated] enable auto portforwarding to tekton-results-api-service, when addr is set and portforward is true, tkn-results will portforward tekton-results-api-service automatically")
-	c.PersistentFlags().Bool("insecure", false, "[To be deprecated] determines whether to run insecure GRPC tls request")
-	c.PersistentFlags().Bool("v1alpha2", false, "[To be deprecated] use v1alpha2 API for get log command")
+	c.PersistentFlags().StringP("addr", "a", "", "[DEPRECATED] Result API server address. Use 'config set --host=<host>' instead")
+	_ = c.PersistentFlags().MarkDeprecated("addr", "use 'config set --host=<host>' to configure the API server address")
+	c.PersistentFlags().StringP("authtoken", "t", "", "[DEPRECATED] authorization bearer token. Use 'config set --token=<token>' instead")
+	_ = c.PersistentFlags().MarkDeprecated("authtoken", "use 'config set --token=<token>' to configure authentication")
+	c.PersistentFlags().String("sa", "", "[DEPRECATED] ServiceAccount for authorization. Use 'config set' instead")
+	_ = c.PersistentFlags().MarkDeprecated("sa", "use 'config set' for service account-based authentication")
+	c.PersistentFlags().String("sa-ns", "", "[DEPRECATED] ServiceAccount Namespace. Use 'config set' instead")
+	_ = c.PersistentFlags().MarkDeprecated("sa-ns", "use 'config set' for service account configuration")
+	c.PersistentFlags().Bool("portforward", true, "[DEPRECATED] enable auto portforwarding. Use 'config set' instead")
+	_ = c.PersistentFlags().MarkDeprecated("portforward", "use 'config set' to configure portforwarding behavior")
+	c.PersistentFlags().Bool("insecure", false, "[DEPRECATED] determines whether to run insecure GRPC tls request. Use 'config set' instead")
+	_ = c.PersistentFlags().MarkDeprecated("insecure", "use 'config set --insecure' to configure TLS settings")
+	c.PersistentFlags().Bool("v1alpha2", false, "[DEPRECATED] use v1alpha2 API. This flag is no longer needed")
+	_ = c.PersistentFlags().MarkDeprecated("v1alpha2", "v1alpha2 API support has been deprecated and this flag has no effect")
 
 	c.AddCommand(
 		// Commands to be deprecated

--- a/pkg/cli/dev/cmd/logs/get.go
+++ b/pkg/cli/dev/cmd/logs/get.go
@@ -40,10 +40,10 @@ func GetLogCommand(params *flags.Params) *cobra.Command {
 	opts := &flags.GetOptions{}
 
 	cmd := &cobra.Command{
-		Use: "get [flags] <log-name>",
-
-		Short: "[To be deprecated] Get Log by <log-name>",
-		Long:  "Get Log by <log-name>. <log-name> is typically of format <namespace>/results/<parent-run-uuid>/logs/<child-run-uuid>",
+		Use:        "get [flags] <log-name>",
+		Short:      "[DEPRECATED] Get Log by <log-name>",
+		Deprecated: "use 'pipelinerun logs' or 'taskrun logs' to retrieve logs",
+		Long:       "Get Log by <log-name>. <log-name> is typically of format <namespace>/results/<parent-run-uuid>/logs/<child-run-uuid>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resp grpc.ServerStreamingClient[httpbody.HttpBody]
 			var err error

--- a/pkg/cli/dev/cmd/logs/list.go
+++ b/pkg/cli/dev/cmd/logs/list.go
@@ -30,9 +30,10 @@ func ListLogsCommand(params *flags.Params) *cobra.Command {
 	opts := &flags.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "list [flags] <result-name>",
-		Short: "[To be deprecated] List Logs for a given Result",
-		Long:  "List Logs for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of <parent-run-uuid> to query all Logs for a given parent.",
+		Use:        "list [flags] <result-name>",
+		Short:      "[DEPRECATED] List Logs for a given Result",
+		Deprecated: "use 'pipelinerun logs' or 'taskrun logs' to retrieve logs",
+		Long:       "List Logs for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of <parent-run-uuid> to query all Logs for a given parent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := params.LogsClient.ListLogs(cmd.Context(), &pb.ListRecordsRequest{
 				Parent:    args[0],

--- a/pkg/cli/dev/cmd/logs/logs.go
+++ b/pkg/cli/dev/cmd/logs/logs.go
@@ -22,8 +22,9 @@ import (
 // Command returns a cobra command for `logs` sub commands
 func Command(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "logs",
-		Short: "[To be deprecated] Commands for finding and retrieving logs",
+		Use:        "logs [command]",
+		Short:      "[DEPRECATED] Commands for finding and retrieving logs",
+		Deprecated: "use 'pipelinerun logs' or 'taskrun logs' commands to retrieve logs",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cli/dev/cmd/records/get.go
+++ b/pkg/cli/dev/cmd/records/get.go
@@ -30,9 +30,10 @@ func GetRecordCommand(params *flags.Params) *cobra.Command {
 	opts := &flags.GetOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "get [flags] <record-name>",
-		Short: "[To be deprecated] Get Record by <record-name>",
-		Long:  "Get Record by <record-name>. <record-name> is typically of format <namespace>/results/<parent-run-uuid>/records/<child-run-uuid>",
+		Use:        "get [flags] <record-name>",
+		Short:      "[DEPRECATED] Get Record by <record-name>",
+		Deprecated: "use 'pipelinerun describe' or 'taskrun describe' to get detailed information about PipelineRuns and TaskRuns",
+		Long:       "Get Record by <record-name>. <record-name> is typically of format <namespace>/results/<parent-run-uuid>/records/<child-run-uuid>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := params.ResultsClient.GetRecord(cmd.Context(), &pb.GetRecordRequest{
 				Name: args[0],

--- a/pkg/cli/dev/cmd/records/list.go
+++ b/pkg/cli/dev/cmd/records/list.go
@@ -16,9 +16,10 @@ func ListRecordsCommand(params *flags.Params) *cobra.Command {
 	opts := &flags.ListOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "list [flags] <result-name>",
-		Short: "[To be deprecated] List Records for a given Result",
-		Long:  "List Records for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of  <parent-run-uuid> to query all Records for a given parent.",
+		Use:        "list [flags] <result-name>",
+		Short:      "[DEPRECATED] List Records for a given Result",
+		Deprecated: "use 'pipelinerun list' or 'taskrun list' to list PipelineRuns and TaskRuns",
+		Long:       "List Records for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of  <parent-run-uuid> to query all Records for a given parent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp, err := params.ResultsClient.ListRecords(cmd.Context(), &pb.ListRecordsRequest{
 				Parent:    args[0],

--- a/pkg/cli/dev/cmd/records/records.go
+++ b/pkg/cli/dev/cmd/records/records.go
@@ -8,8 +8,9 @@ import (
 // Command returns a cobra command for `records` sub commands
 func Command(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "records",
-		Short: "[To be deprecated] Command sub-group for querying Records",
+		Use:        "records [command]",
+		Short:      "[DEPRECATED] Command sub-group for querying Records",
+		Deprecated: "use 'pipelinerun' or 'taskrun' commands to query PipelineRuns and TaskRuns",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},

--- a/pkg/cli/dev/cmd/result/describe.go
+++ b/pkg/cli/dev/cmd/result/describe.go
@@ -54,9 +54,10 @@ Query by parent and uid:
 tkn-results result desc --parent default --uid 949eebd9-1cf7-478f-a547-9ee313035f10
 `
 	cmd := &cobra.Command{
-		Use:     "describe [-p parent -u uid] [name]",
-		Aliases: []string{"desc"},
-		Short:   "[To be deprecated] Describes a Result",
+		Use:        "describe [-p parent -u uid] [name]",
+		Aliases:    []string{"desc"},
+		Short:      "[DEPRECATED] Describes a Result",
+		Deprecated: "use 'pipelinerun describe' or 'taskrun describe' to get detailed information about PipelineRuns and TaskRuns",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
@@ -90,8 +91,10 @@ tkn-results result desc --parent default --uid 949eebd9-1cf7-478f-a547-9ee313035
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Parent, "parent", "p", "", "[To be deprecated] parent of the result")
-	cmd.Flags().StringVarP(&opts.UID, "uid", "u", "", "[To be deprecated] uid of the result")
+	cmd.Flags().StringVarP(&opts.Parent, "parent", "p", "", "[DEPRECATED] parent of the result")
+	_ = cmd.Flags().MarkDeprecated("parent", "use 'pipelinerun describe' or 'taskrun describe' instead")
+	cmd.Flags().StringVarP(&opts.UID, "uid", "u", "", "[DEPRECATED] uid of the result")
+	_ = cmd.Flags().MarkDeprecated("uid", "use 'pipelinerun describe' or 'taskrun describe' instead")
 	return cmd
 }
 

--- a/pkg/cli/dev/cmd/result/describe_test.go
+++ b/pkg/cli/dev/cmd/result/describe_test.go
@@ -52,7 +52,8 @@ func TestDescribeResult(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	test.AssertOutput(t, `Name:   default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7
+	test.AssertOutput(t, `Command "describe" is deprecated, use 'pipelinerun describe' or 'taskrun describe' to get detailed information about PipelineRuns and TaskRuns
+Name:   default/results/e6b4b2e3-d876-4bbe-a927-95c691b6fdc7
 UID:    949eebd9-1cf7-478f-a547-9ee313035f10
 Annotations:
 	object.metadata.name=hello-goodbye-run-vfsxn

--- a/pkg/cli/dev/cmd/result/list.go
+++ b/pkg/cli/dev/cmd/result/list.go
@@ -19,7 +19,8 @@ func ListCommand(params *flags.Params) *cobra.Command {
 		Use: `list [flags] <parent>
 
   <parent>: Parent name to query. This is typically corresponds to a namespace, but may vary depending on the API Server. "-" may be used to query all parents. This will list results for namespaces the token has access to`,
-		Short: "[To be deprecated] List Results",
+		Short:      "[DEPRECATED] List Results",
+		Deprecated: "use 'pipelinerun list' or 'taskrun list' to list PipelineRuns and TaskRuns",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parent := args[0]
 			resp, err := params.ResultsClient.ListResults(cmd.Context(), &pb.ListResultsRequest{

--- a/pkg/cli/dev/cmd/result/result.go
+++ b/pkg/cli/dev/cmd/result/result.go
@@ -8,9 +8,10 @@ import (
 // Command initializes a cobra command for `pipelinerun` sub commands
 func Command(params *flags.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "result",
-		Aliases: []string{"r", "results"},
-		Short:   "[To be deprecated] Query Results",
+		Use:        "result [command]",
+		Aliases:    []string{"r", "results"},
+		Short:      "[DEPRECATED] Query Results",
+		Deprecated: "use 'pipelinerun' or 'taskrun' commands to query PipelineRuns and TaskRuns",
 		Annotations: map[string]string{
 			"commandType": "main",
 		},


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Deprecate old CLI commands (result, records, logs) and their flags in favor of new pipelinerun and taskrun commands. Users will see deprecation warnings with clear migration paths.

Deprecated commands:
- result → use pipelinerun/taskrun
- records → use pipelinerun/taskrun
- logs → use pipelinerun logs/taskrun logs

Deprecated flags:
- --addr → use 'config set --host=<host>'
- --authtoken → use 'config set --token=<token>'
- --sa, --sa-ns → use 'config set'
- --portforward → use 'config set'
- --insecure → use 'config set --insecure'
- --v1alpha2 → no longer needed

All deprecated items display user-friendly messages directing to the replacement commands.


<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required: DEPRECATION: Legacy CLI commands (result, records, logs) and global flags (--addr, --authtoken, --sa, etc.) are deprecated; use pipelinerun/taskrun commands and config set for configuration instead.
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
