### PR TITLE
fix(CLI): use ListRecords for old CLI log listing

### DIFF
--- a/cmd/tkn-results/main.go
+++ b/cmd/tkn-results/main.go
@@ -1,21 +1,33 @@
-// Package main provides the entry point for the tkn-results CLI.
+// Copyright 2026 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command tkn-results is the Tekton Results CLI entrypoint.
 package main
 
 import (
-	"context"
+	"fmt"
 	"os"
 
-	"github.com/tektoncd/results/pkg/cli/common"
-
 	"github.com/tektoncd/results/pkg/cli/cmd"
+	"github.com/tektoncd/results/pkg/cli/common"
 )
 
-// Creates a new ResultsParams struct.
-// Executes the root command with the ResultsParams and a background context.
 func main() {
-	tp := &common.ResultsParams{}
-	err := cmd.Root(tp).ExecuteContext(context.Background())
-	if err != nil {
+	p := &common.ResultsParams{}
+	root := cmd.Root(p)
+	if err := root.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cli/dev/cmd/logs/list.go
+++ b/pkg/cli/dev/cmd/logs/list.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/log"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/record"
+	"github.com/tektoncd/results/pkg/api/server/v1alpha2/result"
 	"github.com/tektoncd/results/pkg/cli/dev/flags"
 	"github.com/tektoncd/results/pkg/cli/dev/format"
 
@@ -34,16 +37,19 @@ func ListLogsCommand(params *flags.Params) *cobra.Command {
 		Short: "[To be deprecated] List Logs for a given Result",
 		Long:  "List Logs for a given Result. <result-name> is typically of format <namespace>/results/<parent-run-uuid>. '-' may be used in place of <parent-run-uuid> to query all Logs for a given parent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resp, err := params.LogsClient.ListLogs(cmd.Context(), &pb.ListRecordsRequest{
+			// Use Results.ListRecords (not Logs.ListLogs): many deployments omit tekton.results.v1alpha2.Logs.
+			req := &pb.ListRecordsRequest{
 				Parent:    args[0],
-				Filter:    opts.Filter,
+				Filter:    buildLogListFilter(opts.Filter),
 				PageSize:  opts.Limit,
 				PageToken: opts.PageToken,
-			})
+			}
+			resp, err := params.ResultsClient.ListRecords(cmd.Context(), req)
 			if err != nil {
 				fmt.Printf("List Logs: %v\n", err)
 				return err
 			}
+			rewriteLogRecordNames(resp.Records)
 			return format.PrintProto(os.Stdout, resp, opts.Format)
 		},
 		Args: cobra.ExactArgs(1),
@@ -61,4 +67,32 @@ func ListLogsCommand(params *flags.Params) *cobra.Command {
 	flags.AddListFlags(opts, cmd)
 
 	return cmd
+}
+
+// buildLogListFilter restricts ListRecords to Log record types; optional user CEL is AND-combined.
+func buildLogListFilter(user string) string {
+	const logTypes = `(data_type == "results.tekton.dev/v1alpha3.Log" || data_type == "results.tekton.dev/v1alpha2.Log")`
+	if user == "" {
+		return logTypes
+	}
+	return fmt.Sprintf("(%s) && %s", user, logTypes)
+}
+
+func rewriteLogRecordNames(records []*pb.Record) {
+	var skippedCount int
+	for _, api := range records {
+		if api == nil {
+			continue
+		}
+		parent, resultName, recordName, err := record.ParseName(api.Name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: skipping record with invalid name %q: %v\n", api.Name, err)
+			skippedCount++
+			continue
+		}
+		api.Name = log.FormatName(result.FormatName(parent, resultName), recordName)
+	}
+	if skippedCount > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: skipped %d record(s) due to parse errors\n", skippedCount)
+	}
 }

--- a/pkg/cli/dev/cmd/logs/list_test.go
+++ b/pkg/cli/dev/cmd/logs/list_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+)
+
+func TestBuildLogListFilter(t *testing.T) {
+	const wantBase = `(data_type == "results.tekton.dev/v1alpha3.Log" || data_type == "results.tekton.dev/v1alpha2.Log")`
+	for _, tc := range []struct {
+		user string
+		want string
+	}{
+		{"", wantBase},
+		{`data.spec.resource.kind=TaskRun`, `(data.spec.resource.kind=TaskRun) && ` + wantBase},
+	} {
+		got := buildLogListFilter(tc.user)
+		if diff := cmp.Diff(tc.want, got); diff != "" {
+			t.Errorf("buildLogListFilter(%q) diff (-want +got):\n%s", tc.user, diff)
+		}
+	}
+}
+
+func TestRewriteLogRecordNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []*pb.Record
+		want    []string
+	}{
+		{
+			name:    "single valid record",
+			records: []*pb.Record{{Name: "ns/results/res-1/records/rec-log"}},
+			want:    []string{"ns/results/res-1/logs/rec-log"},
+		},
+		{
+			name: "multiple valid records",
+			records: []*pb.Record{
+				{Name: "ns/results/res-1/records/rec-log-1"},
+				{Name: "ns/results/res-2/records/rec-log-2"},
+				{Name: "ns/results/res-3/records/rec-log-3"},
+			},
+			want: []string{
+				"ns/results/res-1/logs/rec-log-1",
+				"ns/results/res-2/logs/rec-log-2",
+				"ns/results/res-3/logs/rec-log-3",
+			},
+		},
+		{
+			name: "mix of valid and invalid names",
+			records: []*pb.Record{
+				{Name: "ns/results/res-1/records/rec-log-1"},
+				{Name: "invalid-name"},
+				{Name: "ns/results/res-2/records/rec-log-2"},
+				{Name: ""},
+				{Name: "ns/results/res-3/records/rec-log-3"},
+			},
+			want: []string{
+				"ns/results/res-1/logs/rec-log-1",
+				"invalid-name", // unchanged
+				"ns/results/res-2/logs/rec-log-2",
+				"", // unchanged
+				"ns/results/res-3/logs/rec-log-3",
+			},
+		},
+		{
+			name:    "nil record in list",
+			records: []*pb.Record{{Name: "ns/results/res-1/records/rec-log"}, nil, {Name: "ns/results/res-2/records/rec-log-2"}},
+			want:    []string{"ns/results/res-1/logs/rec-log", "", "ns/results/res-2/logs/rec-log-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewriteLogRecordNames(tt.records)
+
+			for i, record := range tt.records {
+				if record == nil {
+					continue
+				}
+				if record.Name != tt.want[i] {
+					t.Errorf("record[%d].Name = %q, want %q", i, record.Name, tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The `logs list` command in the old CLI fails with `unknown service tekton.results.v1alpha2.Logs` because many
deployments do not register the v1alpha2 Logs gRPC service. When LOGS_API is disabled (default) or a log plugin is active (e.g. S3/GCS/Loki), only v1alpha3 Logs (GetLog) or no Logs service is exposed, causing the ListLogs RPC to fail.
Fix by switching to Results.ListRecords with a CEL filter for log record types (v1alpha2.Log and v1alpha3.Log). Record names are rewritten from records/ to logs/ format to preserve output compatibility. This avoids depending on the optional Logs gRPC service entirely. Also clean up cmd/tkn-results/main.go formatting and add
unit tests for the new helper functions.

Signed-off-by: divyansh42 <diagrawa@redhat.com>
Assisted-by: Claude Opus 4 (via Claude Code)

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix `logs list` command failing with "unknown service tekton.results.v1alpha2.Logs" on deployments where the Logs gRPC service is not registered.
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:


-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
