### PR TITLE
fix(CLI): trim whitespace from host, token, and API path inputs

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/tektoncd/results/pkg/cli/client"
@@ -255,6 +256,7 @@ func (c *config) Set(prompt bool, p common.Params) error {
 		if err := c.Prompt("Host", &c.Extension.Host, host); err != nil {
 			return err
 		}
+		c.Extension.Host = strings.TrimSpace(c.Extension.Host)
 
 		token := c.Token()
 		if err, ok := token.(error); ok {
@@ -263,22 +265,26 @@ func (c *config) Set(prompt bool, p common.Params) error {
 		if err := c.Prompt("Token", &c.Extension.Token, token); err != nil {
 			return err
 		}
+		c.Extension.Token = strings.TrimSpace(c.Extension.Token)
 
 		if err := c.Prompt("API Path", &c.Extension.APIPath, ""); err != nil {
 			return err
 		}
+		c.Extension.APIPath = strings.TrimSpace(c.Extension.APIPath)
+
 		if err := c.Prompt("Insecure Skip TLS Verify", &c.Extension.InsecureSkipTLSVerify, []string{"false", "true"}); err != nil {
 			return err
 		}
+		c.Extension.InsecureSkipTLSVerify = strings.TrimSpace(c.Extension.InsecureSkipTLSVerify)
 	} else {
 		if p.Host() != "" {
-			c.Extension.Host = p.Host()
+			c.Extension.Host = strings.TrimSpace(p.Host())
 		}
 		if p.Token() != "" {
-			c.Extension.Token = p.Token()
+			c.Extension.Token = strings.TrimSpace(p.Token())
 		}
 		if p.APIPath() != "" {
-			c.Extension.APIPath = p.APIPath()
+			c.Extension.APIPath = strings.TrimSpace(p.APIPath())
 		}
 		if p.SkipTLSVerify() {
 			c.Extension.InsecureSkipTLSVerify = strconv.FormatBool(p.SkipTLSVerify())


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The change adds strings.TrimSpace() calls to clean up user input for configuration fields, preventing issues with accidental leading/trailing whitespace.

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
 Fixed CLI configuration issue where accidental whitespace in host, token, or API path inputs could cause connection failures                                                      
```

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
