### PR TITLE
plugin(logs): support time based queries for Splunk

### DIFF
--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -157,8 +157,7 @@ func (s *LogServer) getLogRequestParams(rec *db.Record) (startTime, endTime, uid
 		endTime = strconv.FormatInt(data.Status.CompletionTime.Add(s.forwarderDelayDuration).UTC().Unix(), 10)
 
 	default:
-		s.logger.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID:  %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID)
-		return "", "", "", errors.New("record type is invalid")
+		return "", "", "", fmt.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID: %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID)
 	}
 	return startTime, endTime, uidKey, nil
 }

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs.go
@@ -119,37 +119,23 @@ func (s *LogServer) GetLog(req *pb3.GetLogRequest, srv pb3.Logs_GetLogServer) er
 	return nil
 }
 
-func getLokiLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) error {
-	URL, err := url.Parse(s.config.LOGGING_PLUGIN_API_URL)
-	if err != nil {
-		s.logger.Error(err)
-		return err
-	}
-	URL.Path = path.Join(URL.Path, s.config.LOGGING_PLUGIN_PROXY_PATH, lokiQueryPath)
-
-	var startTime, endTime, uidKey string
+func (s *LogServer) getLogRequestParams(rec *db.Record) (startTime, endTime, uidKey string, err error) {
 	switch rec.Type {
 	case typePipelineRun:
 		uidKey = pipelineRunUIDKey
 		data := &pipelinev1.PipelineRun{}
 		err := json.Unmarshal(rec.Data, data)
 		if err != nil {
-			err = fmt.Errorf("failed to marshal pipelinerun data for fetching log, err: %s", err.Error())
-			s.logger.Error(err)
-			return err
+			return "", "", "", fmt.Errorf("failed to marshal pipelinerun data for fetching log, err: %w", err)
 		}
 
 		if data.Status.StartTime == nil {
-			err = errors.New("there's no startime in pipelinerun")
-			s.logger.Error(err)
-			return err
+			return "", "", "", errors.New("there's no startime in pipelinerun")
 		}
 		startTime = strconv.FormatInt(data.Status.StartTime.UTC().Unix(), 10)
 
 		if data.Status.CompletionTime == nil {
-			err = errors.New("there's no completion in pipelinerun")
-			s.logger.Error(err)
-			return err
+			return "", "", "", errors.New("there's no completion in pipelinerun")
 		}
 		endTime = strconv.FormatInt(data.Status.CompletionTime.Add(s.forwarderDelayDuration).UTC().Unix(), 10)
 
@@ -158,27 +144,37 @@ func getLokiLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) 
 		data := &pipelinev1.TaskRun{}
 		err := json.Unmarshal(rec.Data, data)
 		if err != nil {
-			err = fmt.Errorf("failed to marshal taskrun data for fetching log, err: %s", err.Error())
-			s.logger.Error(err)
-			return err
+			return "", "", "", fmt.Errorf("failed to marshal taskrun data for fetching log, err: %w", err)
 		}
 		if data.Status.StartTime == nil {
-			err = errors.New("there's no startime in taskrun")
-			s.logger.Error(err)
-			return err
+			return "", "", "", errors.New("there's no startime in taskrun")
 		}
 		startTime = strconv.FormatInt(data.Status.StartTime.UTC().Unix(), 10)
 
 		if data.Status.CompletionTime == nil {
-			err = errors.New("there's no completion in taskrun")
-			s.logger.Error(err)
-			return err
+			return "", "", "", errors.New("there's no completion in taskrun")
 		}
 		endTime = strconv.FormatInt(data.Status.CompletionTime.Add(s.forwarderDelayDuration).UTC().Unix(), 10)
 
 	default:
 		s.logger.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID:  %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID)
-		return errors.New("record type is invalid")
+		return "", "", "", errors.New("record type is invalid")
+	}
+	return startTime, endTime, uidKey, nil
+}
+
+func getLokiLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record) error {
+	URL, err := url.Parse(s.config.LOGGING_PLUGIN_API_URL)
+	if err != nil {
+		s.logger.Error(err)
+		return err
+	}
+	URL.Path = path.Join(URL.Path, s.config.LOGGING_PLUGIN_PROXY_PATH, lokiQueryPath)
+
+	startTime, endTime, uidKey, err := s.getLogRequestParams(rec)
+	if err != nil {
+		s.logger.Error(err)
+		return err
 	}
 
 	parameters := url.Values{}
@@ -536,16 +532,12 @@ func getSplunkLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record
 
 	}
 
-	var uidKey string
-	switch rec.Type {
-	case typePipelineRun:
-		uidKey = pipelineRunUIDKey
-	case typeTaskRun:
-		uidKey = taskRunUIDKey
-	default:
-		s.logger.Errorf("record type is invalid, record ID: %v, Name: %v, result Name: %v, result ID:  %v, rec Type: %v", rec.ID, rec.Name, rec.ResultName, rec.ResultID, rec.Type)
-		return errors.New("record type is invalid")
+	startTime, endTime, uidKey, err := s.getLogRequestParams(rec)
+	if err != nil {
+		s.logger.Error(err)
+		return err
 	}
+
 	index, ok := s.queryParams["index"]
 	if !ok {
 		s.logger.Errorf("index not specified in queryParams: %v\n", s.queryParams)
@@ -560,6 +552,8 @@ func getSplunkLogs(s *LogServer, writer io.Writer, parent string, rec *db.Record
 
 	queryData := url.Values{}
 	queryData.Set("search", query)
+	queryData.Set("earliest_time", startTime)
+	queryData.Set("latest_time", endTime)
 
 	req, err := http.NewRequest("POST", URL.String()+splunkOutputFormat, bytes.NewReader([]byte(queryData.Encode())))
 	if err != nil {

--- a/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
+++ b/pkg/api/server/v1alpha2/plugin/plugin_logs_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -254,6 +255,7 @@ func TestMergeLogParts(t *testing.T) {
 }
 
 func TestSplunkLogs(t *testing.T) {
+	var gotEarliestTime, gotLatestTime string
 
 	mockSplunk := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Log the received request for debugging
@@ -263,6 +265,9 @@ func TestSplunkLogs(t *testing.T) {
 		// Verify the request path and query parameters
 		switch r.URL.Path {
 		case "/services/search/v2/jobs":
+			r.ParseForm()
+			gotEarliestTime = r.FormValue("earliest_time")
+			gotLatestTime = r.FormValue("latest_time")
 			w.WriteHeader(http.StatusCreated)
 			w.Write(json.RawMessage(`{"sid":"1234567"}`))
 			return
@@ -338,6 +343,9 @@ func TestSplunkLogs(t *testing.T) {
 		t.Fatalf("CreateResult: %v", err)
 	}
 
+	startTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	completionTime := time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC)
+
 	_, err = srv.CreateRecord(ctx, &pb.CreateRecordRequest{
 		Parent: res.GetName(),
 		Record: &pb.Record{
@@ -351,10 +359,10 @@ func TestSplunkLogs(t *testing.T) {
 					Status: pipelinev1.TaskRunStatus{
 						TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
 							StartTime: &metav1.Time{
-								Time: time.Now().Add(-time.Hour),
+								Time: startTime,
 							},
 							CompletionTime: &metav1.Time{
-								Time: time.Now(),
+								Time: completionTime,
 							},
 						},
 					},
@@ -389,6 +397,14 @@ func TestSplunkLogs(t *testing.T) {
 		t.Errorf("expected to have received %q, got %q", expectedData, actualData)
 	}
 
+	wantEarliestTime := strconv.FormatInt(startTime.Unix(), 10)
+	wantLatestTime := strconv.FormatInt(completionTime.Unix(), 10)
+	if gotEarliestTime != wantEarliestTime {
+		t.Errorf("earliest_time = %q, want %q", gotEarliestTime, wantEarliestTime)
+	}
+	if gotLatestTime != wantLatestTime {
+		t.Errorf("latest_time = %q, want %q", gotLatestTime, wantLatestTime)
+	}
 }
 
 func TestGetLokiLogs_BuildsQueryWithConfiguredJSONMappingAndLineFormat(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* PR concept change:
    * with the request to split the PR into it's functions, `time based queries` and custom `UIDKeyEnv` the documentation changes accordingly `startTime and endTime for Splunk queries`
    * the second [PR](https://github.com/tektoncd/results/pull/1362) tackles the variable resolution for UIDkeys on `pipelineRunUIDKeyEnv, taskRunUIDKeyEnv`
    * this PR now focuses on 

# Release Notes

Splunk queries do now contain `startTime` and `endTime` to limit the range result returned by Splunk.
The default values are taken from the stored Results record.


For pull requests with a release note:

```release-note
* Implements https://github.com/tektoncd/results/issues/1179 
* reduces the load to Splunk servers by limiting the search window with start/endTime
```

# additional note for reviewers

Since I am not the best at writing go code, the code snippets are AI powered. I reviewed them and they seem to be adequate. 
