### PR TITLE
Enable Server-Side Apply for finalizers management

### DIFF
--- a/pkg/watcher/reconciler/customrun/controller.go
+++ b/pkg/watcher/reconciler/customrun/controller.go
@@ -66,9 +66,11 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 	impl := customrunreconciler.NewImpl(ctx, c, func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			// This results customrun reconciler shouldn't mutate the customrun's status.
-			SkipStatusUpdates: true,
-			ConfigStore:       configStore,
-			FinalizerName:     "results.tekton.dev/customrun",
+			SkipStatusUpdates:               true,
+			ConfigStore:                     configStore,
+			FinalizerName:                   "results.tekton.dev/customrun",
+			UseServerSideApplyForFinalizers: true,
+			FinalizerFieldManager:           "tekton-results-watcher/finalizers",
 		}
 	})
 

--- a/pkg/watcher/reconciler/customrun/reconciler.go
+++ b/pkg/watcher/reconciler/customrun/reconciler.go
@@ -17,7 +17,9 @@ limitations under the License.
 package customrun
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -37,6 +39,8 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -123,7 +127,27 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, cr *pipelinev1beta1.Custo
 	return r.finalize(ctx, cr, rerr)
 }
 
-func (r *Reconciler) finalize(ctx context.Context, cr *pipelinev1beta1.CustomRun, rerr error) knativereconciler.Event {
+func (r *Reconciler) finalize(ctx context.Context, cr *pipelinev1beta1.CustomRun, rerr error) (result knativereconciler.Event) {
+	// MIGRATION: When finalize decides to allow deletion (returns nil), check if the
+	// finalizer was added via merge patch by the old controller version. SSA cannot
+	// remove finalizers it doesn't own, so we remove it via merge patch ourselves.
+	// This can be removed once all pre-SSA resources are deleted.
+	defer func() {
+		if result != nil {
+			return
+		}
+		if !r.isFinalizerOwnedByMergePatch(cr) {
+			return
+		}
+		logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration",
+			cr.Namespace, cr.Name)
+		if err := r.removeFinalizerViaMergePatch(ctx, cr); err != nil {
+			logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+				zap.Error(err))
+			result = controller.NewRequeueAfter(r.cfg.FinalizerRequeueInterval)
+		}
+	}()
+
 	// If annotation update is disabled, we can't use finalizers to coordinate deletion.
 	if r.cfg.DisableAnnotationUpdate {
 		return nil
@@ -185,4 +209,60 @@ func (r *Reconciler) finalize(ctx context.Context, cr *pipelinev1beta1.CustomRun
 	}
 
 	return nil
+}
+
+// isFinalizerOwnedByMergePatch checks if the finalizer was added via merge patch (Update operation).
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight CustomRuns have finalizers set via merge patch by the old controller version.
+// Kubernetes SSA treats (manager, Update) and (manager, Apply) as different owners, so we need
+// to detect and handle the old ownership pattern.
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) isFinalizerOwnedByMergePatch(cr *pipelinev1beta1.CustomRun) bool {
+	for _, mf := range cr.ManagedFields {
+		// Check if this is from the old merge patch operation
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate {
+			// Parse FieldsV1 to check if it owns the finalizers field
+			// FieldsV1 is a JSON structure, we need to check if it contains f:metadata.f:finalizers
+			if mf.FieldsV1 != nil && mf.FieldsV1.Raw != nil {
+				// Check if this managed field entry owns finalizers AND specifically our finalizer
+				if bytes.Contains(mf.FieldsV1.Raw, []byte(`"f:finalizers"`)) &&
+					bytes.Contains(mf.FieldsV1.Raw, []byte(`v:\"results.tekton.dev/customrun\"`)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// removeFinalizerViaMergePatch removes the finalizer using merge patch.
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight CustomRuns have finalizers set via merge patch by the old controller version.
+// This uses merge patch to remove finalizers that cannot be removed via SSA due to different
+// ownership (manager, Update) vs (manager, Apply).
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, cr *pipelinev1beta1.CustomRun) error {
+	// Remove our finalizer from the list
+	var newFinalizers []string
+	for _, f := range cr.Finalizers {
+		if f != "results.tekton.dev/customrun" {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+
+	mergePatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers":      newFinalizers,
+			"resourceVersion": cr.ResourceVersion,
+		},
+	}
+
+	patch, err := json.Marshal(mergePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.pipelineClient.TektonV1beta1().CustomRuns(cr.Namespace).Patch(
+		ctx, cr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/watcher/reconciler/customrun/reconciler_test.go
+++ b/pkg/watcher/reconciler/customrun/reconciler_test.go
@@ -16,16 +16,23 @@ package customrun
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakeversioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	resultsannotation "github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	apis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	knativereconciler "knative.dev/pkg/reconciler"
 )
@@ -97,6 +104,149 @@ func TestReconcile(t *testing.T) {
 			got := r.ReconcileKind(ctx, tc.cr)
 			if got != tc.want {
 				t.Errorf("ReconcileKind() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func mergePatchFinalizerManagedFields(finalizerName string) []metav1.ManagedFieldsEntry {
+	raw := fmt.Sprintf(`{"f:metadata":{"f:finalizers":{".":{},"v:\"%s\"":{}}}}`, finalizerName)
+	return []metav1.ManagedFieldsEntry{{
+		Operation: metav1.ManagedFieldsOperationUpdate,
+		FieldsV1:  &metav1.FieldsV1{Raw: []byte(raw)},
+	}}
+}
+
+func TestFinalize(t *testing.T) {
+	storeDeadline := time.Hour
+	finalizerRequeueInterval := time.Second
+
+	cfg := &reconciler.Config{
+		StoreDeadline:            &storeDeadline,
+		FinalizerRequeueInterval: finalizerRequeueInterval,
+	}
+
+	for _, tc := range []struct {
+		name           string
+		cr             *pipelinev1beta1.CustomRun
+		cfg            *reconciler.Config
+		reconcileError knativereconciler.Event
+		patchErr       error
+		want           knativereconciler.Event
+	}{
+		{
+			name: "migration: merge-patch finalizer removed successfully",
+			cr: &pipelinev1beta1.CustomRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/customrun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/customrun"),
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:  cfg,
+			want: nil,
+		},
+		{
+			name: "migration: merge-patch removal fails - requeue",
+			cr: &pipelinev1beta1.CustomRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/customrun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/customrun"),
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:      cfg,
+			patchErr: fmt.Errorf("connection refused"),
+			want:     controller.NewRequeueAfter(finalizerRequeueInterval),
+		},
+		{
+			name: "no migration: finalizer owned by SSA - no patch needed",
+			cr: &pipelinev1beta1.CustomRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/customrun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{{
+						Operation: metav1.ManagedFieldsOperationApply,
+						FieldsV1:  &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:finalizers":{".":{},"v:\"results.tekton.dev/customrun\"":{}}}}`)},
+					}},
+				},
+				Status: pipelinev1beta1.CustomRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					CustomRunStatusFields: pipelinev1beta1.CustomRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:  cfg,
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+
+			r := &Reconciler{
+				cfg: tc.cfg,
+			}
+
+			if tc.cr.ManagedFields != nil {
+				fakeClient := fakeversioned.NewSimpleClientset(tc.cr)
+				if tc.patchErr != nil {
+					fakeClient.PrependReactor("patch", "customruns", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, tc.patchErr
+					})
+				}
+				r.pipelineClient = fakeClient
+			}
+
+			got := r.finalize(ctx, tc.cr, tc.reconcileError)
+			if !errors.Is(got, tc.want) {
+				t.Errorf("finalize() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -73,9 +73,11 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 	impl := pipelinerunreconciler.NewImpl(ctx, c, func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			// This results pipelinerun reconciler shouldn't mutate the pipelinerun's status.
-			SkipStatusUpdates: true,
-			ConfigStore:       configStore,
-			FinalizerName:     "results.tekton.dev/pipelinerun",
+			SkipStatusUpdates:               true,
+			ConfigStore:                     configStore,
+			FinalizerName:                   "results.tekton.dev/pipelinerun",
+			UseServerSideApplyForFinalizers: true,
+			FinalizerFieldManager:           "tekton-results-watcher/finalizers",
 		}
 	})
 

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -15,7 +15,9 @@
 package pipelinerun
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -37,6 +39,8 @@ import (
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -207,7 +211,27 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *pipelinev1.PipelineRu
 	return r.finalize(ctx, pr, rerr)
 }
 
-func (r *Reconciler) finalize(ctx context.Context, pr *pipelinev1.PipelineRun, rerr error) knativereconciler.Event {
+func (r *Reconciler) finalize(ctx context.Context, pr *pipelinev1.PipelineRun, rerr error) (result knativereconciler.Event) {
+	// MIGRATION: When finalize decides to allow deletion (returns nil), check if the
+	// finalizer was added via merge patch by the old controller version. SSA cannot
+	// remove finalizers it doesn't own, so we remove it via merge patch ourselves.
+	// This can be removed once all pre-SSA resources are deleted.
+	defer func() {
+		if result != nil {
+			return
+		}
+		if !r.isFinalizerOwnedByMergePatch(pr) {
+			return
+		}
+		logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration",
+			pr.Namespace, pr.Name)
+		if err := r.removeFinalizerViaMergePatch(ctx, pr); err != nil {
+			logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+				zap.Error(err))
+			result = controller.NewRequeueAfter(r.cfg.FinalizerRequeueInterval)
+		}
+	}()
+
 	// If logsClient isn't nil, it means we have logging storage enabled
 	// and we can't use finalizers to coordinate deletion.
 	if r.logsClient != nil {
@@ -274,4 +298,60 @@ func (r *Reconciler) finalize(ctx context.Context, pr *pipelinev1.PipelineRun, r
 	}
 
 	return nil
+}
+
+// isFinalizerOwnedByMergePatch checks if the finalizer was added via merge patch (Update operation).
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight PipelineRuns have finalizers set via merge patch by the old controller version.
+// Kubernetes SSA treats (manager, Update) and (manager, Apply) as different owners, so we need
+// to detect and handle the old ownership pattern.
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) isFinalizerOwnedByMergePatch(pr *pipelinev1.PipelineRun) bool {
+	for _, mf := range pr.ManagedFields {
+		// Check if this is from the old merge patch operation
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate {
+			// Parse FieldsV1 to check if it owns the finalizers field
+			// FieldsV1 is a JSON structure, we need to check if it contains f:metadata.f:finalizers
+			if mf.FieldsV1 != nil && mf.FieldsV1.Raw != nil {
+				// Check if this managed field entry owns finalizers AND specifically our finalizer
+				if bytes.Contains(mf.FieldsV1.Raw, []byte(`"f:finalizers"`)) &&
+					bytes.Contains(mf.FieldsV1.Raw, []byte(`v:\"results.tekton.dev/pipelinerun\"`)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// removeFinalizerViaMergePatch removes the finalizer using merge patch.
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight PipelineRuns have finalizers set via merge patch by the old controller version.
+// This uses merge patch to remove finalizers that cannot be removed via SSA due to different
+// ownership (manager, Update) vs (manager, Apply).
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, pr *pipelinev1.PipelineRun) error {
+	// Remove our finalizer from the list
+	var newFinalizers []string
+	for _, f := range pr.Finalizers {
+		if f != "results.tekton.dev/pipelinerun" {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+
+	mergePatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers":      newFinalizers,
+			"resourceVersion": pr.ResourceVersion,
+		},
+	}
+
+	patch, err := json.Marshal(mergePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.pipelineClient.TektonV1().PipelineRuns(pr.Namespace).Patch(
+		ctx, pr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
@@ -23,6 +23,7 @@ import (
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakeversioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	pipelinev1listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
 	pipelinev1beta1listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
@@ -31,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	apis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -231,6 +233,14 @@ func TestAreAllUnderlyingTaskRunsReadyForDeletion(t *testing.T) {
 	}
 }
 
+func mergePatchFinalizerManagedFields(finalizerName string) []metav1.ManagedFieldsEntry {
+	raw := fmt.Sprintf(`{"f:metadata":{"f:finalizers":{".":{},"v:\"%s\"":{}}}}`, finalizerName)
+	return []metav1.ManagedFieldsEntry{{
+		Operation: metav1.ManagedFieldsOperationUpdate,
+		FieldsV1:  &metav1.FieldsV1{Raw: []byte(raw)},
+	}}
+}
+
 func TestFinalize(t *testing.T) {
 	storeDeadline := time.Hour
 	finalizerRequeueInterval := time.Second
@@ -245,6 +255,7 @@ func TestFinalize(t *testing.T) {
 		pr             *pipelinev1.PipelineRun
 		cfg            *reconciler.Config
 		reconcileError knativereconciler.Event
+		patchErr       error
 		want           knativereconciler.Event
 	}{
 		{
@@ -451,6 +462,97 @@ func TestFinalize(t *testing.T) {
 			},
 			want: controller.NewRequeueAfter(finalizerRequeueInterval),
 		},
+		{
+			name: "migration: merge-patch finalizer removed successfully",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/pipelinerun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/pipelinerun"),
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:  cfg,
+			want: nil,
+		},
+		{
+			name: "migration: merge-patch removal fails - requeue",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/pipelinerun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/pipelinerun"),
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:      cfg,
+			patchErr: fmt.Errorf("connection refused"),
+			want:     controller.NewRequeueAfter(finalizerRequeueInterval),
+		},
+		{
+			name: "no migration: finalizer owned by SSA - no patch needed",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/pipelinerun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{{
+						Operation: metav1.ManagedFieldsOperationApply,
+						FieldsV1:  &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:finalizers":{".":{},"v:\"results.tekton.dev/pipelinerun\"":{}}}}`)},
+					}},
+				},
+				Status: pipelinev1.PipelineRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:  cfg,
+			want: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -458,6 +560,16 @@ func TestFinalize(t *testing.T) {
 
 			r := &Reconciler{
 				cfg: tc.cfg,
+			}
+
+			if tc.pr.ManagedFields != nil {
+				fakeClient := fakeversioned.NewSimpleClientset(tc.pr)
+				if tc.patchErr != nil {
+					fakeClient.PrependReactor("patch", "pipelineruns", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, tc.patchErr
+					})
+				}
+				r.pipelineClient = fakeClient
 			}
 
 			got := r.finalize(ctx, tc.pr, tc.reconcileError)

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -69,9 +69,11 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 	impl := taskrunreconciler.NewImpl(ctx, c, func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			// This results taskrun reconciler shouldn't mutate the taskrun's status.
-			SkipStatusUpdates: true,
-			ConfigStore:       configStore,
-			FinalizerName:     "results.tekton.dev/taskrun",
+			SkipStatusUpdates:               true,
+			ConfigStore:                     configStore,
+			FinalizerName:                   "results.tekton.dev/taskrun",
+			UseServerSideApplyForFinalizers: true,
+			FinalizerFieldManager:           "tekton-results-watcher/finalizers",
 		}
 	})
 

--- a/pkg/watcher/reconciler/taskrun/reconciler.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler.go
@@ -1,7 +1,9 @@
 package taskrun
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -21,6 +23,8 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/results"
 	pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -107,7 +111,27 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *pipelinev1.TaskRun) k
 	return r.finalize(ctx, tr, rerr)
 }
 
-func (r *Reconciler) finalize(ctx context.Context, tr *pipelinev1.TaskRun, rerr error) knativereconciler.Event {
+func (r *Reconciler) finalize(ctx context.Context, tr *pipelinev1.TaskRun, rerr error) (result knativereconciler.Event) {
+	// MIGRATION: When finalize decides to allow deletion (returns nil), check if the
+	// finalizer was added via merge patch by the old controller version. SSA cannot
+	// remove finalizers it doesn't own, so we remove it via merge patch ourselves.
+	// This can be removed once all pre-SSA resources are deleted.
+	defer func() {
+		if result != nil {
+			return
+		}
+		if !r.isFinalizerOwnedByMergePatch(tr) {
+			return
+		}
+		logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration",
+			tr.Namespace, tr.Name)
+		if err := r.removeFinalizerViaMergePatch(ctx, tr); err != nil {
+			logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+				zap.Error(err))
+			result = controller.NewRequeueAfter(r.cfg.FinalizerRequeueInterval)
+		}
+	}()
+
 	// If logsClient isn't nil, it means we have logging storage enabled
 	// and we can't use finalizers to coordinate deletion.
 	if r.logsClient != nil {
@@ -189,4 +213,60 @@ func (r *Reconciler) finalize(ctx context.Context, tr *pipelinev1.TaskRun, rerr 
 	}
 
 	return nil
+}
+
+// isFinalizerOwnedByMergePatch checks if the finalizer was added via merge patch (Update operation).
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight TaskRuns have finalizers set via merge patch by the old controller version.
+// Kubernetes SSA treats (manager, Update) and (manager, Apply) as different owners, so we need
+// to detect and handle the old ownership pattern.
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) isFinalizerOwnedByMergePatch(tr *pipelinev1.TaskRun) bool {
+	for _, mf := range tr.ManagedFields {
+		// Check if this is from the old merge patch operation
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate {
+			// Parse FieldsV1 to check if it owns the finalizers field
+			// FieldsV1 is a JSON structure, we need to check if it contains f:metadata.f:finalizers
+			if mf.FieldsV1 != nil && mf.FieldsV1.Raw != nil {
+				// Check if this managed field entry owns finalizers AND specifically our finalizer
+				if bytes.Contains(mf.FieldsV1.Raw, []byte(`"f:finalizers"`)) &&
+					bytes.Contains(mf.FieldsV1.Raw, []byte(`v:\"results.tekton.dev/taskrun\"`)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// removeFinalizerViaMergePatch removes the finalizer using merge patch.
+// MIGRATION: This is a temporary migration feature to handle the upgrade scenario where
+// in-flight TaskRuns have finalizers set via merge patch by the old controller version.
+// This uses merge patch to remove finalizers that cannot be removed via SSA due to different
+// ownership (manager, Update) vs (manager, Apply).
+// This function can be removed once all resources from the pre-SSA version are deleted.
+func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, tr *pipelinev1.TaskRun) error {
+	// Remove our finalizer from the list
+	var newFinalizers []string
+	for _, f := range tr.Finalizers {
+		if f != "results.tekton.dev/taskrun" {
+			newFinalizers = append(newFinalizers, f)
+		}
+	}
+
+	mergePatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"finalizers":      newFinalizers,
+			"resourceVersion": tr.ResourceVersion,
+		},
+	}
+
+	patch, err := json.Marshal(mergePatch)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.pipelineClient.TektonV1().TaskRuns(tr.Namespace).Patch(
+		ctx, tr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/watcher/reconciler/taskrun/reconciler_test.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler_test.go
@@ -22,11 +22,14 @@ import (
 	"time"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	fakeversioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/results/pkg/watcher/reconciler"
 	resultsannotation "github.com/tektoncd/results/pkg/watcher/reconciler/annotation"
 	"go.uber.org/zap/zaptest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	apis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
@@ -106,6 +109,14 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func mergePatchFinalizerManagedFields(finalizerName string) []metav1.ManagedFieldsEntry {
+	raw := fmt.Sprintf(`{"f:metadata":{"f:finalizers":{".":{},"v:\"%s\"":{}}}}`, finalizerName)
+	return []metav1.ManagedFieldsEntry{{
+		Operation: metav1.ManagedFieldsOperationUpdate,
+		FieldsV1:  &metav1.FieldsV1{Raw: []byte(raw)},
+	}}
+}
+
 func TestFinalize(t *testing.T) {
 	storeDeadline := time.Hour
 	finalizerRequeueInterval := time.Second
@@ -120,6 +131,7 @@ func TestFinalize(t *testing.T) {
 		pr             *pipelinev1.TaskRun
 		cfg            *reconciler.Config
 		reconcileError knativereconciler.Event
+		patchErr       error
 		want           knativereconciler.Event
 	}{
 		{
@@ -326,6 +338,97 @@ func TestFinalize(t *testing.T) {
 			},
 			want: controller.NewRequeueAfter(finalizerRequeueInterval),
 		},
+		{
+			name: "migration: merge-patch finalizer removed successfully",
+			pr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/taskrun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/taskrun"),
+				},
+				Status: pipelinev1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:  cfg,
+			want: nil,
+		},
+		{
+			name: "migration: merge-patch removal fails - requeue",
+			pr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/taskrun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/taskrun"),
+				},
+				Status: pipelinev1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:      cfg,
+			patchErr: fmt.Errorf("connection refused"),
+			want:     controller.NewRequeueAfter(finalizerRequeueInterval),
+		},
+		{
+			name: "no migration: finalizer owned by SSA - no patch needed",
+			pr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/taskrun"},
+					Annotations: map[string]string{
+						resultsannotation.Stored: "true",
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{{
+						Operation: metav1.ManagedFieldsOperationApply,
+						FieldsV1:  &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:finalizers":{".":{},"v:\"results.tekton.dev/taskrun\"":{}}}}`)},
+					}},
+				},
+				Status: pipelinev1.TaskRunStatus{
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{
+							apis.Condition{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+					TaskRunStatusFields: pipelinev1.TaskRunStatusFields{
+						CompletionTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			cfg:  cfg,
+			want: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -333,6 +436,16 @@ func TestFinalize(t *testing.T) {
 
 			r := &Reconciler{
 				cfg: tc.cfg,
+			}
+
+			if tc.pr.ManagedFields != nil {
+				fakeClient := fakeversioned.NewSimpleClientset(tc.pr)
+				if tc.patchErr != nil {
+					fakeClient.PrependReactor("patch", "taskruns", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+						return true, nil, tc.patchErr
+					})
+				}
+				r.pipelineClient = fakeClient
 			}
 
 			got := r.finalize(ctx, tc.pr, tc.reconcileError)


### PR DESCRIPTION
Leverages functionality added here:
https://github.com/knative/pkg/pull/3275
Options documented here:
https://github.com/knative/pkg/blob/main/controller/options.go#L31-L40

Added migration cleanup process, for inflight objects caught between the old version (using merge patch) and the new version (using SSA patch). It could be removed once all supported versions using merge patch become EOL. That code add minimal overhead and no extra API calls.

Assisted-by: Claude Code

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->
/kind enhancement

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
Switch finalizer management to Server-Side Apply patch to improve performance and reduce API load.
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
