### PR TITLE
Fix race condition in the TestController

### DIFF
--- a/pkg/watcher/reconciler/reconciler_test.go
+++ b/pkg/watcher/reconciler/reconciler_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/tektoncd/results/pkg/watcher/reconciler/taskrun"
 	"github.com/tektoncd/results/pkg/watcher/results"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
@@ -61,8 +62,15 @@ func TestController(t *testing.T) {
 	go controller.StartAll(ctx, trctrl, prctrl)
 
 	// Start informers - this notifies the controller of new events.
-	go taskruninformer.Get(ctx).Informer().Run(ctx.Done())
-	go pipelineruninformer.Get(ctx).Informer().Run(ctx.Done())
+	trinf := taskruninformer.Get(ctx).Informer()
+	prinf := pipelineruninformer.Get(ctx).Informer()
+	go trinf.Run(ctx.Done())
+	go prinf.Run(ctx.Done())
+
+	// Wait for informer caches to sync before creating objects.
+	if !cache.WaitForCacheSync(ctx.Done(), trinf.HasSynced, prinf.HasSynced) {
+		t.Fatal("failed to wait for caches to sync")
+	}
 
 	pipeline := fakepipelineclient.Get(ctx)
 	t.Run("taskrun", func(t *testing.T) {


### PR DESCRIPTION
With the newer Go version also came some runtime optimizations which exposed the race condition - PR and TR objects are created before the informers are synced. The issue is not affecting local execution as usually it runs faster, but is consistently seen in the upstream CI.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind flake
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
NONE
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
