### PR TITLE
chore: switch base image to ghcr.io/tektoncd/plumbing/static-base

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,3 @@
 ---
-# The default base image, cgr.dev/chainguard/static, as used in tektoncd/pipeline
-defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7
+# Static base image from tektoncd/plumbing
+defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -110,7 +110,7 @@ spec:
         cp ${PROJECT_ROOT}/.ko.yaml /workspace/.ko.yaml
       else
         echo "---" > /workspace/.ko.yaml
-        echo "defaultBaseImage: cgr.dev/chainguard/static@sha256:67a1b00e0134e2b3a614c7198a26f7deed9d11b7acad4d52c79c0cfd47a2eae7" >> /workspace/.ko.yaml
+        echo "defaultBaseImage: ghcr.io/tektoncd/plumbing/static-base@sha256:e150c89001e336b6a0200a6bac766a7b455e5573bf91c6c37f3ef8cf2fdccf0a" >> /workspace/.ko.yaml
       fi
 
       cat /workspace/.ko.yaml


### PR DESCRIPTION
# Changes

Switch `defaultBaseImage` to the Tekton-maintained static base image
(`ghcr.io/tektoncd/plumbing/static-base`), built and published from
[tektoncd/plumbing](https://github.com/tektoncd/plumbing/tree/main/tekton/images/static-base).

This image:
- Supports all four target architectures (amd64, arm64, s390x, ppc64le)
- Is rebuilt daily from Alpine packages via apko
- Includes CA certs, timezone data, and nonroot user (UID 65532)
- Is ~300KB per arch

Related: tektoncd/pipeline#9557, tektoncd/plumbing#3434

Replaces `cgr.dev/chainguard/static` in both `.ko.yaml` and `tekton/publish.yaml`.

/kind cleanup

# Submitter Checklist

- [x] Has Docs included if any changes are user facing
- [x] Has Tests included if any functionality added or changed
- [x] Tested your changes locally
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [x] Has a kind label.

# Release Notes

```release-note
NONE
```