### PR TITLE
Enable Codecov coverage reporting on push to main

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,32 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
+
+ignore:
+  # Auto-generated protobuf code.
+  - "proto/v1alpha2/results_go_proto/**"
+  - "proto/v1alpha3/results_go_proto/**"
+  - "proto/pipeline/v1/pipeline_go_proto/**"
+  - "pkg/api/server/db/pagination/proto/internal_go_proto/**"
+  - "pkg/api/server/v1alpha2/lister/proto/pagetoken_go_proto/**"
+  - "internal/fieldmask/test/**"
+  - "pkg/test/**"
+  - "cmd/**"
+  - "test/**"
+  - "config/**"
+  - "hack/**"
+  - "tools/**"
+  - "release/**"
+  - "tekton/**"
+  - "docs/**"
+  - "vendor/**"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -4,13 +4,8 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    branches: ["main"]
   push:
     branches: ["main"]
-  # run at least once every 2 months to prevent the coverage artifact from expiring
-  schedule:
-    - cron: '14 3 4 */2 *'
   workflow_dispatch:
 
 concurrency:
@@ -26,7 +21,7 @@ jobs:
     name: Go coverage
     runs-on: ubuntu-24.04
     permissions:
-      pull-requests: write
+      id-token: write
 
     steps:
       - name: Harden runner
@@ -48,20 +43,14 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
         run: |
-          go test -cover -coverprofile=coverage.txt ./... || true
+          go test ./... -coverprofile=coverage.out -covermode=atomic || true
           echo "Generated coverage profile"
 
-      - name: Archive coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
+        continue-on-error: true # job still "succeeds" even if this step fails
         with:
-          name: code-coverage
-          path: ${{ github.workspace }}/src/github.com/tektoncd/results/coverage.txt
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
-        continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
-        with:
-          token: ${{ secrets.CHATOPS_TOKEN }}
-          coverage-artifact-name: "code-coverage"
-          coverage-file-name: "coverage.txt"
+          files: ${{ github.workspace }}/src/github.com/tektoncd/results/coverage.out
+          flags: unit-tests
+          use_oidc: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Add .codecov.yaml with coverage thresholds and an ignore list for generated protobuf code and non-source directories. Update the go-coverage workflow to run only on push to main (no PR trigger or PR comments) and upload results to Codecov via OIDC.

Assisted-by: Claude (Sonnet 5)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kinf misc
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
NONE
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
