### PR TITLE
Security: Fix Go stdlib CVEs (CVE-2026-27145, CVE-2026-42504) - update Go 1.25.8 to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/results
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
# Changes

Update Go stdlib from `go 1.25.8` to `go 1.25.12` to remediate confirmed Go stdlib CVEs across the Tekton Results images:

**CVEs addressed (confirmed reachable by govulncheck):**

| CVE | Go Advisory | Severity | CVSS | Package | Fixed In |
|-----|------------|----------|------|---------|----------|
| CVE-2026-27145 | GO-2026-5037 | IMPORTANT | 7.5 | crypto/x509 | go1.25.11 |
| CVE-2026-42504 | GO-2026-5038 | IMPORTANT | 7.5 | mime | go1.25.11 |
| CVE-2026-42507 | GO-2026-5039 | MODERATE | 5.3 | net/textproto | go1.25.11 |
| GO-2026-5856 | GO-2026-5856 | HIGH | — | crypto/tls | go1.25.12 |

**Images affected:** `pipelines-results-api-rhel9`, `pipelines-results-watcher-rhel9`, `pipelines-results-retention-policy-agent-rhel9`

**Fix:** Single-line change bumping `go 1.25.8` → `go 1.25.12` in `go.mod` — the minimum safe patch in the 1.25.x line that covers all identified stdlib vulnerabilities.

**Verification:** `go mod tidy && go mod verify && go mod vendor` all passed.

**OS-level CVEs in the same Jira tickets** (CVE-2026-58016/glib2, CVE-2026-54369/libacl) are unfixable at the Go source level — those require base image rebuilds by the RedHat CVS team.

**Jira:** SRVKP-12770, SRVKP-12766, SRVKP-12752

<!-- /kind bug -->

# Submitter Checklist

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing — N/A (dependency update only)
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed — N/A (no functionality change)
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) — ✅ All 18 unit test packages passed (see below)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md)
- [x] Has a kind label — `/kind bug`
- [x] Release notes block updated below

**Test Results:**
```
ok  github.com/tektoncd/results/pkg/cli/dev/config           0.005s
ok  github.com/tektoncd/results/pkg/cli/flags                0.010s
ok  github.com/tektoncd/results/pkg/customrunmetrics         0.010s
ok  github.com/tektoncd/results/pkg/internal/protoutil       0.006s
ok  github.com/tektoncd/results/pkg/logs                     0.005s
ok  github.com/tektoncd/results/pkg/metrics                  0.011s
ok  github.com/tektoncd/results/pkg/pipelinerunmetrics       0.021s
ok  github.com/tektoncd/results/pkg/retention                0.066s
ok  github.com/tektoncd/results/pkg/taskrunmetrics           0.012s
ok  github.com/tektoncd/results/pkg/watcher/convert          0.112s
ok  github.com/tektoncd/results/pkg/watcher/reconciler       2.207s
ok  github.com/tektoncd/results/pkg/watcher/reconciler/annotation   0.075s
ok  github.com/tektoncd/results/pkg/watcher/reconciler/customrun    0.084s
ok  github.com/tektoncd/results/pkg/watcher/reconciler/dynamic      0.158s
ok  github.com/tektoncd/results/pkg/watcher/reconciler/pipelinerun  0.033s
ok  github.com/tektoncd/results/pkg/watcher/reconciler/taskrun      0.036s
ok  github.com/tektoncd/results/pkg/watcher/results          0.107s
ok  github.com/tektoncd/results/tools/postgres-migrate       0.010s [no tests to run]
```
All 18 packages: PASSED ✅

# Release Notes

```release-note
Security: update Go stdlib from 1.25.8 to 1.25.12 to address CVE-2026-27145, CVE-2026-42504, CVE-2026-42507 (crypto/x509, mime, net/textproto, crypto/tls)
```