### PR TITLE
Security: Fix GHSA-259r-337f-4rfw (klauspost/compress v1.18.7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,7 +173,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/ktr0731/go-ansisgr v0.1.0 // indirect
 	github.com/ktr0731/go-fuzzyfinder v0.9.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXw
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -817,7 +817,7 @@ github.com/kballard/go-shellquote
 # github.com/kelseyhightower/envconfig v1.4.0
 ## explicit
 github.com/kelseyhightower/envconfig
-# github.com/klauspost/compress v1.18.6
+# github.com/klauspost/compress v1.18.7
 ## explicit; go 1.24
 github.com/klauspost/compress
 github.com/klauspost/compress/fse


### PR DESCRIPTION
# Changes

Security fix: update `github.com/klauspost/compress` from v1.18.6 to v1.18.7 to address GHSA-259r-337f-4rfw.

| CVE / Advisory | Package | From | To | Severity |
|---|---|---|---|---|
| GHSA-259r-337f-4rfw | github.com/klauspost/compress | v1.18.6 | v1.18.7 | Unknown (fixable) |

**Fix Summary:**
- Updated `github.com/klauspost/compress` from `v1.18.6` → `v1.18.7` (minimum safe patch in 1.18.x line)
- Ran `go mod tidy && go mod verify && go mod vendor`

**Already fixed on this branch (no action needed):**
- `golang.org/x/net` v0.57.0 ✅ (CVE-2026-46600 fixed in ≥0.56.0)
- `golang.org/x/text` v0.40.0 ✅ (CVE-2026-56852 fixed in ≥0.39.0)
- `google.golang.org/grpc` v1.83.0 ✅ (GHSA-hrxh-6v49-42gf fixed in ≥1.82.1)
- `go.opentelemetry.io/otel` v1.44.0 ✅ (CVE-2026-41178 fixed in ≥1.44.0)
- `stdlib` go1.26.5 ✅ (CVE-2026-39822 fixed in ≥1.26.5)

**Test Results:** ✅ All unit tests pass (`GOTOOLCHAIN=go1.26.5 go test ./...`)

**Breaking Changes:** None — patch update within same minor version (1.18.x).

**Risk Assessment:** Low — only indirect dependency update, no API changes.

**Note:** This supersedes PR #1415 (same fix, but that PR has an EasyCLA issue due to incorrect commit author).

Jira: SRVKP-13180, SRVKP-13181, SRVKP-13191

# Submitter Checklist

- [x] Tested your changes locally
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [ ] Has a kind label. `/kind bug`
- [x] Release notes block below has been updated

# Release Notes

```release-note
NONE
```