### PR TITLE
watcher and api-server horizontal scaling

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -37,6 +37,7 @@ import (
 	v1alpha2pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
@@ -59,6 +60,7 @@ const (
 	// This is a fixed path which does not contain a hard-coded secret or credential
 	podTokenPath             = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec
 	finalizerRequeueInterval = 10 * time.Second
+	defaultServiceConfig     = `{"loadBalancingConfig":[{"round_robin":{}}]}`
 )
 
 var (
@@ -101,7 +103,7 @@ func main() {
 
 	ctx = filteredinformerfactory.WithSelectors(ctx, "app.kubernetes.io/name")
 
-	conn, err := connectToAPIServer(ctx, *apiAddr, *authMode)
+	conn, err := connectToAPIServer(*apiAddr, *authMode)
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -178,7 +180,7 @@ func main() {
 	)
 }
 
-func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*grpc.ClientConn, error) {
+func connectToAPIServer(apiAddr string, authMode string) (*grpc.ClientConn, error) {
 	// Load TLS certs
 	certs, err := loadCerts()
 	if err != nil {
@@ -186,9 +188,17 @@ func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*
 	}
 	cred := credentials.NewClientTLSFromCert(certs, "")
 
-	opts := []grpc.DialOption{
-		grpc.WithBlock(),
+	connectParams := grpc.ConnectParams{
+		Backoff:           backoff.DefaultConfig,
+		MinConnectTimeout: 1 * time.Minute,
 	}
+
+	opts := []grpc.DialOption{
+		grpc.WithDefaultServiceConfig(defaultServiceConfig),
+		grpc.WithConnectParams(connectParams),
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
+	}
+
 	// Add in additional credentials to requests if desired.
 	switch authMode {
 	case "google":
@@ -215,9 +225,7 @@ func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*
 	}
 
 	log.Printf("dialing %s...\n", apiAddr)
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
-	defer cancel()
-	return grpc.DialContext(ctx, apiAddr, opts...)
+	return grpc.NewClient(apiAddr, opts...)
 }
 
 func loadCerts() (*x509.CertPool, error) {

--- a/cmd/watcher/main_test.go
+++ b/cmd/watcher/main_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"google.golang.org/grpc/balancer/roundrobin"
+)
+
+func TestDefaultServiceConfig(t *testing.T) {
+	var config struct {
+		LoadBalancingConfig []map[string]interface{} `json:"loadBalancingConfig"`
+	}
+
+	if err := json.Unmarshal([]byte(defaultServiceConfig), &config); err != nil {
+		t.Fatalf("defaultServiceConfig is not valid JSON: %v", err)
+	}
+
+	if len(config.LoadBalancingConfig) == 0 {
+		t.Fatal("defaultServiceConfig must contain at least one load balancing policy")
+	}
+
+	foundRoundRobin := false
+	for _, policy := range config.LoadBalancingConfig {
+		if _, ok := policy[roundrobin.Name]; ok {
+			foundRoundRobin = true
+			break
+		}
+	}
+
+	if !foundRoundRobin {
+		t.Errorf("defaultServiceConfig must include the round_robin load balancing policy, got: %v", config.LoadBalancingConfig)
+	}
+}

--- a/config/components/horizontal-scaling/api-service-headless.yaml
+++ b/config/components/horizontal-scaling/api-service-headless.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service-headless
+  labels:
+    app.kubernetes.io/name: tekton-results-api
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: tekton-results-api
+  ports:
+    - name: server
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+    - name: prometheus
+      protocol: TCP
+      port: 9090
+      targetPort: 9090

--- a/config/components/horizontal-scaling/generate-tls-cert.sh
+++ b/config/components/horizontal-scaling/generate-tls-cert.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# This script generates a TLS certificate for the Tekton Results API service.
+# By default it includes both the regular ClusterIP service and the headless
+# service in the SAN, which is what horizontal scaling deployments need since
+# the watcher connects to the API via the headless service for DNS-based load
+# balancing. Callers that only need the regular service name (e.g. a
+# single-replica deployment) can opt out by setting EXTRA_SANS="".
+
+NAMESPACE="${NAMESPACE:-tekton-pipelines}"
+SECRET_NAME="${SECRET_NAME:-tekton-results-tls}"
+CERT_DAYS="${CERT_DAYS:-365}"
+OUTPUT_DIR="${OUTPUT_DIR:-./}"
+CERT_FILE_NAME="${CERT_FILE_NAME:-cert.pem}"
+KEY_FILE_NAME="${KEY_FILE_NAME:-key.pem}"
+SSL_INCLUDE_LOCALHOST="${SSL_INCLUDE_LOCALHOST:-false}"
+# NOTE: uses "${VAR-default}" (no colon) rather than "${VAR:-default}" so that
+# an explicitly empty EXTRA_SANS="" disables the headless SAN instead of
+# falling back to the default.
+EXTRA_SANS="${EXTRA_SANS-DNS:tekton-results-api-service-headless.${NAMESPACE}.svc.cluster.local}"
+
+CERT_PATH="${OUTPUT_DIR}/${CERT_FILE_NAME}"
+KEY_PATH="${OUTPUT_DIR}/${KEY_FILE_NAME}"
+
+echo "Generating TLS certificate..."
+echo "  Namespace: ${NAMESPACE}"
+echo "  Secret: ${SECRET_NAME}"
+echo "  Valid for: ${CERT_DAYS} days"
+
+# Subject Alternative Names always include the regular ClusterIP service,
+# plus any caller-supplied extras (e.g. the headless service, localhost).
+SANS="DNS:tekton-results-api-service.${NAMESPACE}.svc.cluster.local"
+if [ -n "${EXTRA_SANS}" ]; then
+    SANS="${SANS},${EXTRA_SANS}"
+fi
+if [ "${SSL_INCLUDE_LOCALHOST}" = "true" ]; then
+    SANS="${SANS},DNS:localhost"
+fi
+
+# Common Name is the primary service
+CN="tekton-results-api-service.${NAMESPACE}.svc.cluster.local"
+
+# Try modern OpenSSL syntax first (with -addext flag)
+set +e
+if ! openssl req -x509 \
+    -newkey rsa:4096 \
+    -keyout "${KEY_PATH}" \
+    -out "${CERT_PATH}" \
+    -days "${CERT_DAYS}" \
+    -nodes \
+    -subj "/CN=${CN}" \
+    -addext "subjectAltName = ${SANS}" \
+    2>/dev/null; then
+    echo "Modern OpenSSL syntax failed, trying legacy LibreSSL syntax..."
+
+    # Fallback for older LibreSSL versions (e.g., macOS Big Sur)
+    if ! openssl req -x509 \
+        -verbose \
+        -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName = %s" "${SANS}")) \
+        -extensions SAN \
+        -newkey rsa:4096 \
+        -keyout "${KEY_PATH}" \
+        -out "${CERT_PATH}" \
+        -days "${CERT_DAYS}" \
+        -nodes \
+        -subj "/CN=${CN}"; then
+        echo "ERROR: Failed to generate TLS certificate" >&2
+        exit 1
+    fi
+fi
+set -e
+
+echo "Certificate generated successfully:"
+echo "  - ${CERT_PATH}"
+echo "  - ${KEY_PATH}"
+
+# Verify the SAN entries
+echo ""
+echo "Subject Alternative Names in certificate:"
+openssl x509 -in "${CERT_PATH}" -noout -text | grep -A1 "Subject Alternative Name"
+
+# Create or update the Kubernetes secret
+echo ""
+echo "Creating/updating Kubernetes secret..."
+if kubectl create secret tls -n "${NAMESPACE}" "${SECRET_NAME}" \
+    --cert="${CERT_PATH}" \
+    --key="${KEY_PATH}" \
+    --dry-run=client -o yaml | kubectl apply -f -; then
+    echo "Secret ${SECRET_NAME} created/updated successfully in namespace ${NAMESPACE}"
+else
+    echo "ERROR: Failed to create secret. You can manually create it with:" >&2
+    echo "  kubectl create secret tls -n ${NAMESPACE} ${SECRET_NAME} --cert=${CERT_PATH} --key=${KEY_PATH}" >&2
+    exit 1
+fi
+
+echo ""
+echo "TLS certificate setup complete!"

--- a/config/components/horizontal-scaling/kustomization.yaml
+++ b/config/components/horizontal-scaling/kustomization.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Horizontal Scaling Component
+#
+# Enables horizontal scaling for the Tekton Results API and Watcher.
+# - Scales the API to 3 replicas with DNS-based gRPC load balancing
+# - Replaces the Watcher Deployment with a StatefulSet for bucket-based sharding
+# - Configures 3 buckets for workload distribution
+#
+# IMPORTANT: The number of replicas must equal the number of buckets.
+# See documentation for details.
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - api-service-headless.yaml
+  - watcher-statefulset.yaml
+  - watcher-headless-service.yaml
+patches:
+  # Scale the base watcher Deployment to 0 replicas
+  # The StatefulSet defined in this component replaces it
+  - target:
+      kind: Deployment
+      name: watcher
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 0
+  # Scale the API Deployment to 3 replicas for high availability
+  - target:
+      kind: Deployment
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  # Configure leader election buckets to match watcher replicas
+  - target:
+      kind: ConfigMap
+      name: config-leader-election
+    patch: |-
+      - op: add
+        path: /data/buckets
+        value: "3"

--- a/config/components/horizontal-scaling/watcher-headless-service.yaml
+++ b/config/components/horizontal-scaling/watcher-headless-service.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: watcher-headless
+  labels:
+    app.kubernetes.io/name: tekton-results-watcher
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: tekton-results-watcher
+  ports:
+    - name: metrics
+      port: 9090
+    - name: profiling
+      port: 8008

--- a/config/components/horizontal-scaling/watcher-statefulset.yaml
+++ b/config/components/horizontal-scaling/watcher-statefulset.yaml
@@ -1,0 +1,118 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: watcher
+  labels:
+    app.kubernetes.io/name: tekton-results-watcher
+spec:
+  serviceName: watcher-headless
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-results-watcher
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app.kubernetes.io/name: tekton-results-watcher
+        app: tekton-results-watcher
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: NotIn
+                  values:
+                  - windows
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: tekton-results-watcher
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: watcher
+      containers:
+        - name: watcher
+          image: ko://github.com/tektoncd/results/cmd/watcher
+          args:
+            - -api_addr
+            - $(TEKTON_RESULTS_API_SERVICE)
+            - -auth_mode
+            - $(AUTH_MODE)
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: tekton-results-config-logging
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-results-config-leader-election
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: tekton-results-config-observability
+            - name: METRICS_DOMAIN
+              value: tekton.dev/results
+            - name: TEKTON_RESULTS_API_SERVICE
+              value: dns:///tekton-results-api-service-headless.tekton-pipelines.svc.cluster.local:8080
+            - name: AUTH_MODE
+              value: token
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
+            - name: STATEFUL_CONTROLLER_ORDINAL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STATEFUL_SERVICE_NAME
+              value: tekton-results-watcher-headless
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/tls"
+              readOnly: true
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: tls
+          secret:
+            secretName: tekton-results-tls
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: watcher-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-results-watcher

--- a/config/overlays/ha-base-only/kustomization.yaml
+++ b/config/overlays/ha-base-only/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tekton-pipelines
+resources:
+  - ../../base
+components:
+  - ../../components/horizontal-scaling
+  - ../../components/metadata

--- a/config/overlays/ha-local-db/kustomization.yaml
+++ b/config/overlays/ha-local-db/kustomization.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tekton-pipelines
+resources:
+  - ../../base
+components:
+  - ../../components/local-db
+  - ../../components/horizontal-scaling
+  - ../../components/metadata

--- a/docs/horizontal-scaling.md
+++ b/docs/horizontal-scaling.md
@@ -1,0 +1,298 @@
+# Horizontal Scaling
+
+Tekton Results supports horizontal scaling for both the API server and the watcher to provide high availability and increased throughput.
+
+## Overview
+
+Horizontal scaling enables Tekton Results to:
+
+- **Increase availability** - Multiple replicas eliminate single points of failure
+- **Distribute load** - Workload is partitioned across watcher replicas and API requests are load-balanced across API replicas
+- **Scale throughput** - More replicas handle more concurrent reconciliations and API requests
+
+The horizontal scaling configuration deploys:
+
+- **3 API server replicas** behind a headless Service for DNS-based gRPC load balancing
+- **3 watcher replicas** as a StatefulSet with bucket-based workload partitioning
+- **3 buckets** for consistent hashing of Tekton resources across watchers
+
+## Architecture
+
+### API Server Scaling
+
+The API server scales horizontally using a standard Kubernetes Deployment with multiple replicas. Load balancing is achieved through DNS-based gRPC client-side load balancing.
+
+**Components:**
+
+- **Deployment** - `tekton-results-api` with 3 replicas
+- **Headless Service** - `tekton-results-api-service-headless` with `clusterIP: None`
+- **ClusterIP Service** - `tekton-results-api-service` for non-HA clients (preserved for backwards compatibility)
+
+**How it works:**
+
+1. The headless Service has `clusterIP: None`, causing DNS queries to return all pod IP addresses instead of a single virtual IP
+2. gRPC clients use the `dns:///` scheme to trigger DNS-based endpoint resolution
+3. The `round_robin` load balancing policy distributes requests evenly across all resolved endpoints
+4. Each watcher maintains a single gRPC connection that multiplexes requests to all API replicas via HTTP/2 streams
+
+**Why headless Service:**
+
+Standard Kubernetes ClusterIP Services load-balance at the TCP connection level. Since gRPC uses long-lived HTTP/2 connections, all requests from a single watcher would go to the same API pod. The headless Service enables DNS to return all pod IPs, allowing gRPC's client-side load balancer to distribute individual requests across all API replicas.
+
+### Watcher Scaling
+
+The watcher scales horizontally using a StatefulSet with bucket-based workload partitioning provided by Knative's leader-aware controllers.
+
+**Components:**
+
+- **StatefulSet** - `tekton-results-watcher` with 3 replicas (replaces the base Deployment)
+- **Headless Service** - `tekton-results-watcher-headless` for StatefulSet network identity
+- **ConfigMap** - `config-leader-election` with `buckets: "3"`
+
+**How it works:**
+
+1. Knative's controller framework partitions the reconciliation key space into buckets using consistent hashing
+2. Each StatefulSet replica is assigned one or more buckets based on its ordinal (derived from pod name)
+3. When a watcher observes a TaskRun, PipelineRun, or CustomRun, it computes the bucket hash from the resource's namespace/name
+4. The watcher only reconciles the resource if the computed bucket matches one of its assigned buckets
+5. Resources are deterministically assigned to exactly one watcher, eliminating duplicate reconciliation
+
+Note: Deprecated blocking grpc.DialContext client connection function has been replaced with newer grpc.NewClient function. 
+grpc.WithBlock is incompatible with the new scaling functionality and has been removed and replaced with 
+grpc.WithConnectParams(connectParams) to use new scaling parameters;
+
+
+**Bucket assignment example:**
+
+With 3 replicas and 3 buckets:
+- `tekton-results-watcher-0` reconciles bucket 0
+- `tekton-results-watcher-1` reconciles bucket 1
+- `tekton-results-watcher-2` reconciles bucket 2
+
+A TaskRun named `default/my-task` hashes to bucket 1, so only `watcher-1` reconciles it.
+
+**StatefulSet vs Deployment:**
+
+StatefulSets provide stable network identities and ordinals that Knative uses for bucket assignment. The `STATEFUL_CONTROLLER_ORDINAL` environment variable (set by Knative injection) identifies which replica this is, enabling the bucket-to-replica mapping.
+
+## Configuration
+
+### Deploying with Kustomize
+
+The horizontal scaling feature is packaged as a Kustomize component at `config/components/horizontal-scaling`.
+
+**Example overlay:**
+
+```yaml
+# config/overlays/ha-local-db/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tekton-pipelines
+resources:
+  - ../../base
+components:
+  - ../../components/local-db
+  - ../../components/horizontal-scaling
+  - ../../components/metadata
+```
+
+**Deploy:**
+
+```bash
+# Generate TLS certificate with both service names
+./config/components/horizontal-scaling/generate-tls-cert.sh
+
+# Deploy with kustomize and ko
+kubectl kustomize config/overlays/ha-local-db | ko apply -f -
+```
+
+### Environment Variables
+
+**Watcher StatefulSet:**
+
+- `TEKTON_RESULTS_API_SERVICE` - API server address using DNS scheme for load balancing
+  - Value: `dns:///tekton-results-api-service-headless.tekton-pipelines.svc.cluster.local:8080`
+  - The `dns:///` prefix triggers DNS-based endpoint resolution
+- `AUTH_MODE` - Authentication mode for API requests
+  - Value: `token`
+  - Uses TLS transport credentials with per-RPC service account token authentication
+  - Do NOT use `insecure` in production - it disables TLS encryption entirely
+- `SYSTEM_NAMESPACE` - Namespace for Knative configuration
+  - Value: Derived from pod metadata (`metadata.namespace`)
+- `STATEFUL_CONTROLLER_ORDINAL` - Pod ordinal for bucket assignment
+  - Value: Derived from pod name (`metadata.name`)
+  - Knative extracts the ordinal number (0, 1, 2) from the StatefulSet pod name
+- `STATEFUL_SERVICE_NAME` - Headless Service name for StatefulSet
+  - Value: `tekton-results-watcher-headless`
+
+**ConfigMap (config-leader-election):**
+
+- `buckets` - Number of buckets for workload partitioning
+  - Value: `"3"` (must be a string)
+  - Must equal the number of watcher replicas
+  - Maximum supported by Knative: 10
+
+### Scaling to Different Replica Counts
+
+To scale to a different number of replicas:
+
+1. Update `spec.replicas` in `config/components/horizontal-scaling/watcher-statefulset.yaml`
+2. Update the `buckets` value in `config/components/horizontal-scaling/kustomization.yaml`
+3. Optionally update API replicas in the same kustomization file
+
+**Example for 5 replicas:**
+
+```yaml
+# watcher-statefulset.yaml
+spec:
+  replicas: 5
+
+# kustomization.yaml patches
+patches:
+  - target:
+      kind: Deployment
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 5
+  - target:
+      kind: ConfigMap
+      name: config-leader-election
+    patch: |-
+      - op: add
+        path: /data/buckets
+        value: "5"
+```
+
+### TLS Certificate Requirements
+
+The TLS certificate must include both the ClusterIP Service name and the headless Service name in the Subject Alternative Names (SAN):
+
+1. `tekton-results-api-service.tekton-pipelines.svc.cluster.local`
+2. `tekton-results-api-service-headless.tekton-pipelines.svc.cluster.local`
+
+Without both names, watcher pods will fail TLS validation when connecting via the headless Service.
+
+**Generate certificate:**
+
+```bash
+./config/components/horizontal-scaling/generate-tls-cert.sh
+```
+
+**Verify certificate includes both names:**
+
+```bash
+kubectl get secret -n tekton-pipelines tekton-results-tls \
+  -o jsonpath='{.data.tls\.crt}' | base64 -d \
+  | openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
+```
+
+### DNS-Based Load Balancing
+
+The watcher configures the gRPC client with DNS-based endpoint resolution and round-robin load balancing.
+
+**How DNS resolution works:**
+
+1. gRPC parses the `dns:///` scheme and extracts the hostname
+2. The DNS resolver queries the headless Service name
+3. Kubernetes DNS returns A records for all ready API pod IPs
+4. gRPC creates subchannels to each resolved endpoint
+5. The `round_robin` picker distributes RPCs across all subchannels in order
+
+**Re-resolution:**
+
+gRPC re-resolves DNS every 30 minutes by default. New API pods may take up to 30 minutes to receive traffic from existing watcher connections. Manual watcher restart forces immediate re-resolution.
+
+### Manual Testing
+
+**Verify watcher bucket assignments:**
+
+```bash
+kubectl logs -n tekton-pipelines tekton-results-watcher-0 | grep "knative.dev/key"
+kubectl logs -n tekton-pipelines tekton-results-watcher-1 | grep "knative.dev/key"
+kubectl logs -n tekton-pipelines tekton-results-watcher-2 | grep "knative.dev/key"
+```
+
+Each watcher should show log entries for a distinct subset of resources.
+
+**Verify API load balancing:**
+
+```bash
+kubectl logs -n tekton-pipelines -l app.kubernetes.io/name=tekton-results-api | grep "grpc.method" | wc -l
+```
+
+All API pods should have non-zero request counts.
+
+**Verify no duplicate records:**
+
+```bash
+tkn-results records list --result default/results/<result-id>
+```
+
+Should return exactly 1 TaskRun record (plus any log/event records).
+
+## Operational Considerations
+
+### Scaling Down
+
+Bucket ownership is assigned statically at startup (each pod computes its
+buckets from its StatefulSet ordinal and the configured `buckets` count) and
+is never reassigned dynamically. Scaling down requires all of the following
+steps:
+
+1. Update `spec.replicas` in the watcher StatefulSet
+2. Update `buckets` in the config-leader-election ConfigMap to match the new replica count
+3. Apply the updated configuration
+4. Restart (roll) the remaining watcher pods so they read the updated `buckets` value and recompute their bucket assignments
+
+Steps 2-4 are all required: the leader election config is only read once at
+process startup, so a running pod never picks up a `buckets` change on its
+own. Only a restart with the corrected value causes a pod to recompute its
+assigned buckets.
+
+**Scale-down:**
+
+Kubernetes deletes StatefulSet pods in reverse ordinal order (2, 1, 0). If
+`buckets` is not updated and the remaining pods are not restarted, the
+buckets previously owned by the removed pods become orphaned: no pod owns
+them, and resources hashing into those buckets go unreconciled until the
+misconfiguration is corrected.
+
+### Rolling Updates
+
+When updating the watcher StatefulSet (new image, config change):
+
+1. Kubernetes performs a rolling update, replacing one pod at a time
+2. Knative demotes the terminating pod's buckets and promotes a different replica
+3. The new pod starts, cache syncs, and takes ownership of assigned buckets
+4. Reconciliations continue with at-least-once delivery guarantees
+
+**Downtime:**
+
+Individual resources may experience reconciliation delays during rolling updates (up to the requeue interval), but no reconciliations are lost.
+
+### DNS Re-Resolution Latency
+
+gRPC-Go's built-in DNS resolver does not poll on a timer. It only re-resolves
+reactively, when a connection fails (e.g. a subchannel hits `TRANSIENT_FAILURE`), 
+with a default 30-second resolving timeout: 
+[SetResolvingTimeout](https://github.com/grpc/grpc-go/blob/master/resolver/dns/dns_resolver.go#L42)
+and a minimum resolution interval which also can be configured:
+[MinResolutionInterval](https://github.com/grpc/grpc-go/blob/master/resolver/dns/dns_resolver.go#L58)
+A healthy connection has no failure to react to, so
+it may never discover newly added API replicas on its own.
+
+**Force immediate re-resolution:**
+
+```bash
+kubectl rollout restart statefulset/tekton-results-watcher -n tekton-pipelines
+```
+
+New watcher pods establish fresh connections with current DNS resolution.
+
+### Maximum Bucket Count
+
+Knative's leader-aware controller framework supports a maximum of 10 buckets. Scaling beyond 10 replicas requires code changes to the bucket assignment algorithm.
+
+For most deployments, 3-5 replicas provide sufficient availability and throughput.

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,6 +33,8 @@ want to use an external database, please refer [this page](./external-database.m
    Tekton Results expects the cert/key pair to be stored in a
    [TLS Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) named `tekton-results-tls`.
 
+   **For standard deployments** (single replica):
+
    - Generate new self-signed cert
 
    ```sh
@@ -49,6 +51,33 @@ want to use an external database, please refer [this page](./external-database.m
    - Create new TLS Secret from cert.
 
    ```sh
+   kubectl create secret tls -n tekton-pipelines tekton-results-tls \
+   --cert=cert.pem \
+   --key=key.pem
+   ```
+
+   **For horizontal scaling deployments** (multiple replicas with headless service):
+
+   If you plan to use the horizontal-scaling component,
+   the certificate must include both the regular service and the headless service in the Subject Alternative Names.
+   Use the provided helper script:
+
+   ```sh
+   ./config/components/horizontal-scaling/generate-tls-cert.sh
+   ```
+
+   Or generate manually with both service names:
+
+   ```sh
+   openssl req -x509 \
+   -newkey rsa:4096 \
+   -keyout key.pem \
+   -out cert.pem \
+   -days 365 \
+   -nodes \
+   -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local" \
+   -addext "subjectAltName = DNS:tekton-results-api-service.tekton-pipelines.svc.cluster.local,DNS:tekton-results-api-service-headless.tekton-pipelines.svc.cluster.local"
+
    kubectl create secret tls -n tekton-pipelines tekton-results-tls \
    --cert=cert.pem \
    --key=key.pem

--- a/test/e2e/01-install.sh
+++ b/test/e2e/01-install.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# shellcheck disable=SC2181 # To ignore long command exit code check
-
 set -e
+
+MODE="${1:-standard}" # "standard" or "ha"
 
 export KO_DOCKER_REPO=${KO_DOCKER_REPO:-"kind.local"}
 export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-"tekton-results"}
@@ -27,56 +27,39 @@ ROOT="$(git rev-parse --show-toplevel)"
 echo "Installing Tekton Pipelines..."
 TEKTON_PIPELINE_CONFIG=${TEKTON_PIPELINE_CONFIG:-"https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml"}
 kubectl apply --filename "${TEKTON_PIPELINE_CONFIG}"
+kubectl wait --for=condition=ready pod -l app=tekton-pipelines-controller -n tekton-pipelines --timeout=120s
+kubectl wait --for=condition=ready pod -l app=tekton-pipelines-webhook -n tekton-pipelines --timeout=120s
 
 echo "Generating DB secret..."
 # Don't fail if the secret isn't created - this can happen if the secret already exists.
 kubectl create secret generic tekton-results-postgres --namespace="tekton-pipelines" --from-literal=POSTGRES_USER=postgres --from-literal=POSTGRES_PASSWORD="$(openssl rand -base64 20)" || true
 
 echo "Generating TLS key pair..."
-set +e
 mkdir -p "${SSL_CERT_PATH}"
 
-SSL_INCLUDE_LOCALHOST=${SSL_INCLUDE_LOCALHOST:-"false"}
-altNames="DNS:tekton-results-api-service.tekton-pipelines.svc.cluster.local"
-if [ "$SSL_INCLUDE_LOCALHOST" = "true" ] ; then
-    altNames+=",DNS:localhost"
+# The headless service SAN is only needed for the HA deployment, where the
+# watcher connects to the API via DNS-based load balancing over the headless
+# service. generate-tls-cert.sh includes it by default, so opt out for the
+# standard, single-replica install.
+if [ "$MODE" = "ha" ]; then
+    export EXTRA_SANS="DNS:tekton-results-api-service-headless.tekton-pipelines.svc.cluster.local"
+else
+    export EXTRA_SANS=""
 fi
+export OUTPUT_DIR="${SSL_CERT_PATH}"
+export CERT_FILE_NAME="tekton-results-cert.pem"
+export KEY_FILE_NAME="tekton-results-key.pem"
+"${ROOT}/config/components/horizontal-scaling/generate-tls-cert.sh"
 
-openssl req -x509 \
-        -newkey rsa:4096 \
-        -keyout "${SSL_CERT_PATH}/tekton-results-key.pem" \
-        -out "${SSL_CERT_PATH}/tekton-results-cert.pem" \
-        -days 365 \
-        -nodes \
-        -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local" \
-        -addext "subjectAltName = ${altNames}"
-
-if [ $? -ne 0 ] ; then
-    # LibreSSL didn't support the -addext flag until version 3.1.0 but
-    # version 2.8.3 ships with MacOS Big Sur. So let's try a different way...
-    echo "Falling back to legacy libressl cert generation"
-    openssl req -x509 \
-            -verbose \
-            -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName = %s" ${altNames})) \
-            -extensions SAN \
-            -newkey rsa:4096 \
-            -keyout "${SSL_CERT_PATH}/tekton-results-key.pem" \
-            -out "${SSL_CERT_PATH}/tekton-results-cert.pem" \
-            -days 365 \
-            -nodes \
-            -subj "/CN=tekton-results-api-service.tekton-pipelines.svc.cluster.local"
-
-    if [ $? -ne 0 ] ; then
-        echo "There was an error generating certificates"
-        exit 1
-    fi
+if [ "$MODE" = "ha" ]; then
+    echo "Installing Tekton Results with HA configuration..."
+    kustomize_dir="${ROOT}/test/e2e/kustomize-ha"
+else
+    echo "Installing Tekton Results..."
+    kustomize_dir="${ROOT}/test/e2e/kustomize"
 fi
-set -e
-kubectl create secret tls -n tekton-pipelines tekton-results-tls --cert="${SSL_CERT_PATH}/tekton-results-cert.pem" --key="${SSL_CERT_PATH}/tekton-results-key.pem" || true
-
-echo "Installing Tekton Results..."
 extra_ko_params="linux/$(go env GOARCH)"
-kubectl kustomize "${ROOT}/test/e2e/kustomize" | ko apply --platform="$extra_ko_params" -f -
+kubectl kustomize "${kustomize_dir}" | ko apply --platform="$extra_ko_params" -f -
 
 echo "Fetching access tokens..."
 mkdir -p "${SA_TOKEN_PATH}"
@@ -86,7 +69,23 @@ for service_account in "${service_accounts[@]}"; do
     echo "Created ${SA_TOKEN_PATH}/$service_account"
 done
 
-echo "Waiting for deployments to be ready..."
-kubectl wait pod "tekton-results-postgres-0" --namespace="tekton-pipelines" --for="condition=Ready" --timeout="120s"
-kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
-kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
+if [ "$MODE" = "ha" ]; then
+    echo "Waiting for Tekton Results pods..."
+    # The watcher and API run with multiple replicas in HA mode, so wait on
+    # the pod labels rather than a single Deployment/StatefulSet rollout.
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tekton-results-api -n tekton-pipelines --timeout=300s
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tekton-results-watcher -n tekton-pipelines --timeout=300s
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tekton-results-postgres -n tekton-pipelines --timeout=120s
+
+    echo ""
+    echo "Installation complete!"
+    echo ""
+    kubectl get pods -n tekton-pipelines | grep tekton-results
+    echo ""
+    echo "Run E2E tests: go test -v --tags=e2e,e2e_ha -run TestHorizontalScaling ./test/e2e/..."
+else
+    echo "Waiting for deployments to be ready..."
+    kubectl wait pod "tekton-results-postgres-0" --namespace="tekton-pipelines" --for="condition=Ready" --timeout="120s"
+    kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
+    kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
+fi

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -55,6 +55,9 @@ All components are installed to the current kubectl context
 This can safely be ran multiple times, and should be ran anytime a change is
 made to Results components.
 
+Accepts an optional mode argument: `./01-install.sh` (standard, default) or
+`./01-install.sh ha` (horizontal scaling configuration, see below).
+
 | Environment variable   | Description                                                                   | Default                                                                     |
 | ---------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | KO_DOCKER_REPO         | Docker repository to use for ko                                               | kind.local                                                                  |
@@ -71,3 +74,73 @@ Once you have configured your local client, you can run the tests by running:
 ```sh
 $ go test --tags=e2e .
 ```
+### HA E2E Tests
+
+The E2E test suite verifies the three correctness guarantees using a real Kubernetes cluster with the HA configuration deployed.
+
+**Test file:** `test/e2e/e2e_ha_test.go`
+**Prerequisites:**
+1. HA configuration deployed via `test/e2e/01-install.sh ha`
+2. Tekton Pipelines installed
+3. Service account tokens extracted for API authentication
+
+**Run tests:**
+
+```bash
+cd test/e2e
+./01-install.sh ha
+go test -v --tags=e2e,e2e_ha -run TestHorizontalScaling .
+```
+
+### Test Structure
+
+**TestHorizontalScaling** contains four subtests:
+
+**1. VerifyPods** (precondition)
+
+Polls pod status and asserts:
+- 3 API pods are Ready
+- 3 watcher pods are Ready
+- 1 Postgres pod is Ready
+
+Fails fast if the deployment is unhealthy.
+
+**2. NoDuplicates**
+
+Creates 9 TaskRuns and waits for Result/Record annotations.
+
+**API-side check:**
+
+For each TaskRun's Result, calls ListRecords and counts TaskRun-type records (filters by `Data.Type` to exclude log/event records). Asserts exactly 1 TaskRun record per Result.
+
+**Watcher-side check:**
+
+Reads logs from all watcher pods via Kubernetes Logs API. Searches for log entries containing `"knative.dev/key":"default/<taskrun-name>"`. Asserts each TaskRun appears in exactly one watcher's logs, 
+proving bucket sharding worked.
+
+**3. NoLostRequests**
+
+**Count invariant:**
+
+Lists all records via `ListRecords(parent: "default/results/-")` with pagination. Counts records matching TaskRuns from the test. Asserts exactly 9 records found.
+
+**Individual retrieval:**
+
+For each TaskRun, calls GetRecord using the record name from the annotation. Asserts every call succeeds, proving records are persisted and retrievable.
+
+**Data integrity:**
+
+For each Record, unmarshals the `data` field to a TaskRun and verifies the `Name` field matches the expected TaskRun name. Catches corruption during concurrent writes.
+
+**4. APIDistribution**
+
+Reads logs from all API pods via Kubernetes Logs API. Counts log lines containing `"grpc.method"` per pod. Asserts at least 2 of 3 API pods received gRPC requests.
+  
+Prints per-pod request counts for debugging:
+
+```
+API pod tekton-results-api-abc123: 15 requests
+API pod tekton-results-api-def456: 12 requests
+API pod tekton-results-api-ghi789: 14 requests
+```
+

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -37,25 +37,36 @@ main() {
     REPO="$(git rev-parse --show-toplevel)"
 
     ${REPO}/test/e2e/00-setup.sh
-    ${REPO}/test/e2e/01-install.sh
-
-    # Build static binaries; otherwise go test complains.
     export CGO_ENABLED=0
-    kubectl patch configmap tekton-results-config-logging -n tekton-pipelines --type='merge' -p='{ "data": {
-        "zap-logger-config": "{\n  \"level\": \"debug\",\n  \"development\": false,\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"json\",\n  \"encoderConfig\": {\n    \"timeKey\": \"time\",\n    \"levelKey\": \"level\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"msg\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"lineEnding\": \"\",\n    \"levelEncoder\": \"\",\n    \"timeEncoder\": \"iso8601\",\n    \"durationEncoder\": \"string\",\n    \"callerEncoder\": \"\"\n  }\n}",
-        "loglevel.watcher": "debug"}
-    }'
-    kubectl get pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines -o yaml
-    go test -v -count=1 --tags=e2e $(go list --tags=e2e ${REPO}/test/e2e/... | grep -v /client)
-    kubectl logs $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines
 
-    # Test GCS logging
-    kubectl apply -f ${REPO}/test/e2e/gcs-emulator.yaml
-    kubectl delete pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-api | sed "s/^.\{4\}//") -n tekton-pipelines
-    kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
-    kubectl delete pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines
-    kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
-    go test -v -count=1 --tags=e2e,gcs $(go list --tags=e2e ${REPO}/test/e2e/... | grep -v /client) -run TestGCSLog
+    if [ $# -gt 0 ] && [ "$1" == "ha" ]; then
+        ${REPO}/test/e2e/01-install.sh ha
+        kubectl patch configmap tekton-results-config-logging -n tekton-pipelines --type='merge' -p='{ "data": {
+          "zap-logger-config": "{\n  \"level\": \"debug\",\n  \"development\": false,\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"json\",\n  \"encoderConfig\": {\n    \"timeKey\": \"time\",\n    \"levelKey\": \"level\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"msg\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"lineEnding\": \"\",\n    \"levelEncoder\": \"\",\n    \"timeEncoder\": \"iso8601\",\n    \"durationEncoder\": \"string\",\n    \"callerEncoder\": \"\"\n  }\n}",
+          "loglevel.watcher": "debug"}
+        }'
+        go test -v -count=1 --tags=e2e,e2e_ha -run TestHorizontalScaling ${REPO}/test/e2e/
+    else
+        ${REPO}/test/e2e/01-install.sh
+        # Build static binaries; otherwise go test complains.
+
+        kubectl patch configmap tekton-results-config-logging -n tekton-pipelines --type='merge' -p='{ "data": {
+          "zap-logger-config": "{\n  \"level\": \"debug\",\n  \"development\": false,\n  \"outputPaths\": [\"stdout\"],\n  \"errorOutputPaths\": [\"stderr\"],\n  \"encoding\": \"json\",\n  \"encoderConfig\": {\n    \"timeKey\": \"time\",\n    \"levelKey\": \"level\",\n    \"nameKey\": \"logger\",\n    \"callerKey\": \"caller\",\n    \"messageKey\": \"msg\",\n    \"stacktraceKey\": \"stacktrace\",\n    \"lineEnding\": \"\",\n    \"levelEncoder\": \"\",\n    \"timeEncoder\": \"iso8601\",\n    \"durationEncoder\": \"string\",\n    \"callerEncoder\": \"\"\n  }\n}",
+          "loglevel.watcher": "debug"}
+        }'
+        kubectl get pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines -o yaml
+        go test -v -count=1 --tags=e2e $(go list --tags=e2e ${REPO}/test/e2e/... | grep -v /client)
+        kubectl logs $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines
+
+        # Test GCS logging
+        kubectl apply -f ${REPO}/test/e2e/gcs-emulator.yaml
+        kubectl delete pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-api | sed "s/^.\{4\}//") -n tekton-pipelines
+        kubectl wait deployment "tekton-results-api" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
+        kubectl delete pod $(kubectl get pod -o=name -n tekton-pipelines | grep tekton-results-watcher | sed "s/^.\{4\}//") -n tekton-pipelines
+        kubectl wait deployment "tekton-results-watcher" --namespace="tekton-pipelines" --for="condition=available" --timeout="120s"
+        go test -v -count=1 --tags=e2e,gcs $(go list --tags=e2e ${REPO}/test/e2e/... | grep -v /client) -run TestGCSLog
+    fi
+
 }
 
-main
+main "$@"

--- a/test/e2e/e2e_ha_test.go
+++ b/test/e2e/e2e_ha_test.go
@@ -1,0 +1,518 @@
+// Copyright 2026 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e && e2e_ha
+// +build e2e,e2e_ha
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	resultsv1alpha2 "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	haNamespace        = "tekton-pipelines"
+	haAPIBasename      = "tekton-results-api"
+	haWatcherBasename  = "tekton-results-watcher"
+	haPostgresBasename = "tekton-results-postgres"
+	haExpectedReplicas = 3
+)
+
+// TestHorizontalScaling tests the HA configuration correctness.
+// It verifies three critical properties:
+// 1. No duplicated gRPC requests - each TaskRun reconciled by exactly one watcher
+// 2. No lost requests - every TaskRun gets a Result and Record persisted and retrievable
+// 3. API pod distribution - gRPC requests spread across multiple API pods via round_robin
+func TestHorizontalScaling(t *testing.T) {
+	ctx := context.Background()
+	tc := tektonClient(t)
+	gc, _ := resultsClient(t, allNamespacesReadAccessTokenFile, nil)
+
+	t.Run("VerifyPods", func(t *testing.T) {
+		// Verify 3 API pods are ready
+		t.Run("API replicas", func(t *testing.T) {
+			verifyPodsReady(ctx, t, haNamespace, haAPIBasename, haExpectedReplicas)
+		})
+
+		// Verify 3 watcher pods are ready
+		t.Run("Watcher replicas", func(t *testing.T) {
+			verifyPodsReady(ctx, t, haNamespace, haWatcherBasename, haExpectedReplicas)
+		})
+
+		// Verify postgres pod is ready
+		t.Run("Postgres replica", func(t *testing.T) {
+			verifyPodsReady(ctx, t, haNamespace, haPostgresBasename, 1)
+		})
+	})
+
+	// Setup: create 9 TaskRuns and wait for annotations
+	const numTaskRuns = 9
+	taskRunNames := make([]string, numTaskRuns)
+	for i := 0; i < numTaskRuns; i++ {
+		taskRunNames[i] = fmt.Sprintf("ha-guarantee-taskrun-%d", i)
+	}
+
+	// Clean up any existing TaskRuns and wait for deletion to complete
+	for _, name := range taskRunNames {
+		_ = tc.TaskRuns(defaultNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+	}
+	// Wait for all TaskRuns to be fully deleted
+	for _, name := range taskRunNames {
+		_ = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			_, err = tc.TaskRuns(defaultNamespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				// TaskRun not found means it's deleted
+				return true, nil
+			}
+			return false, nil
+		})
+	}
+
+	// Create TaskRuns
+	t.Log("Creating 9 TaskRuns for HA testing")
+	for _, name := range taskRunNames {
+		tr := &tektonv1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: tektonv1.TaskRunSpec{
+				ServiceAccountName: "default",
+				TaskSpec: &tektonv1.TaskSpec{
+					Steps: []tektonv1.Step{
+						{
+							Name:    "echo",
+							Image:   "alpine",
+							Command: []string{"echo", fmt.Sprintf("hello from %s", name)},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := tc.TaskRuns(defaultNamespace).Create(ctx, tr, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Error creating TaskRun %s: %v", name, err)
+		}
+		t.Logf("Created TaskRun %s", name)
+	}
+
+	// Defer cleanup
+	defer func() {
+		for _, name := range taskRunNames {
+			_ = tc.TaskRuns(defaultNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+		}
+	}()
+
+	// Wait for all TaskRuns to get Result/Record annotations
+	type taskRunAnnotations struct {
+		resultName string
+		recordName string
+	}
+	annotations := make(map[string]taskRunAnnotations, numTaskRuns)
+
+	t.Log("Waiting for all TaskRuns to receive Result and Record annotations")
+	for _, name := range taskRunNames {
+		var resName, recName string
+
+		err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+			tr, err := tc.TaskRuns(defaultNamespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				t.Logf("Error getting TaskRun %s: %v", name, err)
+				return false, nil
+			}
+
+			var resAnnotation, recAnnotation bool
+			resName, resAnnotation = tr.GetAnnotations()["results.tekton.dev/result"]
+			recName, recAnnotation = tr.GetAnnotations()["results.tekton.dev/record"]
+
+			if resAnnotation && recAnnotation {
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err != nil {
+			t.Fatalf("TaskRun %s did not get Result/Record annotations within timeout", name)
+		}
+
+		annotations[name] = taskRunAnnotations{
+			resultName: resName,
+			recordName: recName,
+		}
+		t.Logf("TaskRun %s annotated with Result: %s, Record: %s", name, resName, recName)
+	}
+
+	t.Run("NoDuplicates", func(t *testing.T) {
+		t.Run("API-side check", func(t *testing.T) {
+			// For each TaskRun's Result, list its Records and count only TaskRun-type records.
+			// A single Result may contain multiple record types (TaskRun data, log, event list),
+			// so we filter by Data.Type to check for TaskRun duplicates specifically.
+			for trName, annot := range annotations {
+				resp, err := gc.ListRecords(ctx, &resultsv1alpha2.ListRecordsRequest{
+					Parent: annot.resultName,
+				})
+				if err != nil {
+					t.Errorf("TaskRun %s: error listing records for Result %s: %v", trName, annot.resultName, err)
+					continue
+				}
+
+				taskRunRecordCount := 0
+				for _, rec := range resp.Records {
+					if rec.GetData() != nil && strings.Contains(rec.GetData().GetType(), "TaskRun") {
+						taskRunRecordCount++
+					}
+				}
+
+				if taskRunRecordCount != 1 {
+					t.Errorf("TaskRun %s: expected exactly 1 TaskRun Record for Result %s, got %d (total records: %d)", trName, annot.resultName, taskRunRecordCount, len(resp.Records))
+				} else {
+					t.Logf("TaskRun %s: 1 TaskRun Record, %d total records (includes logs/events)", trName, len(resp.Records))
+				}
+			}
+		})
+
+		t.Run("Watcher-side check", func(t *testing.T) {
+			// Read logs from all watcher pods and verify, from the watcher side, that
+			// every TaskRun was actually reconciled and that reconciliation work was
+			// distributed across the StatefulSet replicas.
+			//
+			// IMPORTANT: we cannot use a bare occurrence of the "knative.dev/key" log
+			// field to decide which pod "owns" a TaskRun. In HA mode each replica runs
+			// its own shared informer and enqueues *every* object it observes via
+			// controller.HandleAll(impl.Enqueue). At debug log level (which this e2e
+			// suite enables) knative's EnqueueKey / EnqueueSlowKey / EnqueueKeyAfter all
+			// emit the "knative.dev/key" field *before* any leader/bucket ownership check
+			// happens. Bucket-leadership handoffs during startup (buckets=3, replicas=3)
+			// also trigger a Promote resync that re-enqueues the same keys on whichever
+			// replica just acquired the bucket. As a result the raw key legitimately
+			// appears in ALL three pods' logs even though only the current bucket owner
+			// ever runs ReconcileKind and writes to the API. That made the old
+			// "exactly one pod" assertion a guaranteed false positive.
+			//
+			// The authoritative no-duplicate guarantee is the API-side check above
+			// (exactly one TaskRun-type Record per Result, which is an idempotent upsert
+			// keyed by name). Here we assert the two invariants the watcher logs *can*
+			// prove without false positives:
+			//   1. Liveness: every TaskRun was successfully reconciled by at least one
+			//      watcher (the "Reconcile succeeded" line is emitted only after a real,
+			//      non-skipped reconcile completes, i.e. only by the bucket owner).
+			//   2. Sharding: reconciliation work landed on at least 2 of the 3 replicas,
+			//      proving the StatefulSet bucket sharding actually distributes load
+			//      (mirrors the ">= 2 of 3" APIDistribution assertion below).
+			clientset := clientConfig(t)
+			k8sClient := kubernetes.NewForConfigOrDie(clientset)
+
+			pods, err := k8sClient.CoreV1().Pods(haNamespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Error listing pods: %v", err)
+			}
+
+			// Map TaskRun name -> set of watcher pods that successfully reconciled it.
+			taskRunToWatchers := make(map[string]map[string]bool)
+			// Track which watcher pods performed at least one successful reconcile.
+			reconcilingPods := make(map[string]bool)
+
+			for _, pod := range pods.Items {
+				if !startsWithPrefix(pod.Name, haWatcherBasename) {
+					continue
+				}
+				req := k8sClient.CoreV1().Pods(haNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+				stream, err := req.Stream(ctx)
+				if err != nil {
+					t.Errorf("Error getting logs for watcher pod %s: %v", pod.Name, err)
+					continue
+				}
+
+				logsBytes, err := io.ReadAll(stream)
+				stream.Close()
+				if err != nil {
+					t.Errorf("Error reading logs for watcher pod %s: %v", pod.Name, err)
+					continue
+				}
+
+				// Scan line by line so we only match a "Reconcile succeeded" entry that
+				// also carries the TaskRun key on the *same* structured log line. This
+				// excludes the enqueue-time debug noise that every replica emits.
+				for _, line := range strings.Split(string(logsBytes), "\n") {
+					if !strings.Contains(line, `"msg":"Reconcile succeeded"`) {
+						continue
+					}
+					for _, trName := range taskRunNames {
+						keyPattern := fmt.Sprintf(`"knative.dev/key":"default/%s"`, trName)
+						if !strings.Contains(line, keyPattern) {
+							continue
+						}
+						if taskRunToWatchers[trName] == nil {
+							taskRunToWatchers[trName] = make(map[string]bool)
+						}
+						taskRunToWatchers[trName][pod.Name] = true
+						reconcilingPods[pod.Name] = true
+					}
+				}
+			}
+
+			//liveness - every TaskRun was reconciled by at least one watcher.
+			for _, trName := range taskRunNames {
+				watchers := taskRunToWatchers[trName]
+				switch len(watchers) {
+				case 0:
+					t.Errorf("TaskRun %s: no watcher pod logged a successful reconcile", trName)
+				case 1:
+					for pod := range watchers {
+						t.Logf("TaskRun %s: reconciled by %s", trName, pod)
+					}
+				default:
+					// >1 is legitimate under leader-election bucket handoff and is not a
+					// duplicate write (API-side check enforces exactly-one Record).
+					t.Logf("TaskRun %s: reconciled by %d watchers (leader-election handoff, not a duplicate write): %v", trName, len(watchers), keysOf(watchers))
+				}
+			}
+
+			//sharding - work distributed across at least 2 of 3 replicas.
+			if len(reconcilingPods) < 2 {
+				t.Errorf("Expected reconciliation work on at least 2 watcher pods, but only %d performed reconciles: %v", len(reconcilingPods), keysOf(reconcilingPods))
+			} else {
+				t.Logf("Sharding check passed: %d watcher pods performed reconciles", len(reconcilingPods))
+			}
+		})
+	})
+
+	t.Run("NoLostRequests", func(t *testing.T) {
+		t.Run("Count invariant", func(t *testing.T) {
+			// List all records and verify all TaskRuns from this test run are present.
+			// Build a set of expected record names from the current test's annotations.
+			expectedRecords := make(map[string]bool)
+			for _, annot := range annotations {
+				expectedRecords[annot.recordName] = true
+			}
+
+			// Paginate through all records to avoid hitting gRPC message size limits
+			count := 0
+			pageToken := ""
+			for {
+				resp, err := gc.ListRecords(ctx, &resultsv1alpha2.ListRecordsRequest{
+					Parent:    "default/results/-",
+					PageSize:  100,
+					PageToken: pageToken,
+				})
+				if err != nil {
+					t.Fatalf("Error listing records (page token: %s): %v", pageToken, err)
+				}
+
+				for _, record := range resp.Records {
+					// Only count records that belong to this test run
+					if !expectedRecords[record.Name] {
+						continue
+					}
+
+					// Verify it's a TaskRun-type record
+					if record.GetData() == nil || !strings.Contains(record.GetData().GetType(), "TaskRun") {
+						t.Errorf("Record %s from current test is not a TaskRun type: %s", record.Name, record.GetData().GetType())
+						continue
+					}
+
+					count++
+				}
+
+				// Check if there are more pages
+				if resp.NextPageToken == "" {
+					break
+				}
+				pageToken = resp.NextPageToken
+			}
+
+			if count != numTaskRuns {
+				t.Errorf("Expected %d TaskRun records from current test run, got %d", numTaskRuns, count)
+			} else {
+				t.Logf("Count check passed: %d TaskRun records found", count)
+			}
+		})
+
+		t.Run("Individual retrieval", func(t *testing.T) {
+			// Verify each annotated Record is individually retrievable via GetRecord
+			for trName, annot := range annotations {
+				_, err := gc.GetRecord(ctx, &resultsv1alpha2.GetRecordRequest{
+					Name: annot.recordName,
+				})
+				if err != nil {
+					t.Errorf("TaskRun %s: failed to retrieve Record %s: %v", trName, annot.recordName, err)
+				}
+			}
+			t.Logf("All %d records individually retrievable", len(annotations))
+		})
+
+		t.Run("Data integrity", func(t *testing.T) {
+			// Verify each Record's data contains the correct TaskRun name
+			for trName, annot := range annotations {
+				record, err := gc.GetRecord(ctx, &resultsv1alpha2.GetRecordRequest{
+					Name: annot.recordName,
+				})
+				if err != nil {
+					t.Errorf("TaskRun %s: failed to get Record: %v", trName, err)
+					continue
+				}
+
+				var tr tektonv1.TaskRun
+				if err := json.Unmarshal(record.Data.Value, &tr); err != nil {
+					t.Errorf("TaskRun %s: failed to unmarshal Record data: %v", trName, err)
+					continue
+				}
+
+				if tr.Name != trName {
+					t.Errorf("TaskRun %s: Record data contains wrong TaskRun name: %s", trName, tr.Name)
+				}
+			}
+			t.Logf("All records have correct TaskRun names")
+		})
+	})
+
+	t.Run("APIDistribution", func(t *testing.T) {
+		// Read logs from all API pods and count gRPC requests per pod
+		clientset := clientConfig(t)
+		k8sClient := kubernetes.NewForConfigOrDie(clientset)
+
+		pods, err := k8sClient.CoreV1().Pods(haNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("Error listing pods: %v", err)
+		}
+
+		requestCountPerPod := make(map[string]int)
+
+		for _, pod := range pods.Items {
+			if !startsWithPrefix(pod.Name, haAPIBasename) {
+				continue
+			}
+
+			req := k8sClient.CoreV1().Pods(haNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+			stream, err := req.Stream(ctx)
+			if err != nil {
+				t.Errorf("Error getting logs for API pod %s: %v", pod.Name, err)
+				continue
+			}
+
+			logsBytes, err := io.ReadAll(stream)
+			stream.Close()
+			if err != nil {
+				t.Errorf("Error reading logs for API pod %s: %v", pod.Name, err)
+				continue
+			}
+
+			logs := string(logsBytes)
+			lines := strings.Split(logs, "\n")
+
+			count := 0
+			for _, line := range lines {
+				if strings.Contains(line, `"grpc.method"`) {
+					count++
+				}
+			}
+
+			requestCountPerPod[pod.Name] = count
+			t.Logf("API pod %s: %d gRPC requests", pod.Name, count)
+		}
+
+		// Assert at least 2 of 3 API pods received requests
+		podsWithRequests := 0
+		for _, count := range requestCountPerPod {
+			if count > 0 {
+				podsWithRequests++
+			}
+		}
+
+		if podsWithRequests < 2 {
+			t.Errorf("Expected at least 2 API pods to receive requests, but only %d pods received requests", podsWithRequests)
+			t.Logf("Request distribution: %v", requestCountPerPod)
+		} else {
+			t.Logf("Distribution check passed: %d of %d API pods received requests", podsWithRequests, len(requestCountPerPod))
+		}
+	})
+}
+
+// verifyPodsReady waits for the expected number of pods with the given basename to be ready.
+func verifyPodsReady(ctx context.Context, t *testing.T, namespace, podBasename string, expectedCount int) {
+	t.Helper()
+
+	clientset := clientConfig(t)
+	k8sClient := kubernetes.NewForConfigOrDie(clientset)
+
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Logf("Error listing pods: %v", err)
+			return false, nil
+		}
+
+		readyCount := 0
+		for _, pod := range pods.Items {
+			// Check if pod name starts with the expected basename
+			if !startsWithPrefix(pod.Name, podBasename) {
+				continue
+			}
+
+			// Check if pod is ready
+			if isPodReady(&pod) {
+				readyCount++
+			}
+		}
+
+		if readyCount >= expectedCount {
+			t.Logf("Found %d/%d ready pods with basename %s", readyCount, expectedCount, podBasename)
+			return true, nil
+		}
+
+		t.Logf("Waiting for pods with basename %s: %d/%d ready", podBasename, readyCount, expectedCount)
+		return false, nil
+	})
+
+	if err != nil {
+		t.Fatalf("Pods with basename %s did not become ready: %v", podBasename, err)
+	}
+}
+
+// startsWithPrefix checks if a string starts with a given prefix.
+func startsWithPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// keysOf returns the keys of a set for readable log/error messages.
+func keysOf(set map[string]bool) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// isPodReady checks if a pod is in Ready state.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/kustomize-ha/api-service.yaml
+++ b/test/e2e/kustomize-ha/api-service.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Patch API service to NodePort for external access during E2E tests
+- op: replace
+  path: /spec/ports/0
+  value:
+    name: server
+    port: 8080
+    nodePort: 30080
+- op: add
+  path: /spec/type
+  value: NodePort

--- a/test/e2e/kustomize-ha/kustomization.yaml
+++ b/test/e2e/kustomize-ha/kustomization.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2E test overlay for HA configuration
+# Uses ha-local-db overlay with test-specific patches
+resources:
+- ../../../config/overlays/ha-local-db
+- rbac.yaml
+
+patches:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: tekton-results-watcher
+  path: watcher-ha.yaml
+- target:
+    version: v1
+    kind: Service
+    name: tekton-results-api-service
+  path: api-service.yaml

--- a/test/e2e/kustomize-ha/rbac.yaml
+++ b/test/e2e/kustomize-ha/rbac.yaml
@@ -1,0 +1,102 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-impersonate
+rules:
+  - apiGroups: [""]
+    resources: ["users", "groups", "serviceaccounts"]
+    verbs: ["impersonate"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["uids"]
+    verbs: ["impersonate"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: all-namespaces-read-access
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: single-namespace-read-access
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: all-namespaces-admin-access
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: all-namespaces-impersonate-access
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: all-namespaces-read-access
+subjects:
+  - kind: ServiceAccount
+    name: all-namespaces-read-access
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-readonly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: single-namespace-read-access
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: single-namespace-read-access
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-readonly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: all-namespaces-admin-access
+subjects:
+  - kind: ServiceAccount
+    name: all-namespaces-admin-access
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: all-namespaces-impersonate-access
+subjects:
+  - kind: ServiceAccount
+    name: all-namespaces-impersonate-access
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-impersonate

--- a/test/e2e/kustomize-ha/watcher-ha.yaml
+++ b/test/e2e/kustomize-ha/watcher-ha.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2E-specific args for watcher StatefulSet in HA mode
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-completed_run_grace_period"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "15s"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-store_deadline"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "20s"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-forward_buffer"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "17s"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-store_event=true"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-logs_api=true"
+- op: add
+  path: "/spec/template/spec/containers/0/args/-"
+  value: "-disable_storing_incomplete_runs=true"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
- added Watcher pods bucket-sharding scaling swithched on in Watcher's gRPC config ;
- deprecated blocking grpc.DialContext client connection function has been replaced with newer grpc.NewClient function. grpc.WithBlock has been removed  and replaced with grpc.WithConnectParams(connectParams) to use new scaling parameters;
- added StatefulSet overlay `tekton-results-watcher` with 3 replicas to be used to scale Watcher pods instead of Deployment ;
- added Deployment overlay `tekton-results-api`  scaled to 3 replicas;
- Headless service `tekton-results-api-service-headless` has been added with `clusterIP: None` for load balancing to be able to use DNS resolution;
- TLS certificate generation script added for the new headless service;
- Deployment scripts modified to deploy a new horizontally scaled configuration;
- Integration and functional tests added;
- Documentation updates about horizontal scaling;


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Added a horizontal scaling functionality for Watcher / API Server high availability.
Added the high availability kustomize overlay to deploy the new horizontaly scaled configuration.
The Watcher and API server can now be deployed scaled to multiple pods and they will use DNS-based round-robin gRPC load balancing to manage workload properly.
By default the service will be deployed the single replica way but the process how to deploy the scaled configuration can be found in documentation.
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
Assisted-by: Claude