### PR TITLE
Security: Fix 7 stdlib CVEs (go 1.26.6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/results
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
# Changes

Security fix: update Go toolchain directive from `1.26.5` to `1.26.6` to address 7 vulnerabilities in the Go standard library, identified via `govulncheck`.

**CVEs Fixed (all stdlib, fixed in go1.26.6):**

| Advisory | Package | Severity | Description |
|---|---|---|---|
| GO-2026-6218 | net/url | Important | Quadratic complexity in resolvePath |
| GO-2026-6091 | html/template | Important | JS regexp context tracking bug |
| GO-2026-6090 | crypto/tls | Important | Post-handshake message limit not enforced |
| GO-2026-6089 | net/http | Important | ReadHeaderTimeout not applied for HTTP/2 unencrypted check |
| GO-2026-6088 | encoding/xml | Important | Missing recursion depth guard during decode |
| GO-2026-5972 | encoding/asn1 | Important | Decode vulnerability |
| GO-2026-5026 | net/http | Important | HTTP vulnerability |

**Affected images (all built from this repo):**
- `openshift-pipelines/pipelines-results-api-rhel9`
- `openshift-pipelines/pipelines-results-watcher-rhel9`
- `openshift-pipelines/pipelines-results-retention-policy-agent-rhel9`

**Fix Summary:**
- Updated `go` directive in `go.mod` from `1.26.5` → `1.26.6` (minimum safe patch in 1.26.x line)
- Ran `go mod tidy && go mod verify && go mod vendor` — no dependency changes, only toolchain directive

**govulncheck verification:**
```
Before: 8 vulnerabilities (7 stdlib go1.26.5 + 1 unfixable in tektoncd/pipeline)
After:  1 vulnerability (GO-2023-1901 in tektoncd/pipeline — no fix available)
```

**Jira References:**
SRVKP-13180, SRVKP-13181, SRVKP-13191

# Submitter Checklist

- [x] Has Tests included if any functionality added or changed — no functional change, stdlib security patch only
- [x] Tested your changes locally — `go test ./pkg/... ./cmd/...` all pass
- [x] Follows the commit message standard
- [x] Meets the Tekton contributor standards
- [x] Has a kind label — /kind bug

# Release Notes

```release-note
Security: Update Go stdlib from 1.26.5 to 1.26.6 to address 7 vulnerabilities (GO-2026-6218, GO-2026-6091, GO-2026-6090, GO-2026-6089, GO-2026-6088, GO-2026-5972, GO-2026-5026)
```

---
*Generated by CVE Fixer automation. Reviewed by: Emil Natan (enatan@redhat.com)*