### PR TITLE
feat(watcher): filter TaskRun/PipelineRun by spec.managedBy

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/oauth"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
@@ -83,6 +84,7 @@ var (
 	disableStoringIncompleteRuns = flag.Bool("disable_storing_incomplete_runs", false, "If enabled, Runs will not be stored until they are complete. If disabled, Runs will be initially stored upon creation and continuously upserted until after they're deleted")
 	storeDeadline                = flag.Duration("store_deadline", 10*time.Minute, "How long to wait for storing the PipelineRun and TaskRun resources before aborting and clearing the finalizer in case of delete event")
 	forwardBuffer                = flag.Duration("forward_buffer", 150*time.Second, "This determines duration since completion time of TaskRun to wait for forwarder to finish")
+	managedByValues              = flag.String("managed_by_values", "", "Comma-separated list of additional spec.managedBy values the watcher will process. Runs with unset, empty, whitespace-only or \"tekton.dev/pipeline\" managedBy values are always accepted.")
 )
 
 func main() {
@@ -136,9 +138,11 @@ func main() {
 		SummaryLabels:                *summaryLabels,
 		SummaryAnnotations:           *summaryAnnotations,
 		DisableStoringIncompleteRuns: *disableStoringIncompleteRuns,
+		AllowedManagedByValues:       reconciler.ParseManagedByValues(*managedByValues),
 	}
 
 	log.Printf("dynamic reconcile timeout %s and update log timeout is %s", cfg.DynamicReconcileTimeout.String(), cfg.UpdateLogTimeout.String())
+	log.Printf("managed_by_values: %v", sets.List(cfg.AllowedManagedByValues))
 
 	if selector := *labelSelector; selector != "" {
 		if err := cfg.SetLabelSelector(selector); err != nil {
@@ -169,7 +173,8 @@ func main() {
 		k8scfg.Burst = *burst * len(ctors)
 	}
 
-	sharedmain.MainWithConfig(injection.WithNamespaceScope(ctx, *namespace), "watcher", k8scfg, ctors...,
+	sharedmain.MainWithConfig(
+		injection.WithNamespaceScope(ctx, *namespace), "watcher", k8scfg, ctors...,
 	)
 }
 
@@ -187,7 +192,8 @@ func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*
 	// Add in additional credentials to requests if desired.
 	switch authMode {
 	case "google":
-		opts = append(opts,
+		opts = append(
+			opts,
 			grpc.WithAuthority(apiAddr),
 			grpc.WithTransportCredentials(cred),
 			grpc.WithDefaultCallOptions(grpc.PerRPCCredentials(creds.Google())),
@@ -199,7 +205,8 @@ func connectToAPIServer(ctx context.Context, apiAddr string, authMode string) (*
 		} else {
 			ts = transport.NewCachedFileTokenSource(podTokenPath)
 		}
-		opts = append(opts,
+		opts = append(
+			opts,
 			grpc.WithDefaultCallOptions(grpc.PerRPCCredentials(oauth.TokenSource{TokenSource: ts})),
 			grpc.WithTransportCredentials(cred),
 		)

--- a/docs/watcher/README.md
+++ b/docs/watcher/README.md
@@ -77,6 +77,40 @@ Watcher implements a finalizer to block deletion by an external pruner when obje
 When deletion request comes, it will block until completion time + `completed_run_grace_period` period is passed. A hard limit could be set as `store_deadline` (default 10m), after which the object will be removed from the cluster even without confirmation it's been stored in the DB.
 
 
+## Filtering by `spec.managedBy`
+
+The `managed_by_values` flag controls which TaskRuns and PipelineRuns the Watcher will process based on their `spec.managedBy` field. This is useful when multiple controllers manage Tekton resources and you want the Results Watcher to only track runs managed by specific controllers.
+
+- `tekton.dev/pipeline` is **always accepted** and cannot be removed.
+- Runs with **unset, empty, or whitespace-only** `spec.managedBy` are always accepted (backward compatible).
+- Additional values can be specified as a comma-separated list.
+
+For example, to also process runs managed by a custom controller:
+
+```
+--managed_by_values=custom-controller
+```
+
+Multiple values:
+
+```
+--managed_by_values=custom-controller,another-controller
+```
+
+CustomRuns are not filtered because the CustomRun type does not have a `spec.managedBy` field.
+
+> **Note:** If a value is removed from `--managed_by_values`, the Watcher will
+> still process runs that already carry a Results finalizer so the finalizer
+> can be cleared and the resource can be deleted. New runs with that
+> `managedBy` value will be ignored. Runs that had a finalizer but were not
+> yet stored will **not** be stored — the finalizer is released without
+> persisting data, matching the operator's intent to stop tracking those runs.
+
+> **Known limitation:** Filtering applies to each resource independently.
+> If an external controller sets `spec.managedBy` on a PipelineRun but its
+> child TaskRuns or CustomRuns have nil `spec.managedBy` (the default), the
+> Watcher will ignore the PipelineRun but still process the child runs.
+
 ## Disabling Incomplete Runs storage
 
 The `disable_storing_incomplete_runs` flag controls whether the Watcher should store PipelineRuns, TaskRuns, and CustomRuns that are still in progress (i.e., not yet completed, cancelled or failed).

--- a/pkg/watcher/reconciler/config.go
+++ b/pkg/watcher/reconciler/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Config defines shared reconciler configuration options.
@@ -76,6 +77,12 @@ type Config struct {
 
 	// DisableStoringIncompleteRuns disables the collection of incomplete Runs data
 	DisableStoringIncompleteRuns bool
+
+	// AllowedManagedByValues is the set of spec.managedBy values the watcher
+	// will process. pipeline.ManagedBy ("tekton.dev/pipeline") is always
+	// included. Runs with nil or empty managedBy are also always accepted.
+	// This set must not be mutated after initialization to avoid data races.
+	AllowedManagedByValues sets.Set[string]
 }
 
 // GetDisableAnnotationUpdate returns whether annotation updates should be

--- a/pkg/watcher/reconciler/filter.go
+++ b/pkg/watcher/reconciler/filter.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Finalizer names added by the watcher to track resources it processes.
+const (
+	PipelineRunFinalizer = "results.tekton.dev/pipelinerun"
+	TaskRunFinalizer     = "results.tekton.dev/taskrun"
+)
+
+// IsManagedByAllowed reports whether a spec.managedBy value should be
+// processed. Nil, empty, and whitespace-only values are always allowed.
+// The incoming value is trimmed before lookup so that " custom-controller "
+// matches a configured "custom-controller".
+func IsManagedByAllowed(managedBy *string, allowed sets.Set[string]) bool {
+	if managedBy == nil {
+		return true
+	}
+	trimmed := strings.TrimSpace(*managedBy)
+	if trimmed == "" || trimmed == pipeline.ManagedBy {
+		return true
+	}
+	return allowed.Has(trimmed)
+}
+
+// ParseManagedByValues parses a comma-separated list of additional
+// spec.managedBy values into a set. pipeline.ManagedBy is always included.
+func ParseManagedByValues(raw string) sets.Set[string] {
+	s := sets.New[string](pipeline.ManagedBy)
+	if raw == "" {
+		return s
+	}
+	for _, v := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			s.Insert(trimmed)
+		}
+	}
+	return s
+}
+
+// unwrapTombstone extracts the wrapped object from a
+// cache.DeletedFinalStateUnknown tombstone. If obj is not a tombstone
+// it is returned as-is.
+func unwrapTombstone(obj interface{}) interface{} {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		return d.Obj
+	}
+	return obj
+}
+
+// PipelineRunFilterFunc returns a filter function for PipelineRuns
+// that checks whether the run's spec.managedBy value is allowed.
+// Tombstone (DeletedFinalStateUnknown) objects are unwrapped before
+// the type assertion so that delete events are never silently dropped.
+// Objects being deleted (DeletionTimestamp set) that carry a Results
+// finalizer are always passed through so the finalizer can be removed
+// even if the allowlist has been shrunk since the finalizer was added.
+func PipelineRunFilterFunc(allowedManagedBy sets.Set[string]) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		pr, ok := unwrapTombstone(obj).(*v1.PipelineRun)
+		if !ok || pr == nil {
+			return false
+		}
+		if pr.DeletionTimestamp != nil && slices.Contains(pr.Finalizers, PipelineRunFinalizer) {
+			return true
+		}
+		return IsManagedByAllowed(pr.Spec.ManagedBy, allowedManagedBy)
+	}
+}
+
+// TaskRunFilterFunc returns a filter function for TaskRuns
+// that checks whether the run's spec.managedBy value is allowed.
+// Tombstone (DeletedFinalStateUnknown) objects are unwrapped before
+// the type assertion so that delete events are never silently dropped.
+// Objects being deleted (DeletionTimestamp set) that carry a Results
+// finalizer are always passed through so the finalizer can be removed
+// even if the allowlist has been shrunk since the finalizer was added.
+func TaskRunFilterFunc(allowedManagedBy sets.Set[string]) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		tr, ok := unwrapTombstone(obj).(*v1.TaskRun)
+		if !ok || tr == nil {
+			return false
+		}
+		if tr.DeletionTimestamp != nil && slices.Contains(tr.Finalizers, TaskRunFinalizer) {
+			return true
+		}
+		return IsManagedByAllowed(tr.Spec.ManagedBy, allowedManagedBy)
+	}
+}

--- a/pkg/watcher/reconciler/filter_test.go
+++ b/pkg/watcher/reconciler/filter_test.go
@@ -1,0 +1,444 @@
+// Copyright 2026 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
+)
+
+func TestIsManagedByAllowed(t *testing.T) {
+	allowed := sets.New[string]("tekton.dev/pipeline")
+
+	tests := []struct {
+		name      string
+		managedBy *string
+		allowed   sets.Set[string]
+		expected  bool
+	}{
+		{
+			name:      "nil managedBy is allowed",
+			managedBy: nil,
+			allowed:   allowed,
+			expected:  true,
+		},
+		{
+			name:      "empty string managedBy is allowed",
+			managedBy: ptr.To(""),
+			allowed:   allowed,
+			expected:  true,
+		},
+		{
+			name:      "tekton.dev/pipeline is allowed",
+			managedBy: ptr.To("tekton.dev/pipeline"),
+			allowed:   allowed,
+			expected:  true,
+		},
+		{
+			name:      "custom controller is rejected",
+			managedBy: ptr.To("custom-controller"),
+			allowed:   allowed,
+			expected:  false,
+		},
+		{
+			name:      "custom controller is allowed when configured",
+			managedBy: ptr.To("custom-controller"),
+			allowed:   sets.New[string]("tekton.dev/pipeline", "custom-controller"),
+			expected:  true,
+		},
+		{
+			name:      "nil allowlist rejects custom controller",
+			managedBy: ptr.To("custom-controller"),
+			allowed:   nil,
+			expected:  false,
+		},
+		{
+			name:      "nil allowlist accepts tekton.dev/pipeline",
+			managedBy: ptr.To("tekton.dev/pipeline"),
+			allowed:   nil,
+			expected:  true,
+		},
+		{
+			name:      "nil allowlist accepts nil managedBy",
+			managedBy: nil,
+			allowed:   nil,
+			expected:  true,
+		},
+		{
+			name:      "whitespace-only managedBy is allowed",
+			managedBy: ptr.To("  "),
+			allowed:   allowed,
+			expected:  true,
+		},
+		{
+			name:      "trimmed managedBy matches allowed value",
+			managedBy: ptr.To(" custom-controller "),
+			allowed:   sets.New[string]("tekton.dev/pipeline", "custom-controller"),
+			expected:  true,
+		},
+		{
+			name:      "trimmed tekton.dev/pipeline is allowed with nil allowlist",
+			managedBy: ptr.To(" tekton.dev/pipeline "),
+			allowed:   nil,
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsManagedByAllowed(tt.managedBy, tt.allowed)
+			if result != tt.expected {
+				t.Errorf("IsManagedByAllowed() = %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseManagedByValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected sets.Set[string]
+	}{
+		{
+			name:     "empty string includes default",
+			raw:      "",
+			expected: sets.New[string]("tekton.dev/pipeline"),
+		},
+		{
+			name:     "single value",
+			raw:      "custom-controller",
+			expected: sets.New[string]("tekton.dev/pipeline", "custom-controller"),
+		},
+		{
+			name:     "multiple values with whitespace",
+			raw:      "custom-controller, another-controller",
+			expected: sets.New[string]("tekton.dev/pipeline", "custom-controller", "another-controller"),
+		},
+		{
+			name:     "duplicate default value",
+			raw:      "tekton.dev/pipeline",
+			expected: sets.New[string]("tekton.dev/pipeline"),
+		},
+		{
+			name:     "trailing comma ignored",
+			raw:      "custom-controller,",
+			expected: sets.New[string]("tekton.dev/pipeline", "custom-controller"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseManagedByValues(tt.raw)
+			if !result.Equal(tt.expected) {
+				t.Errorf("ParseManagedByValues(%q) = %v, wanted %v", tt.raw, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPipelineRunFilterFunc(t *testing.T) {
+	defaultAllowed := sets.New[string]("tekton.dev/pipeline")
+
+	tests := []struct {
+		name     string
+		allowed  sets.Set[string]
+		obj      interface{}
+		expected bool
+	}{
+		{
+			name:     "nil managedBy, should match",
+			allowed:  defaultAllowed,
+			obj:      &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected: true,
+		},
+		{
+			name:    "empty string managedBy, should match",
+			allowed: defaultAllowed,
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.PipelineRunSpec{ManagedBy: ptr.To("")},
+			},
+			expected: true,
+		},
+		{
+			name:    "tekton.dev/pipeline managedBy, should match",
+			allowed: defaultAllowed,
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.PipelineRunSpec{ManagedBy: ptr.To("tekton.dev/pipeline")},
+			},
+			expected: true,
+		},
+		{
+			name:    "custom controller, should not match",
+			allowed: defaultAllowed,
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.PipelineRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: false,
+		},
+		{
+			name:    "custom controller with custom config, should match",
+			allowed: sets.New[string]("tekton.dev/pipeline", "custom-controller"),
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.PipelineRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: true,
+		},
+		{
+			name:     "non-PipelineRun object, should not match",
+			allowed:  defaultAllowed,
+			obj:      &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected: false,
+		},
+		{
+			name:    "tombstone with allowed PipelineRun, should match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-pr",
+				Obj: &v1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+					Spec:       v1.PipelineRunSpec{ManagedBy: ptr.To("tekton.dev/pipeline")},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "tombstone with custom controller PipelineRun, should not match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-pr-custom",
+				Obj: &v1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+					Spec:       v1.PipelineRunSpec{ManagedBy: ptr.To("custom-controller")},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "tombstone with nil managedBy PipelineRun, should match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-pr-nil",
+				Obj: &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			},
+			expected: true,
+		},
+		{
+			name:    "disallowed managedBy with finalizer but not deleting, should not match",
+			allowed: defaultAllowed,
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "default",
+					Finalizers: []string{PipelineRunFinalizer},
+				},
+				Spec: v1.PipelineRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: false,
+		},
+		{
+			name:    "disallowed managedBy with finalizer and deleting, should match",
+			allowed: defaultAllowed,
+			obj: &v1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Finalizers:        []string{PipelineRunFinalizer},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: v1.PipelineRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: true,
+		},
+		{
+			name:    "tombstone with disallowed managedBy but has Results finalizer, should match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-pr-finalizer",
+				Obj: &v1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "default",
+						Finalizers:        []string{PipelineRunFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: v1.PipelineRunSpec{ManagedBy: ptr.To("custom-controller")},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterFunc := PipelineRunFilterFunc(tt.allowed)
+			result := filterFunc(tt.obj)
+			if result != tt.expected {
+				t.Errorf("PipelineRunFilterFunc() = %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTaskRunFilterFunc(t *testing.T) {
+	defaultAllowed := sets.New[string]("tekton.dev/pipeline")
+
+	tests := []struct {
+		name     string
+		allowed  sets.Set[string]
+		obj      interface{}
+		expected bool
+	}{
+		{
+			name:     "nil managedBy, should match",
+			allowed:  defaultAllowed,
+			obj:      &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected: true,
+		},
+		{
+			name:    "empty string managedBy, should match",
+			allowed: defaultAllowed,
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.TaskRunSpec{ManagedBy: ptr.To("")},
+			},
+			expected: true,
+		},
+		{
+			name:    "tekton.dev/pipeline managedBy, should match",
+			allowed: defaultAllowed,
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.TaskRunSpec{ManagedBy: ptr.To("tekton.dev/pipeline")},
+			},
+			expected: true,
+		},
+		{
+			name:    "custom controller, should not match",
+			allowed: defaultAllowed,
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.TaskRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: false,
+		},
+		{
+			name:    "custom controller with custom config, should match",
+			allowed: sets.New[string]("tekton.dev/pipeline", "custom-controller"),
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec:       v1.TaskRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: true,
+		},
+		{
+			name:     "non-TaskRun object, should not match",
+			allowed:  defaultAllowed,
+			obj:      &v1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			expected: false,
+		},
+		{
+			name:    "tombstone with allowed TaskRun, should match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-tr",
+				Obj: &v1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+					Spec:       v1.TaskRunSpec{ManagedBy: ptr.To("tekton.dev/pipeline")},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:    "tombstone with custom controller TaskRun, should not match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-tr-custom",
+				Obj: &v1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+					Spec:       v1.TaskRunSpec{ManagedBy: ptr.To("custom-controller")},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "tombstone with nil managedBy TaskRun, should match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-tr-nil",
+				Obj: &v1.TaskRun{ObjectMeta: metav1.ObjectMeta{Namespace: "default"}},
+			},
+			expected: true,
+		},
+		{
+			name:    "disallowed managedBy with finalizer but not deleting, should not match",
+			allowed: defaultAllowed,
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "default",
+					Finalizers: []string{TaskRunFinalizer},
+				},
+				Spec: v1.TaskRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: false,
+		},
+		{
+			name:    "disallowed managedBy with finalizer and deleting, should match",
+			allowed: defaultAllowed,
+			obj: &v1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Finalizers:        []string{TaskRunFinalizer},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: v1.TaskRunSpec{ManagedBy: ptr.To("custom-controller")},
+			},
+			expected: true,
+		},
+		{
+			name:    "tombstone with disallowed managedBy but has Results finalizer, should match",
+			allowed: defaultAllowed,
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "default/tombstone-tr-finalizer",
+				Obj: &v1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "default",
+						Finalizers:        []string{TaskRunFinalizer},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+					Spec: v1.TaskRunSpec{ManagedBy: ptr.To("custom-controller")},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterFunc := TaskRunFilterFunc(tt.allowed)
+			result := filterFunc(tt.obj)
+			if result != tt.expected {
+				t.Errorf("TaskRunFilterFunc() = %v, wanted %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/watcher/reconciler/pipelinerun/controller.go
+++ b/pkg/watcher/reconciler/pipelinerun/controller.go
@@ -33,6 +33,7 @@ import (
 	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/pipelinerun"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/taskrun"
 	customruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/customrun"
+	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
@@ -70,6 +71,8 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 		pipelineRunMetrics: pipelineRunMetrics,
 	}
 
+	managedByFilter := reconciler.PipelineRunFilterFunc(cfg.AllowedManagedByValues)
+
 	impl := pipelinerunreconciler.NewImpl(ctx, c, func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			// This results pipelinerun reconciler shouldn't mutate the pipelinerun's status.
@@ -78,12 +81,16 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 			FinalizerName:                   "results.tekton.dev/pipelinerun",
 			UseServerSideApplyForFinalizers: true,
 			FinalizerFieldManager:           "tekton-results-watcher/finalizers",
+			PromoteFilterFunc:               managedByFilter,
 		}
 	})
 
-	_, err = pipelineRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	_, err = pipelineRunInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: managedByFilter,
+		Handler:    controller.HandleAll(impl.Enqueue),
+	})
 	if err != nil {
-		logger.Panicf("Couldn't register PipelineRun informer event handler: %w", err)
+		logger.Panicf("Couldn't register PipelineRun informer event handler: %v", err)
 	}
 
 	return impl

--- a/pkg/watcher/reconciler/pipelinerun/reconciler.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler.go
@@ -42,6 +42,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	knativereconciler "knative.dev/pkg/reconciler"
@@ -49,7 +50,6 @@ import (
 
 // Reconciler represents pipelineRun watcher logic
 type Reconciler struct {
-
 	// kubeClientSet allows us to talk to the k8s for core APIs
 	kubeClientSet kubernetes.Interface
 
@@ -66,14 +66,21 @@ type Reconciler struct {
 }
 
 // Check that our Reconciler implements pipelinerunreconciler.Interface and pipelinerunreconciler.Finalizer
-var _ pipelinerunreconciler.Interface = (*Reconciler)(nil)
-var _ pipelinerunreconciler.Finalizer = (*Reconciler)(nil)
+var (
+	_ pipelinerunreconciler.Interface = (*Reconciler)(nil)
+	_ pipelinerunreconciler.Finalizer = (*Reconciler)(nil)
+)
 
 // ReconcileKind makes new watcher reconcile cycle to handle PipelineRun.
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *pipelinev1.PipelineRun) knativereconciler.Event {
 	logger := logging.FromContext(ctx).With(zap.String("results.tekton.dev/kind", "PipelineRun"))
 
 	logger.Infof("Initiating reconciliation for PipelineRun '%s/%s'", pr.Namespace, pr.Name)
+
+	if !reconciler.IsManagedByAllowed(pr.Spec.ManagedBy, r.cfg.AllowedManagedByValues) {
+		logger.Debugf("skipping PipelineRun %s/%s: managedBy %q not in allowed set", pr.Namespace, pr.Name, ptr.Deref(pr.Spec.ManagedBy, ""))
+		return nil
+	}
 
 	if r.cfg.DisableStoringIncompleteRuns {
 		// Skip if pipelinerun is not done
@@ -200,6 +207,20 @@ func isCustomRunMarkedAsReadyForDeletion(customRun *pipelinev1beta1.CustomRun) b
 // that we see flowing through the system.  If we don't add a finalizer, it could
 // get cleaned up before we see the final state and store it.
 func (r *Reconciler) FinalizeKind(ctx context.Context, pr *pipelinev1.PipelineRun) knativereconciler.Event {
+	if !reconciler.IsManagedByAllowed(pr.Spec.ManagedBy, r.cfg.AllowedManagedByValues) {
+		logging.FromContext(ctx).Infof("releasing finalizer for PipelineRun %s/%s: managedBy no longer in allowed set", pr.Namespace, pr.Name)
+		if r.isFinalizerOwnedByMergePatch(pr) {
+			logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration (disallowed managedBy path)",
+				pr.Namespace, pr.Name)
+			if err := r.removeFinalizerViaMergePatch(ctx, pr); err != nil {
+				logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+					zap.Error(err))
+				return controller.NewRequeueAfter(r.cfg.FinalizerRequeueInterval)
+			}
+		}
+		return nil
+	}
+
 	// Reconcile the pipelinerun to ensure that it is stored in the database
 	rerr := r.ReconcileKind(ctx, pr)
 	if rerr != nil {
@@ -352,6 +373,7 @@ func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, pr *pipel
 	}
 
 	_, err = r.pipelineClient.TektonV1().PipelineRuns(pr.Namespace).Patch(
-		ctx, pr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		ctx, pr.Name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
 	return err
 }

--- a/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
+++ b/pkg/watcher/reconciler/pipelinerun/reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 	apis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
@@ -68,6 +69,22 @@ func TestReconcile(t *testing.T) {
 			},
 			cfg: &reconciler.Config{
 				DisableStoringIncompleteRuns: true,
+			},
+			want: nil,
+		},
+		{
+			name: "disallowed managedBy - skip",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+				},
+				Spec: pipelinev1.PipelineRunSpec{
+					ManagedBy: ptr.To("custom-controller"),
+				},
+			},
+			cfg: &reconciler.Config{
+				AllowedManagedByValues: reconciler.ParseManagedByValues(""),
 			},
 			want: nil,
 		},
@@ -112,41 +129,45 @@ func TestReconcile(t *testing.T) {
 		})
 	}
 }
+
 func TestAreAllUnderlyingTaskRunsReadyForDeletion(t *testing.T) {
 	tests := []struct {
 		name string
 		in   *pipelinev1.PipelineRun
 		want bool
-	}{{
-		name: "all underlying TaskRuns are ready to be deleted",
-		in: &pipelinev1.PipelineRun{
-			Status: pipelinev1.PipelineRunStatus{
-				PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
-					ChildReferences: []pipelinev1.ChildStatusReference{{
-						TypeMeta: runtime.TypeMeta{
-							Kind:       "TaskRun",
-							APIVersion: "tekton.dev/v1",
+	}{
+		{
+			name: "all underlying TaskRuns are ready to be deleted",
+			in: &pipelinev1.PipelineRun{
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						ChildReferences: []pipelinev1.ChildStatusReference{
+							{
+								TypeMeta: runtime.TypeMeta{
+									Kind:       "TaskRun",
+									APIVersion: "tekton.dev/v1",
+								},
+								Name: "foo",
+							},
 						},
-						Name: "foo",
-					},
 					},
 				},
 			},
+			want: true,
 		},
-		want: true,
-	},
 		{
 			name: "one TaskRun is ready to be deleted whereas the other is not",
 			in: &pipelinev1.PipelineRun{
 				Status: pipelinev1.PipelineRunStatus{
 					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
-						ChildReferences: []pipelinev1.ChildStatusReference{{
-							TypeMeta: runtime.TypeMeta{
-								Kind:       "TaskRun",
-								APIVersion: "tekton.dev/v1",
+						ChildReferences: []pipelinev1.ChildStatusReference{
+							{
+								TypeMeta: runtime.TypeMeta{
+									Kind:       "TaskRun",
+									APIVersion: "tekton.dev/v1",
+								},
+								Name: "foo",
 							},
-							Name: "foo",
-						},
 							{
 								TypeMeta: runtime.TypeMeta{
 									Kind:       "TaskRun",
@@ -165,13 +186,14 @@ func TestAreAllUnderlyingTaskRunsReadyForDeletion(t *testing.T) {
 			in: &pipelinev1.PipelineRun{
 				Status: pipelinev1.PipelineRunStatus{
 					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
-						ChildReferences: []pipelinev1.ChildStatusReference{{
-							TypeMeta: runtime.TypeMeta{
-								Kind:       "TaskRun",
-								APIVersion: "tekton.dev/v1",
+						ChildReferences: []pipelinev1.ChildStatusReference{
+							{
+								TypeMeta: runtime.TypeMeta{
+									Kind:       "TaskRun",
+									APIVersion: "tekton.dev/v1",
+								},
+								Name: "foo",
 							},
-							Name: "foo",
-						},
 							{
 								TypeMeta: runtime.TypeMeta{
 									Kind:       "TaskRun",
@@ -580,28 +602,89 @@ func TestFinalize(t *testing.T) {
 	}
 }
 
+func TestFinalizeKindDisallowedManagedBy(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pr   *pipelinev1.PipelineRun
+		cfg  *reconciler.Config
+		want knativereconciler.Event
+	}{
+		{
+			name: "disallowed managedBy - release finalizer",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-pr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/pipelinerun"},
+				},
+				Spec: pipelinev1.PipelineRunSpec{
+					ManagedBy: ptr.To("custom-controller"),
+				},
+			},
+			cfg: &reconciler.Config{
+				AllowedManagedByValues: reconciler.ParseManagedByValues(""),
+			},
+			want: nil,
+		},
+		{
+			name: "disallowed managedBy with merge-patch finalizer - release finalizer",
+			pr: &pipelinev1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:          "test-pr",
+					Namespace:     "test-ns",
+					Finalizers:    []string{"results.tekton.dev/pipelinerun"},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/pipelinerun"),
+				},
+				Spec: pipelinev1.PipelineRunSpec{
+					ManagedBy: ptr.To("custom-controller"),
+				},
+			},
+			cfg: &reconciler.Config{
+				AllowedManagedByValues: reconciler.ParseManagedByValues(""),
+			},
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+
+			fakeClient := fakeversioned.NewSimpleClientset(tc.pr)
+			r := &Reconciler{
+				cfg:            tc.cfg,
+				pipelineClient: fakeClient,
+			}
+			got := r.FinalizeKind(ctx, tc.pr)
+			if got != tc.want {
+				t.Errorf("FinalizeKind() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAreAllUnderlyingRunsReadyForDeletion_WithCustomRuns(t *testing.T) {
 	tests := []struct {
 		name string
 		in   *pipelinev1.PipelineRun
 		want bool
-	}{{
-		name: "all CustomRuns are ready to be deleted",
-		in: &pipelinev1.PipelineRun{
-			Status: pipelinev1.PipelineRunStatus{
-				PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
-					ChildReferences: []pipelinev1.ChildStatusReference{{
-						TypeMeta: runtime.TypeMeta{
-							Kind:       "CustomRun",
-							APIVersion: "tekton.dev/v1beta1",
-						},
-						Name: "custom-foo",
-					}},
+	}{
+		{
+			name: "all CustomRuns are ready to be deleted",
+			in: &pipelinev1.PipelineRun{
+				Status: pipelinev1.PipelineRunStatus{
+					PipelineRunStatusFields: pipelinev1.PipelineRunStatusFields{
+						ChildReferences: []pipelinev1.ChildStatusReference{{
+							TypeMeta: runtime.TypeMeta{
+								Kind:       "CustomRun",
+								APIVersion: "tekton.dev/v1beta1",
+							},
+							Name: "custom-foo",
+						}},
+					},
 				},
 			},
+			want: true,
 		},
-		want: true,
-	},
 		{
 			name: "one CustomRun is ready, one TaskRun is not",
 			in: &pipelinev1.PipelineRun{

--- a/pkg/watcher/reconciler/taskrun/controller.go
+++ b/pkg/watcher/reconciler/taskrun/controller.go
@@ -31,6 +31,7 @@ import (
 
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/taskrun"
+	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
@@ -66,6 +67,8 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 		taskRunMetrics: taskRunMetrics,
 	}
 
+	managedByFilter := reconciler.TaskRunFilterFunc(cfg.AllowedManagedByValues)
+
 	impl := taskrunreconciler.NewImpl(ctx, c, func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			// This results taskrun reconciler shouldn't mutate the taskrun's status.
@@ -74,12 +77,16 @@ func NewControllerWithConfig(ctx context.Context, resultsClient pb.ResultsClient
 			FinalizerName:                   "results.tekton.dev/taskrun",
 			UseServerSideApplyForFinalizers: true,
 			FinalizerFieldManager:           "tekton-results-watcher/finalizers",
+			PromoteFilterFunc:               managedByFilter,
 		}
 	})
 
-	_, err = informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	_, err = informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: managedByFilter,
+		Handler:    controller.HandleAll(impl.Enqueue),
+	})
 	if err != nil {
-		logger.Panicf("Couldn't register TaskRun informer event handler: %w", err)
+		logger.Panicf("Couldn't register TaskRun informer event handler: %v", err)
 	}
 
 	return impl

--- a/pkg/watcher/reconciler/taskrun/reconciler.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	knativereconciler "knative.dev/pkg/reconciler"
@@ -33,7 +34,6 @@ import (
 
 // Reconciler represents taskRun watcher logic
 type Reconciler struct {
-
 	// kubeClientSet allows us to talk to the k8s for core APIs
 	kubeClientSet kubernetes.Interface
 
@@ -48,12 +48,19 @@ type Reconciler struct {
 }
 
 // Check that our Reconciler implements taskrunreconciler.Interface and taskrunreconciler.Finalizer
-var _ taskrunreconciler.Interface = (*Reconciler)(nil)
-var _ taskrunreconciler.Finalizer = (*Reconciler)(nil)
+var (
+	_ taskrunreconciler.Interface = (*Reconciler)(nil)
+	_ taskrunreconciler.Finalizer = (*Reconciler)(nil)
+)
 
 // ReconcileKind makes new watcher reconcile cycle to handle TaskRun.
 func (r *Reconciler) ReconcileKind(ctx context.Context, tr *pipelinev1.TaskRun) knativereconciler.Event {
 	logger := logging.FromContext(ctx).With(zap.String("results.tekton.dev/kind", "TaskRun"))
+
+	if !reconciler.IsManagedByAllowed(tr.Spec.ManagedBy, r.cfg.AllowedManagedByValues) {
+		logger.Debugf("skipping TaskRun %s/%s: managedBy %q not in allowed set", tr.Namespace, tr.Name, ptr.Deref(tr.Spec.ManagedBy, ""))
+		return nil
+	}
 
 	if r.cfg.DisableStoringIncompleteRuns {
 		// Skip if taskrun is not done
@@ -100,6 +107,20 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, tr *pipelinev1.TaskRun) 
 // that we see flowing through the system.  If we don't add a finalizer, it could
 // get cleaned up before we see the final state and store it.
 func (r *Reconciler) FinalizeKind(ctx context.Context, tr *pipelinev1.TaskRun) knativereconciler.Event {
+	if !reconciler.IsManagedByAllowed(tr.Spec.ManagedBy, r.cfg.AllowedManagedByValues) {
+		logging.FromContext(ctx).Infof("releasing finalizer for TaskRun %s/%s: managedBy no longer in allowed set", tr.Namespace, tr.Name)
+		if r.isFinalizerOwnedByMergePatch(tr) {
+			logging.FromContext(ctx).Infof("Removing merge-patch finalizer on %s/%s for SSA migration (disallowed managedBy path)",
+				tr.Namespace, tr.Name)
+			if err := r.removeFinalizerViaMergePatch(ctx, tr); err != nil {
+				logging.FromContext(ctx).Warnw("Failed to remove finalizer via merge patch",
+					zap.Error(err))
+				return controller.NewRequeueAfter(r.cfg.FinalizerRequeueInterval)
+			}
+		}
+		return nil
+	}
+
 	// Reconcile the taskrun to ensure that it is stored in the database
 	rerr := r.ReconcileKind(ctx, tr)
 	if rerr != nil {
@@ -267,6 +288,7 @@ func (r *Reconciler) removeFinalizerViaMergePatch(ctx context.Context, tr *pipel
 	}
 
 	_, err = r.pipelineClient.TektonV1().TaskRuns(tr.Namespace).Patch(
-		ctx, tr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+		ctx, tr.Name, types.MergePatchType, patch, metav1.PatchOptions{},
+	)
 	return err
 }

--- a/pkg/watcher/reconciler/taskrun/reconciler_test.go
+++ b/pkg/watcher/reconciler/taskrun/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 	apis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
@@ -64,6 +65,22 @@ func TestReconcile(t *testing.T) {
 			},
 			cfg: &reconciler.Config{
 				DisableStoringIncompleteRuns: true,
+			},
+			want: nil,
+		},
+		{
+			name: "disallowed managedBy - skip",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-tr",
+					Namespace: "test-ns",
+				},
+				Spec: pipelinev1.TaskRunSpec{
+					ManagedBy: ptr.To("custom-controller"),
+				},
+			},
+			cfg: &reconciler.Config{
+				AllowedManagedByValues: reconciler.ParseManagedByValues(""),
 			},
 			want: nil,
 		},
@@ -451,6 +468,66 @@ func TestFinalize(t *testing.T) {
 			got := r.finalize(ctx, tc.pr, tc.reconcileError)
 			if !errors.Is(got, tc.want) {
 				t.Errorf("finalize() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFinalizeKindDisallowedManagedBy(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tr   *pipelinev1.TaskRun
+		cfg  *reconciler.Config
+		want knativereconciler.Event
+	}{
+		{
+			name: "disallowed managedBy - release finalizer",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-tr",
+					Namespace:  "test-ns",
+					Finalizers: []string{"results.tekton.dev/taskrun"},
+				},
+				Spec: pipelinev1.TaskRunSpec{
+					ManagedBy: ptr.To("custom-controller"),
+				},
+			},
+			cfg: &reconciler.Config{
+				AllowedManagedByValues: reconciler.ParseManagedByValues(""),
+			},
+			want: nil,
+		},
+		{
+			name: "disallowed managedBy with merge-patch finalizer - release finalizer",
+			tr: &pipelinev1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:          "test-tr",
+					Namespace:     "test-ns",
+					Finalizers:    []string{"results.tekton.dev/taskrun"},
+					ManagedFields: mergePatchFinalizerManagedFields("results.tekton.dev/taskrun"),
+				},
+				Spec: pipelinev1.TaskRunSpec{
+					ManagedBy: ptr.To("custom-controller"),
+				},
+			},
+			cfg: &reconciler.Config{
+				AllowedManagedByValues: reconciler.ParseManagedByValues(""),
+			},
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = logging.WithLogger(ctx, zaptest.NewLogger(t).Sugar())
+
+			fakeClient := fakeversioned.NewSimpleClientset(tc.tr)
+			r := &Reconciler{
+				cfg:            tc.cfg,
+				pipelineClient: fakeClient,
+			}
+			got := r.FinalizeKind(ctx, tc.tr)
+			if got != tc.want {
+				t.Errorf("FinalizeKind() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/test/e2e/managed_by_e2e_test.go
+++ b/test/e2e/managed_by_e2e_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+)
+
+// TestManagedByCustomControllerNotProcessed verifies that TaskRuns and
+// PipelineRuns with a custom spec.managedBy value are ignored by the
+// Results watcher. The watcher should not add its finalizer or
+// results.tekton.dev annotations to these runs.
+//
+// Instead of sleeping, we create a "control" resource with the default
+// managedBy and poll until the watcher processes it. Once the control
+// resource has Results annotations, we know the watcher has had ample
+// time to process anything in its queue — so the custom-managed resource
+// should still be untouched.
+func TestManagedByCustomControllerNotProcessed(t *testing.T) {
+	ctx := context.Background()
+	tc := tektonClient(t)
+
+	t.Run("taskrun", func(t *testing.T) {
+		// Create the custom-managed TaskRun (should be ignored).
+		customTR := &tektonv1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "managed-by-custom-tr-",
+			},
+			Spec: tektonv1.TaskRunSpec{
+				TaskSpec: &tektonv1.TaskSpec{
+					Steps: []tektonv1.Step{{
+						Name:    "hello",
+						Image:   "alpine",
+						Command: []string{"echo", "hello"},
+					}},
+				},
+				ManagedBy: ptr.To("custom-controller"),
+			},
+		}
+		createdCustom, err := tc.TaskRuns(defaultNamespace).Create(ctx, customTR, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create custom-managed TaskRun: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = tc.TaskRuns(defaultNamespace).Delete(ctx, createdCustom.Name, metav1.DeleteOptions{})
+		})
+
+		// Create a control TaskRun (default managedBy — should be processed).
+		controlTR := &tektonv1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "managed-by-control-tr-",
+			},
+			Spec: tektonv1.TaskRunSpec{
+				TaskSpec: &tektonv1.TaskSpec{
+					Steps: []tektonv1.Step{{
+						Name:    "hello",
+						Image:   "alpine",
+						Command: []string{"echo", "hello"},
+					}},
+				},
+			},
+		}
+		createdControl, err := tc.TaskRuns(defaultNamespace).Create(ctx, controlTR, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create control TaskRun: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = tc.TaskRuns(defaultNamespace).Delete(ctx, createdControl.Name, metav1.DeleteOptions{})
+		})
+
+		// Wait for the control TaskRun to be processed by the watcher.
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			got, err := tc.TaskRuns(defaultNamespace).Get(ctx, createdControl.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			_, hasResult := got.Annotations["results.tekton.dev/result"]
+			_, hasRecord := got.Annotations["results.tekton.dev/record"]
+			return hasResult && hasRecord, nil
+		}); err != nil {
+			t.Fatalf("Timed out waiting for Results annotations on control TaskRun: %v", err)
+		}
+
+		// Now assert the custom-managed TaskRun was NOT processed.
+		got, err := tc.TaskRuns(defaultNamespace).Get(ctx, createdCustom.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get custom-managed TaskRun: %v", err)
+		}
+		for _, f := range got.Finalizers {
+			if f == "results.tekton.dev/taskrun" {
+				t.Errorf("Results finalizer %q should not be added to externally-managed TaskRun", f)
+			}
+		}
+		for key := range got.Annotations {
+			if key == "results.tekton.dev/result" || key == "results.tekton.dev/record" {
+				t.Errorf("Annotation %q should not be set on externally-managed TaskRun", key)
+			}
+		}
+	})
+
+	t.Run("pipelinerun", func(t *testing.T) {
+		// Create the custom-managed PipelineRun (should be ignored).
+		customPR := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "managed-by-custom-pr-",
+			},
+			Spec: tektonv1.PipelineRunSpec{
+				PipelineSpec: &tektonv1.PipelineSpec{
+					Tasks: []tektonv1.PipelineTask{{
+						Name: "hello",
+						TaskSpec: &tektonv1.EmbeddedTask{
+							TaskSpec: tektonv1.TaskSpec{
+								Steps: []tektonv1.Step{{
+									Name:    "hello",
+									Image:   "alpine",
+									Command: []string{"echo", "hello"},
+								}},
+							},
+						},
+					}},
+				},
+				ManagedBy: ptr.To("custom-controller"),
+			},
+		}
+		createdCustom, err := tc.PipelineRuns(defaultNamespace).Create(ctx, customPR, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create custom-managed PipelineRun: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = tc.PipelineRuns(defaultNamespace).Delete(ctx, createdCustom.Name, metav1.DeleteOptions{})
+		})
+
+		// Create a control PipelineRun (default managedBy — should be processed).
+		controlPR := &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "managed-by-control-pr-",
+			},
+			Spec: tektonv1.PipelineRunSpec{
+				PipelineSpec: &tektonv1.PipelineSpec{
+					Tasks: []tektonv1.PipelineTask{{
+						Name: "hello",
+						TaskSpec: &tektonv1.EmbeddedTask{
+							TaskSpec: tektonv1.TaskSpec{
+								Steps: []tektonv1.Step{{
+									Name:    "hello",
+									Image:   "alpine",
+									Command: []string{"echo", "hello"},
+								}},
+							},
+						},
+					}},
+				},
+			},
+		}
+		createdControl, err := tc.PipelineRuns(defaultNamespace).Create(ctx, controlPR, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create control PipelineRun: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = tc.PipelineRuns(defaultNamespace).Delete(ctx, createdControl.Name, metav1.DeleteOptions{})
+		})
+
+		// Wait for the control PipelineRun to be processed by the watcher.
+		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			got, err := tc.PipelineRuns(defaultNamespace).Get(ctx, createdControl.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			_, hasResult := got.Annotations["results.tekton.dev/result"]
+			_, hasRecord := got.Annotations["results.tekton.dev/record"]
+			return hasResult && hasRecord, nil
+		}); err != nil {
+			t.Fatalf("Timed out waiting for Results annotations on control PipelineRun: %v", err)
+		}
+
+		// Now assert the custom-managed PipelineRun was NOT processed.
+		got, err := tc.PipelineRuns(defaultNamespace).Get(ctx, createdCustom.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get custom-managed PipelineRun: %v", err)
+		}
+		for _, f := range got.Finalizers {
+			if f == "results.tekton.dev/pipelinerun" {
+				t.Errorf("Results finalizer %q should not be added to externally-managed PipelineRun", f)
+			}
+		}
+		for key := range got.Annotations {
+			if key == "results.tekton.dev/result" || key == "results.tekton.dev/record" {
+				t.Errorf("Annotation %q should not be set on externally-managed PipelineRun", key)
+			}
+		}
+	})
+}
+
+// TestManagedByDefaultProcessed verifies that TaskRuns and PipelineRuns
+// with nil or default managedBy values are processed normally by the
+// Results watcher.
+func TestManagedByDefaultProcessed(t *testing.T) {
+	ctx := context.Background()
+	tc := tektonClient(t)
+
+	tests := []struct {
+		name      string
+		managedBy *string
+	}{
+		{
+			name:      "nil managedBy",
+			managedBy: nil,
+		},
+		{
+			name:      "tekton.dev/pipeline managedBy",
+			managedBy: ptr.To("tekton.dev/pipeline"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("taskrun/"+tt.name, func(t *testing.T) {
+			tr := &tektonv1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-by-default-tr-",
+				},
+				Spec: tektonv1.TaskRunSpec{
+					TaskSpec: &tektonv1.TaskSpec{
+						Steps: []tektonv1.Step{{
+							Name:    "hello",
+							Image:   "alpine",
+							Command: []string{"echo", "hello"},
+						}},
+					},
+					ManagedBy: tt.managedBy,
+				},
+			}
+
+			created, err := tc.TaskRuns(defaultNamespace).Create(ctx, tr, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create TaskRun: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = tc.TaskRuns(defaultNamespace).Delete(ctx, created.Name, metav1.DeleteOptions{})
+			})
+
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				got, err := tc.TaskRuns(defaultNamespace).Get(ctx, created.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				_, hasResult := got.Annotations["results.tekton.dev/result"]
+				_, hasRecord := got.Annotations["results.tekton.dev/record"]
+				return hasResult && hasRecord, nil
+			}); err != nil {
+				t.Fatalf("Timed out waiting for Results annotations on TaskRun: %v", err)
+			}
+		})
+
+		t.Run("pipelinerun/"+tt.name, func(t *testing.T) {
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-by-default-pr-",
+				},
+				Spec: tektonv1.PipelineRunSpec{
+					PipelineSpec: &tektonv1.PipelineSpec{
+						Tasks: []tektonv1.PipelineTask{{
+							Name: "hello",
+							TaskSpec: &tektonv1.EmbeddedTask{
+								TaskSpec: tektonv1.TaskSpec{
+									Steps: []tektonv1.Step{{
+										Name:    "hello",
+										Image:   "alpine",
+										Command: []string{"echo", "hello"},
+									}},
+								},
+							},
+						}},
+					},
+					ManagedBy: tt.managedBy,
+				},
+			}
+
+			created, err := tc.PipelineRuns(defaultNamespace).Create(ctx, pr, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Failed to create PipelineRun: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = tc.PipelineRuns(defaultNamespace).Delete(ctx, created.Name, metav1.DeleteOptions{})
+			})
+
+			if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				got, err := tc.PipelineRuns(defaultNamespace).Get(ctx, created.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				_, hasResult := got.Annotations["results.tekton.dev/result"]
+				_, hasRecord := got.Annotations["results.tekton.dev/record"]
+				return hasResult && hasRecord, nil
+			}); err != nil {
+				t.Fatalf("Timed out waiting for Results annotations on PipelineRun: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add filtering so the Results watcher only processes TaskRuns and
  PipelineRuns whose `spec.managedBy` value is allowed. By default,
  `tekton.dev/pipeline` is always accepted, as are runs with unset,
  empty, or whitespace-only `managedBy`. Users can configure additional
  allowed values via the `--managed_by_values` flag.

  The filter is applied in two places:
  - **Informer level**: `cache.FilteringResourceEventHandler` prevents enqueuing runs with disallowed `managedBy` on normal watch events.
  - **Leader promotion**: `PromoteFilterFunc` in `controller.Options` prevents re-enqueuing those same runs when a replica becomes leader.

  Tombstone (`DeletedFinalStateUnknown`) objects are unwrapped before the type assertion so that delete events are never silently dropped.

  CustomRuns are not filtered because the `CustomRun` type does not have a `spec.managedBy` field.

  Similar to [tektoncd/chains#1882](https://github.com/tektoncd/chains/pull/1882).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes


```release-note
The Results Watcher now supports filtering TaskRuns and PipelineRuns by `spec.managedBy`.
  Use the new `--managed_by_values` flag to specify which controllers' runs the Watcher should
  process. `tekton.dev/pipeline` and unset values are always accepted. Runs with disallowed
  `managedBy` values are ignored at the informer, reconciler, and leader election layers.
  If the allowlist is later shrunk, existing finalizers are cleaned up on deletion, including
  legacy merge-patch finalizers from pre-SSA versions.
```

