### PR TITLE
[release-v0.10.x] Security: Update Go directive to 1.25.13 (stdlib CVE fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tektoncd/results
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5


### PR DESCRIPTION
## Changes

Update the `go` directive from 1.25.12 to 1.25.13 to fix multiple stdlib CVEs on release-v0.10.x.

All other security dep upgrades (grpc v1.82.1, x/text v0.39.0, x/net v0.56.0, compress v1.18.7) were already merged into the base branch via #1413, #1423, and #1424 — this PR carries **only the `go` directive bump**.

### CVEs Fixed

| Advisory | Module | Fixed in |
|----------|--------|----------|
| GO-2026-6088 | encoding/xml | go1.25.13 |
| GO-2026-6089 | net/http | go1.25.13 |
| GO-2026-6090 | crypto/tls | go1.25.13 |
| GO-2026-6091 | html/template | go1.25.13 |
| GO-2026-6218 | net/url | go1.25.13 |
| GO-2026-5972 | encoding/asn1 | go1.25.13 |
| GO-2026-5026 | net/http | go1.25.13 |

### What Changed

- `go` directive: 1.25.12 → **1.25.13** (1-line change in go.mod)
- `vendor/` updated: `go mod tidy && go mod verify && go mod vendor`
- All other deps unchanged (grpc v1.82.1, x/text v0.39.0, x/net v0.56.0, compress v1.18.7 already in base)

### Risk Assessment

**Low** — single-line patch version bump within the same minor release. go1.25.13 is a security-only point release with no API changes.

### Jira

Resolves fixable stdlib CVEs in:
- SRVKP-13180 ([GovCloud] pipelines-results-watcher-rhel9)
- SRVKP-13181 ([GovCloud] pipelines-results-api-rhel9)
- SRVKP-13191 ([GovCloud] pipelines-results-retention-policy-agent-rhel9)

/kind bug
/priority high-priority

```release-note
Security: Update Go directive to 1.25.13 to fix stdlib CVEs GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091, GO-2026-6218, GO-2026-5972, GO-2026-5026 in release-v0.10.x
```

---

**Signed-off-by:** Divyanshu Agrawal <diagrawa@redhat.com>
**Co-Assisted-By:** Claude Sonnet 4.6 <noreply@anthropic.com>