### PR TITLE
fix: exclude generated and non-library code from codecov coverage

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,32 +1,33 @@
 coverage:
-  # Commit status https://docs.codecov.io/docs/commit-status are used
-  # to block PR based on coverage threshold.
   status:
     project:
       default:
         target: auto
         threshold: 5%
     patch:
-      # Disable the coverage threshold of the patch, so that PRs are
-      # only failing because of overall project coverage threshold.
-      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
       default: false
 
 ignore:
   # Auto-generated protobuf code.
-  - "proto/v1alpha2/results_go_proto/**"
-  - "proto/v1alpha3/results_go_proto/**"
-  - "proto/pipeline/v1/pipeline_go_proto/**"
-  - "pkg/api/server/db/pagination/proto/internal_go_proto/**"
-  - "pkg/api/server/v1alpha2/lister/proto/pagetoken_go_proto/**"
-  - "internal/fieldmask/test/**"
-  - "pkg/test/**"
-  - "cmd/**"
-  - "test/**"
-  - "config/**"
-  - "hack/**"
-  - "tools/**"
-  - "release/**"
-  - "tekton/**"
-  - "docs/**"
-  - "vendor/**"
+  - "proto"
+  - "**/*.pb.go"
+  - "**/fake/**"
+  # Entry-point binaries.
+  - "cmd"
+  # Test infrastructure.
+  - "test"
+  - "pkg/test/"
+  - "pkg/internal/test/"
+  - "pkg/api/server/test/"
+  - "internal/fieldmask/test/"
+  - "pkg/cli/testutils/"
+  # Non-executable files (doc, go:generate).
+  - "**/doc.go"
+  - "**/generate.go"
+  - "config"
+  - "hack"
+  - "tools"
+  - "release"
+  - "tekton"
+  - "docs"
+  - "vendor"

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Generate coverage
         working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
         run: |
-          go test ./... -coverprofile=coverage.out -covermode=atomic || true
+          PACKAGES=$(go list ./... | grep -vE '/cmd(/|$)|/vendor(/|$)|/hack(/|$)|/test(/|$)|/tools(/|$)|/release(/|$)|/tekton(/|$)|/docs(/|$)|/config(/|$)|/proto(/|$)|/pkg/test(/|$)|/pkg/internal/test(/|$)|/pkg/api/server/test(/|$)|/pkg/cli/testutils(/|$)|/internal/fieldmask/test(/|$)|_go_proto(/|$)')
+          COVERPKG=$(echo $PACKAGES | tr ' ' ',')
+          go test -coverprofile=coverage_raw.out -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES
+          grep -vE '\.pb\.go' coverage_raw.out > coverage.out
+          rm -f coverage_raw.out
           echo "Generated coverage profile"
 
       - name: Upload coverage to Codecov
@@ -54,3 +58,4 @@ jobs:
           flags: unit-tests
           use_oidc: true
           fail_ci_if_error: false
+          disable_search: true


### PR DESCRIPTION
Codecov reports low coverage because it includes auto-generated protobuf code, vendored deps, CLI entry points, and test infrastructure in the denominator. Filter these out so coverage reflects actual library code. Mirrors the approach proven in tektoncd/triggers#2101.

- Replace bare `go test ./...` with filtered package list + `-coverpkg`
- Strip .pb.go files from profile
- Add `disable_search: true` to codecov upload step
- Use bare directory names and glob patterns in .codecov.yaml

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes



```release-note
NONE
```

