### PR TITLE
Make CI workflows reusable via workflow_call for cross-branch reuse

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,7 @@ on:
     branches: ["main"]
   schedule:
     - cron: '38 3 * * 3'
+  workflow_call: {}
 
 jobs:
   analyze:

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -6,7 +6,8 @@ permissions:
 on:
   push:
     branches: ["main"]
-  workflow_dispatch:
+  workflow_dispatch: {}
+  workflow_call: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -4,6 +4,16 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   pull_request:  # yamllint disable-line rule:empty-values
+  workflow_call:
+    inputs:
+      base-ref:
+        description: >-
+          Base ref to diff against for --new-from-merge-base. github.base_ref
+          is only set for direct pull_request triggers and is empty inside a
+          called workflow, so callers invoking this via workflow_call from a
+          pull_request should pass their own github.base_ref here.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -26,4 +36,4 @@ jobs:
         with:
           install-mode: "goinstall" #This is a temporary workaround to unblock the CI. Should be removed after workflow is fixed
           version: v2.12.2
-          args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m
+          args: --new-from-merge-base=origin/${{ inputs['base-ref'] || github.base_ref }} --timeout=10m

--- a/.github/workflows/presubmit-ci.yaml
+++ b/.github/workflows/presubmit-ci.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release-*
+  workflow_call: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -144,5 +145,3 @@ jobs:
           echo "All jobs passed or were skipped"
         env:
           JOB_RESULTS: ${{ join(needs.*.result, ' ') }}
-
-

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["**"]
+  workflow_call: {}
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Adds an `on: workflow_call:` trigger to `codeql.yml`, `zizmor.yaml`, `golangci-lint.yaml`, `presubmit-ci.yaml`, and `go-coverage.yml` so that active release branches can call these canonical workflow definitions directly instead of maintaining full duplicated copies.

This is the first of a set of companion PRs against each active release branch (`release-v0.17.x`, `release-v0.18.x`, `release-v0.19.x`, `release-v0.20.x`) that replace their duplicated workflow files with thin wrappers using:

```yaml
jobs:
  some-job:
    uses: tektoncd/results/.github/workflows/<file>@main
```

Editing workflow logic on `main` then automatically applies everywhere, instead of needing to hand-edit each release branch.

Existing `push`/`pull_request`/`schedule` triggers on `main` are unchanged, so `main`'s own CI behavior is unaffected by this change — it purely adds the ability for other workflows/branches to call these as reusable workflows.

## Test plan

- [ ] Confirm CI still runs as before on this PR (push/pull_request triggers unchanged)
- [ ] Merge this PR before merging the companion release-branch PRs, since they reference `uses: tektoncd/results/.github/workflows/<file>@main`

Made with [Cursor](https://cursor.com)