### PR TITLE
Delegate CI workflows to main's reusable workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,56 +1,22 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
+# Thin wrapper that delegates to the canonical CodeQL workflow maintained
+# on the main branch, so the actual scanning logic only lives in one place.
+# See https://github.com/tektoncd/results/blob/main/.github/workflows/codeql.yml
 name: "CodeQL"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["release-v0.19.x"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ["main"]
+    branches: ["release-v0.19.x"]
   schedule:
     - cron: '38 3 * * 3'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ['go']
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        persist-credentials: false
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@a8d1ac45b9a34d11fe398d5503176af0d06b303e # v3.30.7
-      with:
-        languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@a8d1ac45b9a34d11fe398d5503176af0d06b303e # v3.30.7
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@a8d1ac45b9a34d11fe398d5503176af0d06b303e # v3.30.7
-      with:
-        category: "/language:${{matrix.language}}"
-        output: "../analysis"
+    uses: tektoncd/results/.github/workflows/codeql.yml@main

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,67 +1,20 @@
 name: Go coverage
+# Thin wrapper that delegates to the canonical go-coverage workflow
+# maintained on the main branch. See
+# https://github.com/tektoncd/results/blob/main/.github/workflows/go-coverage.yml
 
 permissions:
   contents: read
 
 on:
-  pull_request:
-    branches: ["main"]
   push:
-    branches: ["main"]
-  # run at least once every 2 months to prevent the coverage artifact from expiring
-  schedule:
-    - cron: '14 3 4 */2 *'
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
-defaults:
-  run:
-    shell: bash
+    branches: ["release-v0.19.x"]
+  workflow_dispatch: {}
 
 jobs:
   go-coverage:
     name: Go coverage
-    runs-on: ubuntu-24.04
     permissions:
-      pull-requests: write
-
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          path: ${{ github.workspace }}/src/github.com/tektoncd/results
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
-        with:
-          go-version-file: "${{ github.workspace }}/src/github.com/tektoncd/results/go.mod"
-
-      - name: Generate coverage
-        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
-        run: |
-          go test -cover -coverprofile=coverage.txt ./... || true
-          echo "Generated coverage profile"
-
-      - name: Archive coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: code-coverage
-          path: ${{ github.workspace }}/src/github.com/tektoncd/results/coverage.txt
-
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: fgrosse/go-coverage-report@8c1d1a09864211d258937b1b1a5b849f7e4f2682 # v1.2.0
-        continue-on-error: true # This may fail if artifact on main branch does not exist (first run or expired)
-        with:
-          token: ${{ secrets.CHATOPS_TOKEN }}
-          coverage-artifact-name: "code-coverage"
-          coverage-file-name: "coverage.txt"
+      contents: read
+      id-token: write
+    uses: tektoncd/results/.github/workflows/go-coverage.yml@main

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,8 +1,11 @@
 name: golangci-lint
+# Thin wrapper that delegates to the canonical golangci-lint workflow
+# maintained on the main branch. See
+# https://github.com/tektoncd/results/blob/main/.github/workflows/golangci-lint.yaml
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
-      - main
+      - release-v0.19.x
   pull_request:  # yamllint disable-line rule:empty-values
 
 permissions:
@@ -12,17 +15,9 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34  # v5.3.0
-        with:
-          go-version-file: "go.mod"
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-        with:
-          version: v2.8.0
-          args: --new-from-merge-base=origin/${{ github.base_ref }} --timeout=10m
+    permissions:
+      contents: read
+      checks: write
+    uses: tektoncd/results/.github/workflows/golangci-lint.yaml@main
+    with:
+      base-ref: ${{ github.base_ref }}

--- a/.github/workflows/presubmit-ci.yaml
+++ b/.github/workflows/presubmit-ci.yaml
@@ -1,4 +1,7 @@
 name: Results CI Presubmit Tests
+# Thin wrapper that delegates to the canonical presubmit workflow
+# maintained on the main branch. See
+# https://github.com/tektoncd/results/blob/main/.github/workflows/presubmit-ci.yaml
 
 on:
   pull_request:
@@ -6,143 +9,28 @@ on:
       - main
       - release-*
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
-env:
-  SHELL: /bin/bash
-  GOPATH: ${{ github.workspace }}
-  GO111MODULE: on
-  KIND_CLUSTER_NAME: tekton-results
-
 jobs:
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          path: ${{ github.workspace }}/src/github.com/tektoncd/results
-          persist-credentials: false
+  presubmit:
+    permissions:
+      contents: read
+    uses: tektoncd/results/.github/workflows/presubmit-ci.yaml@main
+    with:
+      skip-ci-summary: true
 
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          cache-dependency-path: src/github.com/tektoncd/results/go.sum
-          go-version-file: src/github.com/tektoncd/results/go.mod
-
-      - name: Install dependencies
-        run: |
-          go install github.com/jstemmer/go-junit-report@v0.9.1
-          mkdir -p "${ARTIFACTS:-/tmp/artifacts}"
-          echo "${GOPATH}/bin" >> "$GITHUB_PATH"
-
-      - name: Run Unit Tests
-        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
-        run: ./test/presubmit-tests.sh --unit-tests
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: ${{ github.workspace }}/src/github.com/tektoncd/results
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          cache-dependency-path: src/github.com/tektoncd/results/go.sum
-          go-version-file: src/github.com/tektoncd/results/go.mod
-
-      - name: Install dependencies (ko, kind, kubectl, go-junit-report)
-        run: |
-          echo '::group::install ko'
-          curl -L https://github.com/ko-build/ko/releases/download/v0.15.4/ko_0.15.4_Linux_x86_64.tar.gz | tar xzf - ko
-          chmod +x ./ko && sudo mv ko /usr/local/bin
-          echo '::endgroup::'
-
-          echo '::group::install kind'
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
-          chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
-          echo '::endgroup::'
-
-          echo '::group::install kubectl'
-          curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x kubectl && sudo mv kubectl /usr/local/bin/kubectl
-          echo '::endgroup::'
-
-          echo '::group::install go-junit-report'
-          go install github.com/jstemmer/go-junit-report@v0.9.1
-          echo '::endgroup::'
-
-          mkdir -p "${ARTIFACTS:-/tmp/artifacts}"
-          echo "${GOPATH}/bin" >> "$GITHUB_PATH"
-
-      - name: Run Integration Tests
-        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
-        run: ./test/presubmit-tests.sh --integration-tests
-
-  build-tests:
-    name: Build Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: ${{ github.workspace }}/src/github.com/tektoncd/results
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          cache-dependency-path: src/github.com/tektoncd/results/go.sum
-          go-version-file: src/github.com/tektoncd/results/go.mod
-
-      - name: Install dependencies (go-junit-report, go-licenses)
-        run: |
-          echo '::group::install go-junit-report'
-          go install github.com/jstemmer/go-junit-report@v0.9.1
-          echo '::endgroup::'
-
-          echo '::group::install go-licenses'
-          go install github.com/google/go-licenses@latest
-          echo '::endgroup::'
-
-          mkdir -p "${ARTIFACTS:-/tmp/artifacts}"
-          echo "${GOPATH}/bin" >> "$GITHUB_PATH"
-
-      - name: Run Build Tests
-        working-directory: ${{ github.workspace }}/src/github.com/tektoncd/results
-        run: ./test/presubmit-tests.sh --build-tests
-
-  ci-summary:
+  CI-summary:
     name: CI summary
     if: always()
-    needs:
-      - unit-tests
-      - integration-tests
-      - build-tests
+    needs: [presubmit]
     runs-on: ubuntu-latest
     steps:
-      - name: Check job results
+      - name: Check result
         run: |
-          results=(${JOB_RESULTS})
-          for result in "${results[@]}"; do
-            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
-              echo "One or more jobs failed or were cancelled"
-              exit 1
-            fi
-          done
-          echo "All jobs passed or were skipped"
+          if [[ "$PRESUBMIT_RESULT" != "success" ]]; then
+            echo "Presubmit workflow failed"
+            exit 1
+          fi
         env:
-          JOB_RESULTS: ${{ join(needs.*.result, ' ') }}
-
-
+          PRESUBMIT_RESULT: ${{ needs.presubmit.result }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,8 +1,11 @@
+# Thin wrapper that delegates to the canonical zizmor workflow maintained
+# on the main branch. See
+# https://github.com/tektoncd/results/blob/main/.github/workflows/zizmor.yaml
 name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
-    branches: ["main"]
+    branches: ["release-v0.19.x"]
   pull_request:
     branches: ["**"]
 
@@ -10,14 +13,7 @@ permissions: {}
 
 jobs:
   zizmor:
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+    uses: tektoncd/results/.github/workflows/zizmor.yaml@main


### PR DESCRIPTION
## Summary

Companion PR to https://github.com/tektoncd/results/pull/1453 for `release-v0.19.x`.

Replaces the duplicated `codeql.yml`, `zizmor.yaml`, `golangci-lint.yaml`, `presubmit-ci.yaml`, and `go-coverage.yml` logic with thin wrappers that call the canonical `workflow_call`-enabled definitions on `main`:

```yaml
jobs:
  some-job:
    uses: tektoncd/results/.github/workflows/<file>@main
```

This keeps workflow logic maintained in a single place (`main`) instead of duplicated per branch.

### Behavior changes as a result

- Switches `go-coverage.yml` from the artifact + PR-comment mechanism to `main`'s Codecov + OIDC upload, removing the dependency on `secrets.CHATOPS_TOKEN` for this workflow, and scopes its `push` trigger to this branch instead of the non-matching `main` branch.
- Standardizes `golangci-lint` on `main`'s current pinned versions (action v9.3.0 / golangci-lint v2.12.2, up from v9.2.0 / v2.8.0). The `.golangci.yml` linter configuration is unchanged and already identical to `main`; no new default linters were introduced between these versions.

## Test plan

- [ ] Merge https://github.com/tektoncd/results/pull/1453 first so `@main` exposes the `workflow_call` triggers
- [ ] Confirm `presubmit-ci`, `golangci-lint`, `codeql`, and `zizmor` workflows run successfully on this PR via the reusable-workflow delegation
- [ ] Watch the first real `golangci-lint` run for any newly-surfaced findings from the version bump

Made with [Cursor](https://cursor.com)