### PR TITLE
Add skip-ci-summary input to presubmit workflow

### DIFF
--- a/.github/workflows/presubmit-ci.yaml
+++ b/.github/workflows/presubmit-ci.yaml
@@ -5,7 +5,17 @@ on:
     branches:
       - main
       - release-*
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      skip-ci-summary:
+        description: >-
+          When true the ci-summary job is skipped. Callers that need to
+          report their own "CI summary" check (to satisfy branch protection
+          rules that expect the unprefixed name) should set this to true
+          and define the summary job themselves.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -126,7 +136,7 @@ jobs:
 
   ci-summary:
     name: CI summary
-    if: always()
+    if: ${{ always() && !inputs.skip-ci-summary }}
     needs:
       - unit-tests
       - integration-tests


### PR DESCRIPTION
## Summary

- Adds a `skip-ci-summary` boolean input (default `false`) to `presubmit-ci.yaml`'s `workflow_call` trigger
- When `true`, the `ci-summary` job is skipped, allowing callers to define their own "CI summary" check at the caller level

This fixes a branch protection issue where release branch callers report the check as `presubmit / CI summary` (due to reusable workflow job name prefixing) instead of the expected `CI summary`.

Direct runs on `main` are unaffected since the input defaults to `false`.

Companion to PRs #1454, #1455, #1456, #1457 which pass `skip-ci-summary: true` and define their own `CI summary` job.

## Test plan

- CI on this PR validates that the direct `pull_request` trigger still runs `ci-summary` (input defaults to `false`)
- Once merged, release branch PRs will call with `skip-ci-summary: true` and report their own `CI summary` check

/kind cleanup

Made with [Cursor](https://cursor.com)