### PR TITLE
fix(api): bind profiling server to loopback only

### DIFF
--- a/cmd/api/README.md
+++ b/cmd/api/README.md
@@ -11,8 +11,8 @@
 | DB_SSLMODE               | Database SSL mode                                                                                                                 | verify-full                                                                                  |
 | DB_SSLROOTCERT           | Path to CA cert used to validate Database cert                                                                                    | /etc/tls/db/ca.crt                                                                           |
 | DB_ENABLE_AUTO_MIGRATION | Auto-migrate the database on startup (create/update schemas). For further details, refer to <https://gorm.io/docs/migration.html> | true (default)                                                                               |
-| PROFILING                | Enable profiling server                                                                                                           | false  (default)                                                                             |
-| PROFILING_PORT           | Profiling Server Port                                                                                                             | 6060  (default)                                                                              |
+| PROFILING                | Enable profiling server (bound to `127.0.0.1` only, not reachable from outside the pod)                                          | false  (default)                                                                             |
+| PROFILING_PORT           | Profiling Server Port (loopback-only)                                                                                            | 6060  (default)                                                                              |
 | DB_MAX_IDLE_CONNECTIONS  | The number of idle database connections to keep open                                                                              | 2 (default for golang, but specific database drivers may have settings for this too)         |
 | DB_MAX_OPEN_CONNECTIONS  | The maximum number of database connections, for best performance it should equal DB_MAX_IDLE_CONNECTIONS                          | unlimited (default for golang, but specific database drivers may have settings for this too) |
 | GRPC_WORKER_POOL         | The maximum number of goroutines pre-allocated for process GRPC requests. The GRPC server will also dynamically create threads.   | 2 (default)                                                                                  |
@@ -52,6 +52,15 @@ These values can also be set in the config file located in the `config/env/confi
 Values derived from Postgres DSN
 
 If you use the default postgres database we provide, the `DB_HOST` can be set as `tekton-results-postgres-service.tekton-pipelines`.
+
+## Profiling
+
+When `PROFILING=true`, the server exposes Go's `net/http/pprof` endpoints on `127.0.0.1:$PROFILING_PORT`. To access it, use `kubectl exec` or `kubectl port-forward` into the `api` pod, e.g.:
+
+```sh
+kubectl port-forward -n tekton-pipelines deploy/tekton-results-api 6060:6060
+curl http://localhost:6060/debug/pprof/heap > heap.out
+```
 
 ## TLS Configuration
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -79,6 +79,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// profilingServerAddress returns the address to bind the profiling server to.
+// The profiling server is always bound to loopback (127.0.0.1) to prevent
+// unauthenticated access from outside the pod.
+func profilingServerAddress(port string) string {
+	return "127.0.0.1:" + port
+}
+
 func main() {
 	serverConfig := config.Get()
 
@@ -326,11 +333,12 @@ func main() {
 	// Allow service reflection - required for grpc_cli ls to work.
 	reflection.Register(gs)
 
-	// Enable profiling server
+	// Enable profiling server on loopback interface.
+	// Access it via `kubectl exec` or `kubectl port-forward`.
 	if serverConfig.PROFILING {
 		go func() {
-			log.Infof("Profiling server listening on: %s", serverConfig.PROFILING_PORT)
-			if err := http.ListenAndServe(":"+serverConfig.PROFILING_PORT, nil); err != nil {
+			log.Infof("Profiling server listening on: %s", profilingServerAddress(serverConfig.PROFILING_PORT))
+			if err := http.ListenAndServe(profilingServerAddress(serverConfig.PROFILING_PORT), nil); err != nil {
 				log.Fatalf("Error running Profiling server: %v", err)
 			}
 		}()

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -67,3 +67,40 @@ func contextWithLogger(w io.Writer) context.Context {
 	logger := zap.New(zapcore.NewCore(encoder, writer, zapcore.DebugLevel))
 	return ctxzap.ToContext(context.Background(), logger)
 }
+
+func Test_profilingServerAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		port string
+		want string
+	}{
+		{
+			name: "default port",
+			port: "6060",
+			want: "127.0.0.1:6060",
+		},
+		{
+			name: "custom port",
+			port: "9999",
+			want: "127.0.0.1:9999",
+		},
+		{
+			name: "empty port",
+			port: "",
+			want: "127.0.0.1:",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := profilingServerAddress(tc.port)
+			if got != tc.want {
+				t.Errorf("profilingServerAddress(%q) = %q, want %q", tc.port, got, tc.want)
+			}
+			// Security check: verify the address is bound to loopback only
+			if !strings.HasPrefix(got, "127.0.0.1:") {
+				t.Errorf("profilingServerAddress(%q) = %q, must start with '127.0.0.1:' for security", tc.port, got)
+			}
+		})
+	}
+}

--- a/config/base/api.yaml
+++ b/config/base/api.yaml
@@ -128,7 +128,3 @@ spec:
       protocol: TCP
       port: 9090
       targetPort: 9090
-    - name: profiling
-      protocol: TCP
-      port: 6060
-      targetPort: 6060

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -683,9 +683,14 @@ curl -k https://localhost:8080/healthz?service=tekton.results.v1alpha2.Results
 
 ## Profiling
 
-The API Server includes an HTTP server for exposing golang's debug profiles. By default, the Service is disabled and exposes debug profiles on port `:6060`. For more
-details on the using the profiles, see
-<https://pkg.go.dev/net/http/pprof>.
+The API Server includes an HTTP server for exposing golang's debug profiles. By default, the service is disabled. When enabled via `PROFILING=true`, the profiling listener binds to `127.0.0.1:6060` (loopback only) and is not reachable from outside the pod. Access it using `kubectl exec` or `kubectl port-forward`, e.g.:
+
+```sh
+kubectl port-forward -n tekton-pipelines deploy/tekton-results-api 6060:6060
+curl http://localhost:6060/debug/pprof/heap > heap.out
+```
+
+For more details on using the profiles, see <https://pkg.go.dev/net/http/pprof>.
 
 
 ## References


### PR DESCRIPTION
The pprof profiling endpoint had no authentication and was reachable cluster-wide via the api-service Service port. Bind it to 127.0.0.1 and drop the Service port entry so it is only reachable via `kubectl exec`/`kubectl port-forward`.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind bug
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:
-->
```release-note
Hardened the API server's profiling configuration: the `pprof` endpoint listener is now bound to localhost only, instead of being exposed unauthenticated on a cluster-reachable Service port.
```

<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
