### PR TITLE
fix(e2e) Loki configuration in e2e test

### DIFF
--- a/test/e2e/blob-logs/vector-s3.yaml
+++ b/test/e2e/blob-logs/vector-s3.yaml
@@ -4,7 +4,6 @@ customConfig:
   api:
     enabled: true
     address: 127.0.0.1:8686
-    playground: false
   sources:
     kubernetes_logs:
       type: kubernetes_logs

--- a/test/e2e/loki_vector/loki-vector-api-config.yaml
+++ b/test/e2e/loki_vector/loki-vector-api-config.yaml
@@ -21,11 +21,12 @@ data:
     LOGS_BUFFER_SIZE=32768888
     LOGS_PATH=/logs
     LOGGING_PLUGIN_STATIC_LABELS='log_type=application'
-    LOGGING_PLUIN_TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
+    LOGGING_PLUGIN_TOKEN_PATH=/var/run/secrets/kubernetes.io/serviceaccount/token
     LOGGING_PLUGIN_PROXY_PATH=
     LOGGING_PLUGIN_NAMESPACE_KEY=kubernetes_namespace_name
     LOGGING_PLUGIN_CONTAINER_KEY=kubernetes.container_name
-    LOGGING_PLUGIN_API_URL=http://loki.logging.svc.cluster.local:3100/loki/api/v1/query_range
+    LOGGING_PLUGIN_API_URL=http://loki.logging.svc.cluster.local:3100
+    LOGGING_PLUGIN_QUERY_LIMIT=1700
 kind: ConfigMap
 metadata:
   labels:

--- a/test/e2e/loki_vector/vector.yaml
+++ b/test/e2e/loki_vector/vector.yaml
@@ -4,7 +4,6 @@ customConfig:
   api:
     enabled: true
     address: 127.0.0.1:8686
-    playground: false
   sources:
     kubernetes_logs:
       type: kubernetes_logs
@@ -19,6 +18,8 @@ customConfig:
         .log_type = "application"
         .log_tekton = "application"
         .kubernetes_namespace_name = .kubernetes.pod_namespace
+        .kubernetes.labels.tekton_dev_taskRunUID = .kubernetes.pod_labels."tekton.dev/taskRunUID"
+        .kubernetes.labels.tekton_dev_pipelineRunUID = .kubernetes.pod_labels."tekton.dev/pipelineRunUID"
   sinks:
     loki:
       type: loki


### PR DESCRIPTION
It was broken in multiple ways, typo in the env var name, deprecated `playground` option, duplicated path, incompatible limit and pod label mapping. This only affects the e2e flow with loki log forwarding enabled and does not affect the general e2e tests as used in ci.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here and link issues if any- Ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- /kind bug, cleanup, design, documentation, feature, flake, misc, question, tep -->
/kind misc
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you review them:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [Tested your changes locally](https://github.com/tektoncd/results/blob/main/docs/DEVELOPMENT.md) (if this is a code change)
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Has a kind label. You can add a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user-facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contain the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

Use the `/release-note-none` Prow command to add the `release-note-none` label to the PR for pull requests that don't need to be mentioned at release time. You can also write the string "NONE" as a release note in your PR description:
-->
```release-note
NONE
```


<!-- Feel free to add more heading to include screenshots, test logs, action items etc. Prefer removing unused options and comments to keep the description clean. -->
