### PR TITLE
fix: use separate root README for GitHub link resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
-docs/README.md
+
+# Tekton Results
+
+[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/tektoncd/results)
+[![Go Report Card](https://goreportcard.com/badge/tektoncd/results)](https://goreportcard.com/report/tektoncd/results)
+
+Tekton Results aims to help users logically group CI/CD workload history and
+separate out long term result storage away from the Pipeline controller. This
+allows you to:
+
+- Provide custom Result metadata about your CI/CD workflows not available in the
+  Tekton TaskRun/PipelineRun CRDs (for example: post-run actions)
+- Group related workloads together (e.g. bundle related TaskRuns and
+  PipelineRuns into a single unit)
+- Make long-term result history independent of the Pipeline CRD controller,
+  letting you free up etcd resources for Run execution.
+- Store logs produced by the TaskRuns/PipelineRuns so that completed Runs can be cleaned to save resources.
+
+Additional background and design motivations can be found in
+[TEP-0021](https://github.com/tektoncd/community/blob/main/teps/0021-results-api.md).
+
+## Overview
+
+Tekton Results is composed of 3 main components:
+
+- A [queryable gRPC API server](docs/api/) backed by persistent storage (see
+  [proto/v1alpha2](../proto/v1alpha2) for the latest API spec).
+- A [controller to watch and report](docs/watcher/) TaskRun, PipelineRun, and
+  CustomRun updates to the API server.
+- A [retention policy agent](docs/retention-policy-agent/), an agent which deletes older data from DB.
+
+### Life of a Result
+
+```mermaid
+sequenceDiagram
+  actor U as Users
+  participant PC as Pipeline Controller
+  participant RW as Result Watcher
+  participant RA as Result API
+  U->>PC: Create PipelineRun/TaskRun/CustomRun
+  RW-->>PC: Watch PipelineRun/TaskRun/CustomRun
+  Note over PC,RW: Wait for Run Completion
+  RW->>RA: Update results database
+  U--)RA: Get Results
+```
+
+1. User creates a TaskRun, PipelineRun, or CustomRun via the Kubernetes API as usual.
+2. Result Watcher listens for all TaskRun/PipelineRun/CustomRun changes.
+3. If a Run has changed, Watcher updates (or creates) a
+   corresponding `Record` (and `Result` if necessary) using the Results API.
+    - Watcher will also annotate the original Run with
+    identifiers as well.
+4. Users can get/query Result/Record data directly from the API. Once the
+   Run is complete and has been successfully stored in the
+   Result API, the original CRD object can be safely removed from the cluster.
+
+## Getting Started
+
+1. [Installation](docs/install.md)
+2. [Results API](docs/api/README.md): Learn how to connect to the API and make
+   queries.
+3. [Watcher](docs/watcher/README.md): Learn what types the Watcher supports and how
+   it determines Result groupings.
+
+## Usage
+
+See the [Results API documentation](docs/api/README.md) for querying Results and working with the API.
+
+## Data Model
+
+```mermaid
+graph BT
+  B(TaskRun) --> |Record| A[Result]
+  C(Log) --> |Record| A
+  D(PipelineRun) --> |Record| A
+  E(CustomRun) --> |Record| A
+```
+
+- Records are individual instances of data. These will commonly be execution
+  data (e.g. PipelineRun, TaskRuns, Logs), but could also reference additional data
+  about the event/execution. Records are intended to be flexible to support
+  arbitrary information tools want to provide around a CI event.
+- Results are aggregators of Records, allowing users to refer to groups of
+  Records as a single entity. For example, you might have a single Result that
+  groups the following Records:
+  - Source Event (e.g. pull request, push) that kicked off the action.
+  - The PipelineRun that occurred.
+  - The TaskRuns that occurred in response of the PipelineRun (one per Task).
+  - Receipt of Cloud Event delivery.
+  - Receipt of Source status update.
+
+(Note: not all of these types of data are supported by the Watcher yet, but are
+examples of the data we intend to support).
+
+## Development
+
+See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for build, test, and contribution instructions.
+
+## Helpful links
+
+- [Roadmap](docs/roadmap.md)
+- [Results API Query Cookbook](docs/api/README.md#cookbook)
+
+## Contact
+
+- [Tekton Community](https://github.com/tektoncd/community/blob/main/contact.md)
+- [#results - Tekton Slack](https://tektoncd.slack.com/archives/C01GCEH0FLK)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,6 +24,15 @@ These tools are recommended, but not required:
 
 > **Note:** When cloning on Windows, use `git clone -c core.symlinks=true https://github.com/tektoncd/results.git` to properly handle symlinks.
 
+## Documentation README files
+
+This repository maintains two README files:
+
+- **`docs/README.md`** — synced to [tekton.dev](https://tekton.dev/docs/results/). Uses docs-relative links (e.g. `install.md`, `api/README.md`).
+- **`README.md`** (repo root) — displayed on GitHub. Uses repo-root-relative links (e.g. `docs/install.md`, `docs/api/README.md`).
+
+When updating README content, edit both files and keep links consistent with each file's location.
+
 ## Quickstart
 
 The easiest way to get started is to use the e2e testing scripts to bootstrap


### PR DESCRIPTION
## Summary

Fixes #1482

GitHub resolves relative markdown links in `README.md` from the repo root, but `docs/README.md` uses docs-relative paths. The root symlink caused all internal README links to 404 on GitHub.
Replaces the symlink with a dedicated root `README.md` using `docs/*`-prefixed links (same pattern as tektoncd/pipeline). `docs/README.md` is unchanged for tekton.dev sync.

## Test plan
- [ ] `file README.md` is a regular file (not symlink)
- [ ] `git diff docs/README.md` is empty
- [ ] "Installation" link on GitHub → `docs/install.md`
- [ ] "Results API" link → `docs/api/README.md`
- [ ] "proto/v1alpha2" link → `proto/v1alpha2`
