### PR TITLE
fix(api): emit empty list fields in REST JSON responses

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -79,6 +79,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// apiJSONMarshaler returns the JSON marshaler for the gRPC gateway REST API.
+// EmitUnpopulated ensures list responses include empty collections and strings
+// (e.g. {"records":[],"next_page_token":""}) per the OpenAPI spec.
+func apiJSONMarshaler() *runtime.JSONPb {
+	return &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			UseProtoNames:   true,
+			EmitUnpopulated: true,
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		},
+	}
+}
+
 // profilingServerAddress returns the address to bind the profiling server to.
 // The profiling server is always bound to loopback (127.0.0.1) to prevent
 // unauthenticated access from outside the pod.
@@ -239,14 +254,7 @@ func main() {
 
 	// Create the authorization authCheck
 	var authCheck auth.Checker
-	serverMuxOptions := []runtime.ServeMuxOption{runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
-		MarshalOptions: protojson.MarshalOptions{
-			UseProtoNames: true,
-		},
-		UnmarshalOptions: protojson.UnmarshalOptions{
-			DiscardUnknown: true,
-		},
-	})}
+	serverMuxOptions := []runtime.ServeMuxOption{runtime.WithMarshalerOption(runtime.MIMEWildcard, apiJSONMarshaler())}
 	if serverConfig.AUTH_DISABLE {
 		log.Warn("Kubernetes RBAC authorization check disabled - all requests will be allowed by the API server")
 		authCheck = &auth.AllowAll{}

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	v1alpha2pb "github.com/tektoncd/results/proto/v1alpha2/results_go_proto"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/metadata"
@@ -66,6 +68,48 @@ func contextWithLogger(w io.Writer) context.Context {
 	writer := zapcore.AddSync(w)
 	logger := zap.New(zapcore.NewCore(encoder, writer, zapcore.DebugLevel))
 	return ctxzap.ToContext(context.Background(), logger)
+}
+
+func TestAPIJSONMarshaler_EmptyListRecordsResponse(t *testing.T) {
+	m := apiJSONMarshaler()
+	got, err := m.Marshal(&v1alpha2pb.ListRecordsResponse{})
+	if err != nil {
+		t.Fatalf("Marshal(): %v", err)
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+	if _, ok := parsed["records"]; !ok {
+		t.Fatalf("missing records field in %s", got)
+	}
+	if string(parsed["records"]) != "[]" {
+		t.Fatalf("records = %s, want []", parsed["records"])
+	}
+	if string(parsed["next_page_token"]) != `""` {
+		t.Fatalf("next_page_token = %s, want \"\"", parsed["next_page_token"])
+	}
+}
+
+func TestAPIJSONMarshaler_EmptyListResultsResponse(t *testing.T) {
+	m := apiJSONMarshaler()
+	got, err := m.Marshal(&v1alpha2pb.ListResultsResponse{})
+	if err != nil {
+		t.Fatalf("Marshal(): %v", err)
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal(): %v", err)
+	}
+	if _, ok := parsed["results"]; !ok {
+		t.Fatalf("missing results field in %s", got)
+	}
+	if string(parsed["results"]) != "[]" {
+		t.Fatalf("results = %s, want []", parsed["results"])
+	}
+	if string(parsed["next_page_token"]) != `""` {
+		t.Fatalf("next_page_token = %s, want \"\"", parsed["next_page_token"])
+	}
 }
 
 func Test_profilingServerAddress(t *testing.T) {


### PR DESCRIPTION
Fixes tektoncd/results#1076

## Summary
- Enable `EmitUnpopulated` on the gRPC gateway JSON marshaler so empty list responses include `records`/`results` and `next_page_token` fields.

## Changes

The gRPC gateway JSON marshaler omitted zero-value fields, so empty ListRecords/ListResults responses serialized as {} instead of {"records":[],"next_page_token":""}. Enable EmitUnpopulated to match the OpenAPI spec and grpc-gateway defaults.

- Add unit tests for empty `ListRecordsResponse` and `ListResultsResponse` marshaling.
Fixes #1076

## Test plan
- [x] `go test ./cmd/api/ -run 'TestAPIJSONMarshaler' -v`
- [ ] `make fmt`
- [ ] `make golangci-lint`
- [ ] `./test/presubmit-tests.sh --unit-tests`
- [ ] 
/kind bug
